### PR TITLE
Updated services to use a crud

### DIFF
--- a/fantasylol/db/crud.py
+++ b/fantasylol/db/crud.py
@@ -1,0 +1,193 @@
+from typing import List
+from sqlalchemy import select
+from sqlalchemy.orm import aliased
+from fantasylol.db.database import DatabaseConnection
+from fantasylol.db.models import (
+    League,
+    Tournament,
+    Match,
+    Game,
+    ProfessionalTeam,
+    ProfessionalPlayer,
+    Schedule
+)
+
+
+# --------------------------------------------------
+# --------------- League Operations ----------------
+# --------------------------------------------------
+def save_league(league: League):
+    with DatabaseConnection() as db:
+        db.merge(league)
+        db.commit()
+
+
+def get_leagues(filters: list = None) -> List[Match]:
+    with DatabaseConnection() as db:
+        if filters:
+            query = db.query(League).filter(*filters)
+        else:
+            query = db.query(League)
+        return query.all()
+
+
+def get_league_by_id(league_id: int) -> League:
+    with DatabaseConnection() as db:
+        return db.query(League).filter(League.id == league_id).first()
+
+
+# --------------------------------------------------
+# ------------- Tournament Operations --------------
+# --------------------------------------------------
+def save_tournament(tournament: Tournament):
+    with DatabaseConnection() as db:
+        db.merge(tournament)
+        db.commit()
+
+
+def get_tournaments(filters: list) -> List[Tournament]:
+    with DatabaseConnection() as db:
+        if filters:
+            query = db.query(Tournament).filter(*filters)
+        else:
+            query = db.query(Tournament)
+        return query.all()
+
+
+def get_tournament_by_id(tournament_id: int) -> Tournament:
+    with DatabaseConnection() as db:
+        return db.query(Tournament).filter(Tournament.id == tournament_id).first()
+
+
+# --------------------------------------------------
+# --------------- Match Operations -----------------
+# --------------------------------------------------
+def save_match(match: Match):
+    with DatabaseConnection() as db:
+        db.merge(match)
+        db.commit()
+
+
+def get_matches(filters: list = None) -> List[Match]:
+    with DatabaseConnection() as db:
+        if filters:
+            query = db.query(Match).filter(*filters)
+        else:
+            query = db.query(Match)
+        return query.all()
+
+
+def get_match_by_id(match_id: int) -> Match:
+    with DatabaseConnection() as db:
+        return db.query(Match).filter(Match.id == match_id).first()
+
+
+def get_matches_without_games() -> List[Match]:
+    game_alias = aliased(Game)
+
+    # Query to get match IDs without any associated games
+    with DatabaseConnection() as db:
+        subquery = (
+            select([game_alias.match_id])
+            .where(game_alias.match_id.isnot(None))
+            .distinct()
+            .alias()
+        )
+
+        # Query to get match IDs without associated games
+        matches_without_games = (
+            db.query(Match.id)
+            .outerjoin(subquery, Match.id == subquery.c.match_id)
+            .filter(subquery.c.match_id.is_(None))
+            .all()
+        )
+    return matches_without_games
+
+
+# --------------------------------------------------
+# ---------------- Game Operations -----------------
+# --------------------------------------------------
+def save_game(game: Game):
+    with DatabaseConnection() as db:
+        db.merge(game)
+        db.commit()
+
+
+def bulk_save_games(games: List[Game]):
+    with DatabaseConnection() as db:
+        db.bulk_save_objects(games)
+        db.commit()
+
+
+def get_games(filters: list = None) -> List[Game]:
+    with DatabaseConnection() as db:
+        if filters:
+            query = db.query(Game).filter(*filters)
+        else:
+            query = db.query(Game)
+        return query.all()
+
+
+def get_game_by_id(game_id: int) -> Game:
+    with DatabaseConnection() as db:
+        return db.query(Game).filter(Game.id == game_id).first()
+
+
+# --------------------------------------------------
+# ---------------- Team Operations ----------------
+# --------------------------------------------------
+def save_team(team: ProfessionalTeam):
+    with DatabaseConnection() as db:
+        db.merge(team)
+        db.commit()
+
+
+def get_teams(filters: list = None) -> List[ProfessionalTeam]:
+    with DatabaseConnection() as db:
+        if filters:
+            query = db.query(ProfessionalTeam).filter(*filters)
+        else:
+            query = db.query(ProfessionalTeam)
+        return query.all()
+
+
+def get_team_by_id(team_id: int) -> ProfessionalTeam:
+    with DatabaseConnection() as db:
+        return db.query(ProfessionalTeam).filter(ProfessionalTeam.id == team_id).first()
+
+
+# --------------------------------------------------
+# --------------- Player Operations --------------
+# --------------------------------------------------
+def save_player(player: ProfessionalPlayer):
+    with DatabaseConnection() as db:
+        db.merge(player)
+        db.commit()
+
+
+def get_players(filters: list = None) -> List[ProfessionalPlayer]:
+    with DatabaseConnection() as db:
+        if filters:
+            query = db.query(ProfessionalPlayer).filter(*filters)
+        else:
+            query = db.query(ProfessionalPlayer)
+        return query.all()
+
+
+def get_player_by_id(player_id: int) -> ProfessionalPlayer:
+    with DatabaseConnection() as db:
+        return db.query(ProfessionalPlayer).filter(ProfessionalPlayer.id == player_id).first()
+
+
+# --------------------------------------------------
+# --------------- Schedule Operations --------------
+# --------------------------------------------------
+def get_schedule(schedule_name: str) -> Schedule:
+    with DatabaseConnection() as db:
+        return db.query(Schedule).filter(Schedule.schedule_name == schedule_name).first()
+
+
+def update_schedule(schedule: Schedule):
+    with DatabaseConnection() as db:
+        db.merge(schedule)
+        db.commit()

--- a/fantasylol/endpoints/riot_api/game_endpoint_v1.py
+++ b/fantasylol/endpoints/riot_api/game_endpoint_v1.py
@@ -7,14 +7,15 @@ from fantasylol.exceptions.fantasy_lol_exception import FantasyLolException
 from fantasylol.service.riot_game_service import RiotGameService
 from fantasylol.schemas.riot_data_schemas import GameSchema
 from fantasylol.schemas.game_state import GameState
+from fantasylol.schemas.search_parameters import GameSearchParameters
 
 VERSION = "v1"
 router = APIRouter(prefix=f"/{VERSION}")
 game_service = RiotGameService()
 
 
-def validate_status_parameter(status: GameState = Query(None, description="Filter by game state")):
-    return status
+def validate_status_parameter(state: GameState = Query(None, description="Filter by game state")):
+    return state
 
 
 @router.get(
@@ -34,13 +35,13 @@ def validate_status_parameter(status: GameState = Query(None, description="Filte
     }
 )
 def get_riot_games(
-        status: GameState = Depends(validate_status_parameter),
+        state: GameState = Depends(validate_status_parameter),
         match_id: int = Query(None, description="Filter by game match id")):
-    query_params = {
-        "status": status,
-        "match_id": match_id
-    }
-    games = game_service.get_games(query_params)
+    search_parameters = GameSearchParameters(
+        state=state,
+        match_id=match_id
+    )
+    games = game_service.get_games(search_parameters)
     games_response = [GameSchema(**game.to_dict()) for game in games]
     return games_response
 

--- a/fantasylol/endpoints/riot_api/league_endpoint_v1.py
+++ b/fantasylol/endpoints/riot_api/league_endpoint_v1.py
@@ -4,6 +4,7 @@ from typing import List
 
 from fantasylol.service.riot_league_service import RiotLeagueService
 from fantasylol.schemas.riot_data_schemas import LeagueSchema
+from fantasylol.schemas.search_parameters import LeagueSearchParameters
 
 
 VERSION = "v1"
@@ -30,11 +31,11 @@ league_service = RiotLeagueService()
 def get_riot_leagues(
         name: str = Query(None, description="Filter by league name"),
         region: str = Query(None, description="Filter by league region")):
-    query_params = {
-        "name": name,
-        "region": region
-    }
-    leagues = league_service.get_leagues(query_params)
+    search_parameters = LeagueSearchParameters(
+        name=name,
+        region=region
+    )
+    leagues = league_service.get_leagues(search_parameters)
     leagues_response = [LeagueSchema(**league.to_dict()) for league in leagues]
 
     return leagues_response

--- a/fantasylol/endpoints/riot_api/match_endpoint_v1.py
+++ b/fantasylol/endpoints/riot_api/match_endpoint_v1.py
@@ -6,6 +6,7 @@ from typing import List
 
 from fantasylol.service.riot_match_service import RiotMatchService
 from fantasylol.schemas.riot_data_schemas import MatchSchema
+from fantasylol.schemas.search_parameters import MatchSearchParameters
 from fantasylol.exceptions.fantasy_lol_exception import FantasyLolException
 
 VERSION = "v1"
@@ -32,11 +33,11 @@ match_service = RiotMatchService()
 def get_riot_matches(
         league_name: str = Query(None, description="Filter by league name"),
         tournament_id: int = Query(None, description="Filter by tournament id")):
-    query_params = {
-        "league_name": league_name,
-        "tournament_id": tournament_id
-    }
-    matches = match_service.get_matches(query_params)
+    search_parameters = MatchSearchParameters(
+        league_name=league_name,
+        tournament_id=tournament_id
+    )
+    matches = match_service.get_matches(search_parameters)
     matches_response = [MatchSchema(**match.to_dict()) for match in matches]
     return matches_response
 

--- a/fantasylol/endpoints/riot_api/professional_player_endpoint_v1.py
+++ b/fantasylol/endpoints/riot_api/professional_player_endpoint_v1.py
@@ -4,6 +4,7 @@ from typing import List
 
 from fantasylol.service.riot_professional_player_service import RiotProfessionalPlayerService
 from fantasylol.schemas.riot_data_schemas import ProfessionalPlayerSchema
+from fantasylol.schemas.search_parameters import PlayerSearchParameters
 from fantasylol.schemas.player_role import PlayerRole
 
 VERSION = "v1"
@@ -35,12 +36,12 @@ def get_riot_professional_players(
         summoner_name: str = Query(None, description="Filter by players summoner name"),
         role: str = Depends(validate_role_parameter),
         team_id: int = Query(None, description="Filter by players team id")):
-    query_params = {
-        "summoner_name": summoner_name,
-        "role": role,
-        "team_id": team_id
-    }
-    professional_players = professional_player_service.get_players(query_params)
+    search_params = PlayerSearchParameters(
+        summoner_name=summoner_name,
+        role=role,
+        team_id=team_id
+    )
+    professional_players = professional_player_service.get_players(search_params)
     professional_players_response = [ProfessionalPlayerSchema(
         **player.to_dict()) for player in professional_players]
     return professional_players_response
@@ -70,7 +71,7 @@ def get_riot_professional_players(
         }
     }
 )
-def get_professional_team_by_id(professional_player_id: str):
+def get_professional_team_by_id(professional_player_id: int):
     professional_player = professional_player_service.get_player_by_id(professional_player_id)
     professional_player_response = ProfessionalPlayerSchema(**professional_player.to_dict())
     return professional_player_response

--- a/fantasylol/endpoints/riot_api/professional_team_endpoint_v1.py
+++ b/fantasylol/endpoints/riot_api/professional_team_endpoint_v1.py
@@ -4,6 +4,7 @@ from typing import List
 
 from fantasylol.service.riot_professional_team_service import RiotProfessionalTeamService
 from fantasylol.schemas.riot_data_schemas import ProfessionalTeamSchema
+from fantasylol.schemas.search_parameters import TeamSearchParameters
 
 VERSION = "v1"
 router = APIRouter(prefix=f"/{VERSION}")
@@ -32,14 +33,14 @@ def get_riot_professional_teams(
         code: str = Query(None, description="Filter by professional teams code"),
         status: str = Query(None, description="Filter by professional teams status"),
         league: str = Query(None, description="Filter by professional teams home league")):
-    query_params = {
-        "slug": slug,
-        "name": name,
-        "code": code,
-        "status": status,
-        "home_league": league
-    }
-    professional_teams = professional_team_service.get_teams(query_params)
+    search_parameters = TeamSearchParameters(
+        slug=slug,
+        name=name,
+        code=code,
+        status=status,
+        league=league
+    )
+    professional_teams = professional_team_service.get_teams(search_parameters)
     professional_teams_response = [ProfessionalTeamSchema(
         **team.to_dict()) for team in professional_teams]
     return professional_teams_response

--- a/fantasylol/endpoints/riot_api/tournament_endpoint_v1.py
+++ b/fantasylol/endpoints/riot_api/tournament_endpoint_v1.py
@@ -5,6 +5,7 @@ from typing import List
 from fantasylol.service.riot_tournament_service import RiotTournamentService
 from fantasylol.schemas.riot_data_schemas import TournamentSchema
 from fantasylol.schemas.tournament_status import TournamentStatus
+from fantasylol.schemas.search_parameters import TournamentSearchParameters
 
 VERSION = "v1"
 router = APIRouter(prefix=f"/{VERSION}")
@@ -33,7 +34,8 @@ def validate_status_parameter(status: TournamentStatus = Query(
     }
 )
 def get_riot_tournaments(status: TournamentStatus = Depends(validate_status_parameter)):
-    tournaments = tournament_service.get_tournaments(status)
+    search_parameters = TournamentSearchParameters(status=status)
+    tournaments = tournament_service.get_tournaments(search_parameters)
     tournaments_response = [TournamentSchema(**tournament.to_dict()) for tournament in tournaments]
     return tournaments_response
 

--- a/fantasylol/schemas/search_parameters.py
+++ b/fantasylol/schemas/search_parameters.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class PlayerSearchParameters:
+    summoner_name: str = None
+    role: str = None
+    team_id: int = None
+
+
+@dataclass
+class GameSearchParameters:
+    state: str = None
+    match_id: int = None
+
+
+@dataclass
+class MatchSearchParameters:
+    league_name: str = None
+    tournament_id: int = None
+
+
+@dataclass
+class LeagueSearchParameters:
+    name: str = None
+    region: str = None
+
+
+@dataclass
+class TeamSearchParameters:
+    slug: str = None
+    name: str = None
+    code: str = None
+    status: str = None
+    league: str = None
+
+
+@dataclass
+class TournamentSearchParameters:
+    status: str = None

--- a/tests/test_endpoints/test_game_endpoint_v1.py
+++ b/tests/test_endpoints/test_game_endpoint_v1.py
@@ -8,6 +8,7 @@ from tests.test_util.tournament_test_util import TournamentTestUtil
 from fantasylol.exceptions.game_not_found_exception import GameNotFoundException
 from fantasylol.schemas.game_state import GameState
 from fantasylol.schemas.riot_data_schemas import GameSchema
+from fantasylol.schemas.search_parameters import GameSearchParameters
 from fantasylol import app
 
 GAME_BASE_URL = "/riot/v1/game"
@@ -27,10 +28,10 @@ class GameEndpointV1Test(FantasyLolTestBase):
         game_db_fixture = GameTestUtil.create_completed_game(self.test_tournament.id)
         expected_game_response_schema = GameSchema(**game_db_fixture.to_dict())
         mock_get_games.return_value = [game_db_fixture]
-        status = GameState.COMPLETED.value
+        state = GameState.COMPLETED.value
 
         # Act
-        response = self.client.get(f"{GAME_BASE_URL}?status={status}")
+        response = self.client.get(f"{GAME_BASE_URL}?state={state}")
 
         # Assert
         self.assertEqual(HTTPStatus.OK, response.status_code)
@@ -39,10 +40,9 @@ class GameEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(games))
         game_response_schema = GameSchema(**games[0])
         self.assertEqual(expected_game_response_schema, game_response_schema)
-        mock_get_games.assert_called_once_with({
-            "status": status,
-            "match_id": None
-        })
+        mock_get_games.assert_called_once_with(
+            GameSearchParameters(state=state)
+        )
 
     @patch(GET_GAMES_MOCK_PATH)
     def test_get_game_endpoint_inprogress_status(self, mock_get_games):
@@ -50,10 +50,10 @@ class GameEndpointV1Test(FantasyLolTestBase):
         game_db_fixture = GameTestUtil.create_inprogress_game(self.test_tournament.id)
         expected_game_response_schema = GameSchema(**game_db_fixture.to_dict())
         mock_get_games.return_value = [game_db_fixture]
-        status = GameState.INPROGRESS.value
+        state = GameState.INPROGRESS.value
 
         # Act
-        response = self.client.get(f"{GAME_BASE_URL}?status={status}")
+        response = self.client.get(f"{GAME_BASE_URL}?state={state}")
 
         # Assert
         self.assertEqual(HTTPStatus.OK, response.status_code)
@@ -62,10 +62,7 @@ class GameEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(games))
         game_response_schema = GameSchema(**games[0])
         self.assertEqual(expected_game_response_schema, game_response_schema)
-        mock_get_games.assert_called_once_with({
-            "status": status,
-            "match_id": None
-        })
+        mock_get_games.assert_called_once_with(GameSearchParameters(state=state))
 
     @patch(GET_GAMES_MOCK_PATH)
     def test_get_game_endpoint_unstarted_status(self, mock_get_games):
@@ -73,10 +70,10 @@ class GameEndpointV1Test(FantasyLolTestBase):
         game_db_fixture = GameTestUtil.create_unstarted_game(self.test_tournament.id)
         expected_game_response_schema = GameSchema(**game_db_fixture.to_dict())
         mock_get_games.return_value = [game_db_fixture]
-        status = GameState.UNSTARTED.value
+        state = GameState.UNSTARTED.value
 
         # Act
-        response = self.client.get(f"{GAME_BASE_URL}?status={status}")
+        response = self.client.get(f"{GAME_BASE_URL}?state={state}")
 
         # Assert
         self.assertEqual(HTTPStatus.OK, response.status_code)
@@ -85,10 +82,7 @@ class GameEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(games))
         game_response_schema = GameSchema(**games[0])
         self.assertEqual(expected_game_response_schema, game_response_schema)
-        mock_get_games.assert_called_once_with({
-            "status": status,
-            "match_id": None
-        })
+        mock_get_games.assert_called_once_with(GameSearchParameters(state=state))
 
     @patch(GET_GAMES_MOCK_PATH)
     def test_get_game_endpoint_invalid_status(self, mock_get_games):
@@ -96,7 +90,7 @@ class GameEndpointV1Test(FantasyLolTestBase):
         status = "invalid"
 
         # Act
-        response = self.client.get(f"{GAME_BASE_URL}?status={status}")
+        response = self.client.get(f"{GAME_BASE_URL}?state={status}")
 
         # Assert
         self.assertEqual(HTTPStatus.UNPROCESSABLE_ENTITY, response.status_code)
@@ -121,10 +115,9 @@ class GameEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(games))
         game_response_schema = GameSchema(**games[0])
         self.assertEqual(expected_game_response_schema, game_response_schema)
-        mock_get_games.assert_called_once_with({
-            "status": None,
-            "match_id": game_db_fixture.match_id
-        })
+        mock_get_games.assert_called_once_with(
+            GameSearchParameters(match_id=game_db_fixture.match_id)
+        )
 
     @patch(GET_GAME_BY_ID_MOCK_PATH)
     def test_get_game_by_id_endpoint_success(self, mock_get_game_by_id):

--- a/tests/test_endpoints/test_league_endpoint_v1.py
+++ b/tests/test_endpoints/test_league_endpoint_v1.py
@@ -6,6 +6,7 @@ from tests.fantasy_lol_test_base import FantasyLolTestBase
 from tests.riot_api_requester_util import RiotApiRequestUtil
 from fantasylol.exceptions.league_not_found_exception import LeagueNotFoundException
 from fantasylol.schemas.riot_data_schemas import LeagueSchema
+from fantasylol.schemas.search_parameters import LeagueSearchParameters
 from fantasylol import app
 
 LEAGUE_BASE_URL = "/riot/v1/league"
@@ -36,10 +37,7 @@ class LeagueEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(leagues))
         league_response_schema = LeagueSchema(**leagues[0])
         self.assertEqual(self.expected_league_response_schema, league_response_schema)
-        mock_get_leagues.assert_called_once_with({
-            "name": None,
-            "region": None
-        })
+        mock_get_leagues.assert_called_once_with(LeagueSearchParameters())
 
     @patch(GET_LEAGUES_MOCK_PATH)
     def test_get_leagues_endpoint_name_filter_existing_league(self, mock_get_leagues):
@@ -58,10 +56,9 @@ class LeagueEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(leagues))
         league_response_schema = LeagueSchema(**leagues[0])
         self.assertEqual(self.expected_league_response_schema, league_response_schema)
-        mock_get_leagues.assert_called_once_with({
-            "name": self.league_db_fixture.name,
-            "region": None
-        })
+        mock_get_leagues.assert_called_once_with(
+            LeagueSearchParameters(name=self.league_db_fixture.name)
+        )
 
     @patch(GET_LEAGUES_MOCK_PATH)
     def test_get_leagues_endpoint_region_filter_existing_league(self, mock_get_leagues):
@@ -80,10 +77,9 @@ class LeagueEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(leagues))
         league_response_schema = LeagueSchema(**leagues[0])
         self.assertEqual(self.expected_league_response_schema, league_response_schema)
-        mock_get_leagues.assert_called_once_with({
-            "name": None,
-            "region": self.league_db_fixture.region
-        })
+        mock_get_leagues.assert_called_once_with(
+            LeagueSearchParameters(region=self.league_db_fixture.region)
+        )
 
     @patch(GET_LEAGUE_BY_ID_MOCK_PATH)
     def test_get_league_by_id_endpoint_successful(self, mock_get_league_by_id):

--- a/tests/test_endpoints/test_match_endpoint_v1.py
+++ b/tests/test_endpoints/test_match_endpoint_v1.py
@@ -6,6 +6,7 @@ from tests.fantasy_lol_test_base import FantasyLolTestBase
 from tests.riot_api_requester_util import RiotApiRequestUtil
 from fantasylol.exceptions.match_not_found_exception import MatchNotFoundException
 from fantasylol.schemas.riot_data_schemas import MatchSchema
+from fantasylol.schemas.search_parameters import MatchSearchParameters
 from fantasylol import app
 
 MATCH_ENDPOINT_BASE_URL = "/riot/v1/matches"
@@ -36,10 +37,7 @@ class MatchEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(response_matches))
         match_response_schema = MatchSchema(**response_matches[0])
         self.assertEqual(expected_match_response_schema, match_response_schema)
-        mock_get_matches.assert_called_once_with({
-            "league_name": None,
-            "tournament_id": None
-        })
+        mock_get_matches.assert_called_once_with(MatchSearchParameters())
 
     @patch(GET_MATCHES_MOCK_PATH)
     def test_get_riot_matches_endpoint_filter_by_league_name(self, mock_get_matches):
@@ -60,10 +58,9 @@ class MatchEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(response_matches))
         match_response_schema = MatchSchema(**response_matches[0])
         self.assertEqual(expected_match_response_schema, match_response_schema)
-        mock_get_matches.assert_called_once_with({
-            "league_name": match_db_fixture.league_name,
-            "tournament_id": None
-        })
+        mock_get_matches.assert_called_once_with(
+            MatchSearchParameters(league_name=match_db_fixture.league_name)
+        )
 
     @patch(GET_MATCHES_MOCK_PATH)
     def test_get_riot_matches_endpoint_filter_by_tournament_id(self, mock_get_matches):
@@ -84,10 +81,9 @@ class MatchEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(response_matches))
         match_response_schema = MatchSchema(**response_matches[0])
         self.assertEqual(expected_match_response_schema, match_response_schema)
-        mock_get_matches.assert_called_once_with({
-            "league_name": None,
-            "tournament_id": match_db_fixture.tournament_id
-        })
+        mock_get_matches.assert_called_once_with(
+            MatchSearchParameters(tournament_id=match_db_fixture.tournament_id)
+        )
 
     @patch(GET_MATCHES_BY_ID_MOCK_PATH)
     def test_get_matches_by_id_endpoint_for_existing_match(self, mock_get_match_by_id):

--- a/tests/test_endpoints/test_professional_player_endpoint_v1.py
+++ b/tests/test_endpoints/test_professional_player_endpoint_v1.py
@@ -7,6 +7,7 @@ from tests.riot_api_requester_util import RiotApiRequestUtil
 from fantasylol.exceptions.professional_player_not_found_exception import \
     ProfessionalPlayerNotFoundException
 from fantasylol.schemas.riot_data_schemas import ProfessionalPlayerSchema
+from fantasylol.schemas.search_parameters import PlayerSearchParameters
 from fantasylol import app
 
 PROFESSIONAL_PLAYER_BASE_URL = "/riot/v1/professional-player"
@@ -37,11 +38,9 @@ class ProfessionalPlayerEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(professional_players))
         player_response_schema_from_request = ProfessionalPlayerSchema(**professional_players[0])
         self.assertEqual(expected_player_response_schema, player_response_schema_from_request)
-        mock_get_players.assert_called_once_with({
-            "summoner_name": db_fixture.summoner_name,
-            "role": None,
-            "team_id": None
-        })
+        mock_get_players.assert_called_once_with(
+            PlayerSearchParameters(summoner_name=db_fixture.summoner_name)
+        )
 
     @patch(PLAYER_SERVICE_GET_PLAYERS_MOCK_PATH)
     def test_get_professional_players_endpoint_role_query(self, mock_get_players):
@@ -59,11 +58,9 @@ class ProfessionalPlayerEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(professional_players))
         player_response_schema_from_request = ProfessionalPlayerSchema(**professional_players[0])
         self.assertEqual(expected_player_response_schema, player_response_schema_from_request)
-        mock_get_players.assert_called_once_with({
-            "summoner_name": None,
-            "role": db_fixture.role,
-            "team_id": None
-        })
+        mock_get_players.assert_called_once_with(
+            PlayerSearchParameters(role=db_fixture.role)
+        )
 
     @patch(PLAYER_SERVICE_GET_PLAYERS_MOCK_PATH)
     def test_get_professional_players_endpoint_team_id_query(self, mock_get_players):
@@ -81,11 +78,9 @@ class ProfessionalPlayerEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(professional_players))
         player_response_schema_from_request = ProfessionalPlayerSchema(**professional_players[0])
         self.assertEqual(expected_player_response_schema, player_response_schema_from_request)
-        mock_get_players.assert_called_once_with({
-            "summoner_name": None,
-            "role": None,
-            "team_id": db_fixture.team_id
-        })
+        mock_get_players.assert_called_once_with(
+            PlayerSearchParameters(team_id=db_fixture.team_id)
+        )
 
     @patch(PLAYER_SERVICE_GET_PLAYERS_MOCK_PATH)
     def test_get_professional_players_endpoint_search_all(self, mock_get_players):
@@ -101,11 +96,7 @@ class ProfessionalPlayerEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(professional_players))
         player_response_schema_from_request = ProfessionalPlayerSchema(**professional_players[0])
         self.assertEqual(expected_player_response_schema, player_response_schema_from_request)
-        mock_get_players.assert_called_once_with({
-            "summoner_name": None,
-            "role": None,
-            "team_id": None
-        })
+        mock_get_players.assert_called_once_with(PlayerSearchParameters())
 
     @patch(PLAYER_SERVICE_GET_PLAYER_BY_ID_MOCK_PATH)
     def test_get_professional_players_endpoint_by_id(self, mock_get_player_by_id):
@@ -120,7 +111,7 @@ class ProfessionalPlayerEndpointV1Test(FantasyLolTestBase):
         self.assertIsInstance(professional_player, dict)
         player_response_schema_from_request = ProfessionalPlayerSchema(**professional_player)
         self.assertEqual(expected_player_response_schema, player_response_schema_from_request)
-        mock_get_player_by_id.assert_called_once_with(db_fixture.id)
+        mock_get_player_by_id.assert_called_once_with(int(db_fixture.id))
 
     @patch(PLAYER_SERVICE_GET_PLAYER_BY_ID_MOCK_PATH)
     def test_get_professional_players_endpoint_by_id_not_found(self, mock_get_player_by_id):
@@ -129,4 +120,4 @@ class ProfessionalPlayerEndpointV1Test(FantasyLolTestBase):
 
         response = self.client.get(f"{PROFESSIONAL_PLAYER_BASE_URL}/{db_fixture.id}")
         self.assertEqual(HTTPStatus.NOT_FOUND, response.status_code)
-        mock_get_player_by_id.assert_called_once_with(db_fixture.id)
+        mock_get_player_by_id.assert_called_once_with(int(db_fixture.id))

--- a/tests/test_endpoints/test_professional_team_endpoint_v1.py
+++ b/tests/test_endpoints/test_professional_team_endpoint_v1.py
@@ -7,6 +7,7 @@ from tests.riot_api_requester_util import RiotApiRequestUtil
 from fantasylol.exceptions.professional_team_not_found_exception import \
     ProfessionalTeamNotFoundException
 from fantasylol.schemas.riot_data_schemas import ProfessionalTeamSchema
+from fantasylol.schemas.search_parameters import TeamSearchParameters
 from fantasylol import app
 
 PROFESSIONAL_TEAM_BASE_URL = "/riot/v1/professional-team"
@@ -14,21 +15,6 @@ BASE_TEAM_SERVICE_MOCK_PATH = \
     "fantasylol.service.riot_professional_team_service.RiotProfessionalTeamService"
 TEAM_SERVICE_GET_TEAMS_MOCK_PATH = f"{BASE_TEAM_SERVICE_MOCK_PATH}.get_teams"
 TEAM_SERVICE_GET_TEAM_BY_ID_MOCK_PATH = f"{BASE_TEAM_SERVICE_MOCK_PATH}.get_team_by_id"
-
-
-def create_team_query_params(
-        slug: str = None,
-        name: str = None,
-        code: str = None,
-        status: str = None,
-        league: str = None):
-    return {
-        "slug": slug,
-        "name": name,
-        "code": code,
-        "status": status,
-        "home_league": league
-    }
 
 
 class ProfessionalTeamEndpointV1Test(FantasyLolTestBase):
@@ -56,7 +42,7 @@ class ProfessionalTeamEndpointV1Test(FantasyLolTestBase):
         team_response_schema_from_request = ProfessionalTeamSchema(**professional_teams[0])
         self.assertEqual(expected_team_response_schema, team_response_schema_from_request)
         mock_get_teams.assert_called_once_with(
-            create_team_query_params(slug=team_db_fixture.slug)
+            TeamSearchParameters(slug=team_db_fixture.slug)
         )
 
     @patch(TEAM_SERVICE_GET_TEAMS_MOCK_PATH)
@@ -79,7 +65,7 @@ class ProfessionalTeamEndpointV1Test(FantasyLolTestBase):
         team_response_schema_from_request = ProfessionalTeamSchema(**professional_teams[0])
         self.assertEqual(expected_team_response_schema, team_response_schema_from_request)
         mock_get_teams.assert_called_once_with(
-            create_team_query_params(name=team_db_fixture.name)
+            TeamSearchParameters(name=team_db_fixture.name)
         )
 
     @patch(TEAM_SERVICE_GET_TEAMS_MOCK_PATH)
@@ -102,7 +88,7 @@ class ProfessionalTeamEndpointV1Test(FantasyLolTestBase):
         team_response_schema_from_request = ProfessionalTeamSchema(**professional_teams[0])
         self.assertEqual(expected_team_response_schema, team_response_schema_from_request)
         mock_get_teams.assert_called_once_with(
-            create_team_query_params(code=team_db_fixture.code)
+            TeamSearchParameters(code=team_db_fixture.code)
         )
 
     @patch(TEAM_SERVICE_GET_TEAMS_MOCK_PATH)
@@ -125,7 +111,7 @@ class ProfessionalTeamEndpointV1Test(FantasyLolTestBase):
         team_response_schema_from_request = ProfessionalTeamSchema(**professional_teams[0])
         self.assertEqual(expected_team_response_schema, team_response_schema_from_request)
         mock_get_teams.assert_called_once_with(
-            create_team_query_params(status=team_db_fixture.status)
+            TeamSearchParameters(status=team_db_fixture.status)
         )
 
     @patch(TEAM_SERVICE_GET_TEAMS_MOCK_PATH)
@@ -148,7 +134,7 @@ class ProfessionalTeamEndpointV1Test(FantasyLolTestBase):
         team_response_schema_from_request = ProfessionalTeamSchema(**professional_teams[0])
         self.assertEqual(expected_team_response_schema, team_response_schema_from_request)
         mock_get_teams.assert_called_once_with(
-            create_team_query_params(league=team_db_fixture.home_league)
+            TeamSearchParameters(league=team_db_fixture.home_league)
         )
 
     @patch(TEAM_SERVICE_GET_TEAMS_MOCK_PATH)
@@ -168,7 +154,7 @@ class ProfessionalTeamEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(professional_teams))
         team_response_schema_from_request = ProfessionalTeamSchema(**professional_teams[0])
         self.assertEqual(expected_team_response_schema, team_response_schema_from_request)
-        mock_get_teams.assert_called_once_with(create_team_query_params())
+        mock_get_teams.assert_called_once_with(TeamSearchParameters())
 
     @patch(TEAM_SERVICE_GET_TEAM_BY_ID_MOCK_PATH)
     def test_get_professional_team_by_id_success(self, mock_get_team_by_id):

--- a/tests/test_endpoints/test_tournament_endpoint_v1.py
+++ b/tests/test_endpoints/test_tournament_endpoint_v1.py
@@ -8,6 +8,7 @@ from fantasylol.exceptions.tournament_not_found_exception import \
     TournamentNotFoundException
 from fantasylol.schemas.tournament_status import TournamentStatus
 from fantasylol.schemas.riot_data_schemas import TournamentSchema
+from fantasylol.schemas.search_parameters import TournamentSearchParameters
 from fantasylol import app
 
 
@@ -40,7 +41,7 @@ class TournamentEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(tournaments))
         tournament_response_schema = TournamentSchema(**tournaments[0])
         self.assertEqual(expected_tournament_response_schema, tournament_response_schema)
-        mock_get_tournaments.assert_called_once_with(status)
+        mock_get_tournaments.assert_called_once_with(TournamentSearchParameters(status=status))
 
     @patch(GET_TOURNAMENTS_MOCK_PATH)
     def test_get_tournaments_endpoint_completed(self, mock_get_tournaments):
@@ -60,7 +61,7 @@ class TournamentEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(tournaments))
         tournament_response_schema = TournamentSchema(**tournaments[0])
         self.assertEqual(expected_tournament_response_schema, tournament_response_schema)
-        mock_get_tournaments.assert_called_once_with(status)
+        mock_get_tournaments.assert_called_once_with(TournamentSearchParameters(status=status))
 
     @patch(GET_TOURNAMENTS_MOCK_PATH)
     def test_get_tournaments_endpoint_upcoming(self, mock_get_tournaments):
@@ -80,7 +81,7 @@ class TournamentEndpointV1Test(FantasyLolTestBase):
         self.assertEqual(1, len(tournaments))
         tournament_response_schema = TournamentSchema(**tournaments[0])
         self.assertEqual(expected_tournament_response_schema, tournament_response_schema)
-        mock_get_tournaments.assert_called_once_with(status)
+        mock_get_tournaments.assert_called_once_with(TournamentSearchParameters(status=status))
 
     def test_get_tournaments_endpoint_invalid(self):
         status = "invalid"

--- a/tests/test_service/test_game_service.py
+++ b/tests/test_service/test_game_service.py
@@ -12,6 +12,7 @@ from fantasylol.exceptions.riot_api_status_code_assert_exception import \
 from fantasylol.exceptions.game_not_found_exception import GameNotFoundException
 from fantasylol.service.riot_game_service import RiotGameService
 from fantasylol.schemas.game_state import GameState
+from fantasylol.schemas.search_parameters import GameSearchParameters
 
 
 class GameServiceTest(FantasyLolTestBase):
@@ -61,10 +62,10 @@ class GameServiceTest(FantasyLolTestBase):
         GameTestUtil.create_inprogress_game(self.test_tournament.id)
         GameTestUtil.create_unstarted_game(self.test_tournament.id)
         expected_game = GameTestUtil.create_completed_game(self.test_tournament.id)
-        query_params = {"state": GameState.COMPLETED}
+        search_parameters = GameSearchParameters(state=GameState.COMPLETED)
 
         game_service = self.create_game_service()
-        games_from_db = game_service.get_games(query_params)
+        games_from_db = game_service.get_games(search_parameters)
         self.assertIsInstance(games_from_db, list)
         self.assertEqual(len(games_from_db), 1)
         self.assertEqual(games_from_db[0], expected_game)
@@ -72,10 +73,10 @@ class GameServiceTest(FantasyLolTestBase):
     def test_get_completed_games_with_no_completed_games(self):
         GameTestUtil.create_inprogress_game(self.test_tournament.id)
         GameTestUtil.create_unstarted_game(self.test_tournament.id)
-        query_params = {"state": GameState.COMPLETED}
+        search_parameters = GameSearchParameters(state=GameState.COMPLETED)
 
         game_service = self.create_game_service()
-        games_from_db = game_service.get_games(query_params)
+        games_from_db = game_service.get_games(search_parameters)
         self.assertIsInstance(games_from_db, list)
         self.assertEqual(len(games_from_db), 0)
 
@@ -83,10 +84,10 @@ class GameServiceTest(FantasyLolTestBase):
         GameTestUtil.create_unstarted_game(self.test_tournament.id)
         GameTestUtil.create_completed_game(self.test_tournament.id)
         expected_game = GameTestUtil.create_inprogress_game(self.test_tournament.id)
-        query_params = {"state": GameState.INPROGRESS}
+        search_parameters = GameSearchParameters(state=GameState.INPROGRESS)
 
         game_service = self.create_game_service()
-        games_from_db = game_service.get_games(query_params)
+        games_from_db = game_service.get_games(search_parameters)
         self.assertIsInstance(games_from_db, list)
         self.assertEqual(len(games_from_db), 1)
         self.assertEqual(games_from_db[0], expected_game)
@@ -94,10 +95,10 @@ class GameServiceTest(FantasyLolTestBase):
     def test_get_inprogress_games_with_no_inprogress_games(self):
         GameTestUtil.create_completed_game(self.test_tournament.id)
         GameTestUtil.create_unstarted_game(self.test_tournament.id)
-        query_params = {"state": GameState.INPROGRESS}
+        search_parameters = GameSearchParameters(state=GameState.INPROGRESS)
 
         game_service = self.create_game_service()
-        games_from_db = game_service.get_games(query_params)
+        games_from_db = game_service.get_games(search_parameters)
         self.assertIsInstance(games_from_db, list)
         self.assertEqual(len(games_from_db), 0)
 
@@ -105,10 +106,10 @@ class GameServiceTest(FantasyLolTestBase):
         GameTestUtil.create_completed_game(self.test_tournament.id)
         GameTestUtil.create_inprogress_game(self.test_tournament.id)
         expected_game = GameTestUtil.create_unstarted_game(self.test_tournament.id)
-        query_params = {"state": GameState.UNSTARTED}
+        search_parameters = GameSearchParameters(state=GameState.UNSTARTED)
 
         game_service = self.create_game_service()
-        games_from_db = game_service.get_games(query_params)
+        games_from_db = game_service.get_games(search_parameters)
         self.assertIsInstance(games_from_db, list)
         self.assertEqual(len(games_from_db), 1)
         self.assertEqual(games_from_db[0], expected_game)
@@ -116,29 +117,29 @@ class GameServiceTest(FantasyLolTestBase):
     def test_get_unstarted_games_with_no_unstarted_games(self):
         GameTestUtil.create_inprogress_game(self.test_tournament.id)
         GameTestUtil.create_completed_game(self.test_tournament.id)
-        query_params = {"state": GameState.UNSTARTED}
+        search_parameters = GameSearchParameters(state=GameState.UNSTARTED)
 
         game_service = self.create_game_service()
-        games_from_db = game_service.get_games(query_params)
+        games_from_db = game_service.get_games(search_parameters)
         self.assertIsInstance(games_from_db, list)
         self.assertEqual(len(games_from_db), 0)
 
     def test_get_games_by_match_id_existing_games(self):
         expected_game = GameTestUtil.create_inprogress_game(self.test_tournament.id)
-        query_params = {"match_id": expected_game.match_id}
+        search_parameters = GameSearchParameters(match_id=expected_game.match_id)
 
         game_service = self.create_game_service()
-        games_from_db = game_service.get_games(query_params)
+        games_from_db = game_service.get_games(search_parameters)
         self.assertIsInstance(games_from_db, list)
         self.assertEqual(len(games_from_db), 1)
         self.assertEqual(games_from_db[0], expected_game)
 
     def test_get_games_by_match_id_no_existing_games(self):
         GameTestUtil.create_inprogress_game(self.test_tournament.id)
-        query_params = {"match_id": 777}
+        search_parameters = GameSearchParameters(match_id=777)
 
         game_service = self.create_game_service()
-        games_from_db = game_service.get_games(query_params)
+        games_from_db = game_service.get_games(search_parameters)
         self.assertIsInstance(games_from_db, list)
         self.assertEqual(len(games_from_db), 0)
 

--- a/tests/test_service/test_league_service.py
+++ b/tests/test_service/test_league_service.py
@@ -9,6 +9,7 @@ from fantasylol.exceptions.riot_api_status_code_assert_exception import \
     RiotApiStatusCodeAssertException
 from fantasylol.exceptions.league_not_found_exception import LeagueNotFoundException
 from fantasylol.service.riot_league_service import RiotLeagueService
+from fantasylol.schemas.search_parameters import LeagueSearchParameters
 
 
 class LeagueServiceTest(FantasyLolTestBase):
@@ -62,57 +63,47 @@ class LeagueServiceTest(FantasyLolTestBase):
 
     def test_get_leagues_by_name_existing_league(self):
         expected_league = self.create_league_in_db()
-        query_params = {"name": expected_league.name}
+        search_parameters = LeagueSearchParameters(name=expected_league.name)
 
         league_service = self.create_league_service()
-        league_from_db = league_service.get_leagues(query_params)
+        league_from_db = league_service.get_leagues(search_parameters)
         self.assertIsInstance(league_from_db, list)
         self.assertEqual(len(league_from_db), 1)
         self.assertEqual(league_from_db[0], expected_league)
 
     def test_get_leagues_by_name_no_existing_league(self):
         self.create_league_in_db()
-        query_params = {"name": "badName"}
+        search_parameters = LeagueSearchParameters(name="badName")
 
         league_service = self.create_league_service()
-        league_from_db = league_service.get_leagues(query_params)
+        league_from_db = league_service.get_leagues(search_parameters)
         self.assertIsInstance(league_from_db, list)
         self.assertEqual(len(league_from_db), 0)
 
     def test_get_leagues_by_region_existing_league(self):
         expected_league = self.create_league_in_db()
-        query_params = {"region": expected_league.region}
+        search_parameters = LeagueSearchParameters(region=expected_league.region)
 
         league_service = self.create_league_service()
-        league_from_db = league_service.get_leagues(query_params)
+        league_from_db = league_service.get_leagues(search_parameters)
         self.assertIsInstance(league_from_db, list)
         self.assertEqual(len(league_from_db), 1)
         self.assertEqual(league_from_db[0], expected_league)
 
     def test_get_leagues_by_region_no_existing_league(self):
         self.create_league_in_db()
-        query_params = {"region": "badRegion"}
+        search_parameters = LeagueSearchParameters(region="badRegion")
 
         league_service = self.create_league_service()
-        league_from_db = league_service.get_leagues(query_params)
+        league_from_db = league_service.get_leagues(search_parameters)
         self.assertIsInstance(league_from_db, list)
         self.assertEqual(len(league_from_db), 0)
 
-    def test_get_leagues_no_query_params(self):
-        expected_league = self.create_league_in_db()
-
-        league_service = self.create_league_service()
-        league_from_db = league_service.get_leagues()
-        self.assertIsInstance(league_from_db, list)
-        self.assertEqual(len(league_from_db), 1)
-        self.assertEqual(league_from_db[0], expected_league)
-
     def test_get_leagues_empty_query_params(self):
         expected_league = self.create_league_in_db()
-        query_params = {}
 
         league_service = self.create_league_service()
-        league_from_db = league_service.get_leagues(query_params)
+        league_from_db = league_service.get_leagues(LeagueSearchParameters())
         self.assertIsInstance(league_from_db, list)
         self.assertEqual(len(league_from_db), 1)
         self.assertEqual(league_from_db[0], expected_league)

--- a/tests/test_service/test_match_service.py
+++ b/tests/test_service/test_match_service.py
@@ -10,6 +10,7 @@ from fantasylol.service.riot_match_service import RiotMatchService
 from tests.fantasy_lol_test_base import FantasyLolTestBase
 from tests.fantasy_lol_test_base import RIOT_API_REQUESTER_CLOUDSCRAPER_PATH
 from tests.riot_api_requester_util import RiotApiRequestUtil
+from fantasylol.schemas.search_parameters import MatchSearchParameters
 
 
 class MatchServiceTest(FantasyLolTestBase):
@@ -71,48 +72,47 @@ class MatchServiceTest(FantasyLolTestBase):
 
     def test_get_matches_by_league_name_existing_match(self):
         expected_match = self.create_match_in_db()
-        query_params = {"league_name": expected_match.league_name}
+        search_parameters = MatchSearchParameters(league_name=expected_match.league_name)
 
         match_service = self.create_match_service()
-        matches_from_db = match_service.get_matches(query_params)
+        matches_from_db = match_service.get_matches(search_parameters)
         self.assertIsInstance(matches_from_db, list)
         self.assertEqual(1, len(matches_from_db))
         self.assertEqual(expected_match, matches_from_db[0])
 
     def test_get_matches_by_league_name_no_existing_match(self):
         self.create_match_in_db()
-        query_params = {"league_name": "badName"}
+        search_parameters = MatchSearchParameters(league_name="badName")
 
         match_service = self.create_match_service()
-        matches_from_db = match_service.get_matches(query_params)
+        matches_from_db = match_service.get_matches(search_parameters)
         self.assertIsInstance(matches_from_db, list)
         self.assertEqual(0, len(matches_from_db))
 
     def test_get_matches_by_tournament_id_existing_match(self):
         expected_match = self.create_match_in_db()
-        query_params = {"tournament_id": expected_match.tournament_id}
+        search_parameters = MatchSearchParameters(tournament_id=expected_match.tournament_id)
 
         match_service = self.create_match_service()
-        matches_from_db = match_service.get_matches(query_params)
+        matches_from_db = match_service.get_matches(search_parameters)
         self.assertIsInstance(matches_from_db, list)
         self.assertEqual(1, len(matches_from_db))
         self.assertEqual(expected_match, matches_from_db[0])
 
     def test_get_matches_by_tournament_id_no_existing_match(self):
         self.create_match_in_db()
-        query_params = {"tournament_id": 777}
+        search_parameters = MatchSearchParameters(tournament_id=777)
 
         match_service = self.create_match_service()
-        matches_from_db = match_service.get_matches(query_params)
+        matches_from_db = match_service.get_matches(search_parameters)
         self.assertIsInstance(matches_from_db, list)
         self.assertEqual(0, len(matches_from_db))
 
     def test_get_matches_with_empty_query_params(self):
         expected_match = self.create_match_in_db()
-        query_params = {}
 
         match_service = self.create_match_service()
-        matches_from_db = match_service.get_matches(query_params)
+        matches_from_db = match_service.get_matches(MatchSearchParameters())
         self.assertIsInstance(matches_from_db, list)
         self.assertEqual(1, len(matches_from_db))
         self.assertEqual(expected_match, matches_from_db[0])

--- a/tests/test_service/test_professional_player_service.py
+++ b/tests/test_service/test_professional_player_service.py
@@ -1,4 +1,4 @@
-import uuid
+import random
 from http import HTTPStatus
 from unittest.mock import Mock, patch
 from tests.fantasy_lol_test_base import FantasyLolTestBase
@@ -12,6 +12,7 @@ from fantasylol.exceptions.riot_api_status_code_assert_exception import \
     RiotApiStatusCodeAssertException
 from fantasylol.db.models import ProfessionalPlayer
 from fantasylol.service.riot_professional_player_service import RiotProfessionalPlayerService
+from fantasylol.schemas.search_parameters import PlayerSearchParameters
 
 
 def create_professional_player_service():
@@ -69,58 +70,58 @@ class ProfessionalPlayerServiceTest(FantasyLolTestBase):
 
     def test_get_existing_professional_players_by_summoner_name(self):
         expected_player, expected_team = self.create_professional_player_and_team_in_db()
-        query_params = {"summoner_name": expected_player.summoner_name}
+        search_parameters = PlayerSearchParameters(summoner_name=expected_player.summoner_name)
 
         professional_player_service = create_professional_player_service()
-        players_from_db = professional_player_service.get_players(query_params)
+        players_from_db = professional_player_service.get_players(search_parameters)
         self.assertIsInstance(players_from_db, list)
         self.assertEqual(1, len(players_from_db))
         self.assertEqual(expected_player, players_from_db[0])
 
     def test_get_no_existing_professional_players_by_summoner_name(self):
         self.create_professional_player_and_team_in_db()
-        query_params = {"summoner_name": "badSummonerName"}
+        search_parameters = PlayerSearchParameters(summoner_name="badSummonerName")
 
         professional_player_service = create_professional_player_service()
-        players_from_db = professional_player_service.get_players(query_params)
+        players_from_db = professional_player_service.get_players(search_parameters)
         self.assertIsInstance(players_from_db, list)
         self.assertEqual(0, len(players_from_db))
 
     def test_get_existing_professional_players_by_role(self):
         expected_player, expected_team = self.create_professional_player_and_team_in_db()
-        query_params = {"role": expected_player.role}
+        search_parameters = PlayerSearchParameters(role=expected_player.role)
 
         professional_player_service = create_professional_player_service()
-        players_from_db = professional_player_service.get_players(query_params)
+        players_from_db = professional_player_service.get_players(search_parameters)
         self.assertIsInstance(players_from_db, list)
         self.assertEqual(1, len(players_from_db))
         self.assertEqual(expected_player, players_from_db[0])
 
     def test_get_no_existing_professional_players_by_role(self):
         self.create_professional_player_and_team_in_db()
-        query_params = {"role": "badRole"}
+        search_parameters = PlayerSearchParameters(role="badRole")
 
         professional_player_service = create_professional_player_service()
-        players_from_db = professional_player_service.get_players(query_params)
+        players_from_db = professional_player_service.get_players(search_parameters)
         self.assertIsInstance(players_from_db, list)
         self.assertEqual(0, len(players_from_db))
 
     def test_get_existing_professional_players_by_team_id(self):
         expected_player, expected_team = self.create_professional_player_and_team_in_db()
-        query_params = {"team_id": expected_player.team_id}
+        search_parameters = PlayerSearchParameters(team_id=expected_player.team_id)
 
         professional_player_service = create_professional_player_service()
-        players_from_db = professional_player_service.get_players(query_params)
+        players_from_db = professional_player_service.get_players(search_parameters)
         self.assertIsInstance(players_from_db, list)
         self.assertEqual(1, len(players_from_db))
         self.assertEqual(expected_player, players_from_db[0])
 
     def test_get_no_existing_professional_players_by_team_id(self):
         self.create_professional_player_and_team_in_db()
-        query_params = {"team_id": 777}
+        search_parameters = PlayerSearchParameters(team_id=random.randint(1, 100000))
 
         professional_player_service = create_professional_player_service()
-        players_from_db = professional_player_service.get_players(query_params)
+        players_from_db = professional_player_service.get_players(search_parameters)
         self.assertIsInstance(players_from_db, list)
         self.assertEqual(0, len(players_from_db))
 
@@ -134,4 +135,4 @@ class ProfessionalPlayerServiceTest(FantasyLolTestBase):
         self.create_professional_player_and_team_in_db()
         professional_player_service = create_professional_player_service()
         with self.assertRaises(ProfessionalPlayerNotFoundException):
-            professional_player_service.get_player_by_id(str(uuid.uuid4()))
+            professional_player_service.get_player_by_id(random.randint(1, 100000))

--- a/tests/test_service/test_professional_team_service.py
+++ b/tests/test_service/test_professional_team_service.py
@@ -10,6 +10,7 @@ from fantasylol.exceptions.riot_api_status_code_assert_exception import \
 from fantasylol.exceptions.professional_team_not_found_exception import \
     ProfessionalTeamNotFoundException
 from fantasylol.service.riot_professional_team_service import RiotProfessionalTeamService
+from fantasylol.schemas.search_parameters import TeamSearchParameters
 
 
 class ProfessionalTeamServiceTest(FantasyLolTestBase):
@@ -63,112 +64,103 @@ class ProfessionalTeamServiceTest(FantasyLolTestBase):
 
     def test_get_professional_teams_by_slug_existing_team(self):
         expected_team = self.create_professional_team_in_db()
-        query_params = {"slug": expected_team.slug}
+        search_parameters = TeamSearchParameters(slug=expected_team.slug)
 
         professional_team_service = self.create_professional_team_service()
-        professional_team_from_db = professional_team_service.get_teams(query_params)
+        professional_team_from_db = professional_team_service.get_teams(search_parameters)
         self.assertIsInstance(professional_team_from_db, list)
         self.assertEqual(len(professional_team_from_db), 1)
         self.assertEqual(professional_team_from_db[0], expected_team)
 
     def test_get_professional_teams_by_slug_no_existing_team(self):
         self.create_professional_team_in_db()
-        query_params = {"slug": "badSlug"}
+        search_parameters = TeamSearchParameters(slug="badSlug")
 
         professional_team_service = self.create_professional_team_service()
-        professional_team_from_db = professional_team_service.get_teams(query_params)
+        professional_team_from_db = professional_team_service.get_teams(search_parameters)
         self.assertIsInstance(professional_team_from_db, list)
         self.assertEqual(len(professional_team_from_db), 0)
 
     def test_get_professional_teams_by_name_existing_team(self):
         expected_team = self.create_professional_team_in_db()
-        query_params = {"name": expected_team.name}
+        search_parameters = TeamSearchParameters(name=expected_team.name)
 
         professional_team_service = self.create_professional_team_service()
-        professional_team_from_db = professional_team_service.get_teams(query_params)
+        professional_team_from_db = professional_team_service.get_teams(search_parameters)
         self.assertIsInstance(professional_team_from_db, list)
         self.assertEqual(len(professional_team_from_db), 1)
         self.assertEqual(professional_team_from_db[0], expected_team)
 
     def test_get_professional_teams_by_name_no_existing_team(self):
         self.create_professional_team_in_db()
-        query_params = {"name": "badName"}
+        search_parameters = TeamSearchParameters(name="badName")
 
         professional_team_service = self.create_professional_team_service()
-        professional_team_from_db = professional_team_service.get_teams(query_params)
+        professional_team_from_db = professional_team_service.get_teams(search_parameters)
         self.assertIsInstance(professional_team_from_db, list)
         self.assertEqual(len(professional_team_from_db), 0)
 
     def test_get_professional_teams_by_code_existing_team(self):
         expected_team = self.create_professional_team_in_db()
-        query_params = {"code": expected_team.code}
+        search_parameters = TeamSearchParameters(code=expected_team.code)
 
         professional_team_service = self.create_professional_team_service()
-        professional_team_from_db = professional_team_service.get_teams(query_params)
+        professional_team_from_db = professional_team_service.get_teams(search_parameters)
         self.assertIsInstance(professional_team_from_db, list)
         self.assertEqual(len(professional_team_from_db), 1)
         self.assertEqual(professional_team_from_db[0], expected_team)
 
     def test_get_professional_teams_by_code_no_existing_team(self):
         self.create_professional_team_in_db()
-        query_params = {"slug": "badCode"}
+        search_parameters = TeamSearchParameters(code="badCode")
 
         professional_team_service = self.create_professional_team_service()
-        professional_team_from_db = professional_team_service.get_teams(query_params)
+        professional_team_from_db = professional_team_service.get_teams(search_parameters)
         self.assertIsInstance(professional_team_from_db, list)
         self.assertEqual(len(professional_team_from_db), 0)
 
     def test_get_professional_teams_by_status_existing_team(self):
         expected_team = self.create_professional_team_in_db()
-        query_params = {"status": expected_team.status}
+        search_parameters = TeamSearchParameters(status=expected_team.status)
 
         professional_team_service = self.create_professional_team_service()
-        professional_team_from_db = professional_team_service.get_teams(query_params)
+        professional_team_from_db = professional_team_service.get_teams(search_parameters)
         self.assertIsInstance(professional_team_from_db, list)
         self.assertEqual(len(professional_team_from_db), 1)
         self.assertEqual(professional_team_from_db[0], expected_team)
 
     def test_get_professional_teams_by_status_no_existing_team(self):
         self.create_professional_team_in_db()
-        query_params = {"status": "badStatus"}
+        search_parameters = TeamSearchParameters(status="badStatus")
 
         professional_team_service = self.create_professional_team_service()
-        professional_team_from_db = professional_team_service.get_teams(query_params)
+        professional_team_from_db = professional_team_service.get_teams(search_parameters)
         self.assertIsInstance(professional_team_from_db, list)
         self.assertEqual(len(professional_team_from_db), 0)
 
     def test_get_professional_teams_by_home_league_existing_team(self):
         expected_team = self.create_professional_team_in_db()
-        query_params = {"home_league": expected_team.home_league}
+        search_parameters = TeamSearchParameters(league=expected_team.home_league)
 
         professional_team_service = self.create_professional_team_service()
-        professional_team_from_db = professional_team_service.get_teams(query_params)
+        professional_team_from_db = professional_team_service.get_teams(search_parameters)
         self.assertIsInstance(professional_team_from_db, list)
         self.assertEqual(len(professional_team_from_db), 1)
         self.assertEqual(professional_team_from_db[0], expected_team)
 
     def test_get_professional_teams_by_home_league_no_existing_team(self):
         self.create_professional_team_in_db()
-        query_params = {"home_league": "badHomeLeague"}
+        search_parameters = TeamSearchParameters(league="badLeague")
 
         professional_team_service = self.create_professional_team_service()
-        professional_team_from_db = professional_team_service.get_teams(query_params)
+        professional_team_from_db = professional_team_service.get_teams(search_parameters)
         self.assertIsInstance(professional_team_from_db, list)
         self.assertEqual(len(professional_team_from_db), 0)
 
-    def test_get_professional_teams_no_query_string_params(self):
-        expected_team = self.create_professional_team_in_db()
-        professional_team_service = self.create_professional_team_service()
-        professional_team_from_db = professional_team_service.get_teams()
-        self.assertIsInstance(professional_team_from_db, list)
-        self.assertEqual(len(professional_team_from_db), 1)
-        self.assertEqual(professional_team_from_db[0], expected_team)
-
     def test_get_professional_teams_empty_query_string_params(self):
         expected_team = self.create_professional_team_in_db()
-        query_params = {}
         professional_team_service = self.create_professional_team_service()
-        professional_team_from_db = professional_team_service.get_teams(query_params)
+        professional_team_from_db = professional_team_service.get_teams(TeamSearchParameters())
         self.assertIsInstance(professional_team_from_db, list)
         self.assertEqual(len(professional_team_from_db), 1)
         self.assertEqual(professional_team_from_db[0], expected_team)

--- a/tests/test_service/test_tournament_service.py
+++ b/tests/test_service/test_tournament_service.py
@@ -11,6 +11,7 @@ from fantasylol.exceptions.riot_api_status_code_assert_exception import \
 from fantasylol.exceptions.tournament_not_found_exception import TournamentNotFoundException
 from fantasylol.service.riot_tournament_service import RiotTournamentService
 from fantasylol.schemas.tournament_status import TournamentStatus
+from fantasylol.schemas.search_parameters import TournamentSearchParameters
 
 
 class TournamentServiceTest(FantasyLolTestBase):
@@ -62,7 +63,9 @@ class TournamentServiceTest(FantasyLolTestBase):
         TournamentTestUtil.create_upcoming_tournament()
         expected_tournament = TournamentTestUtil.create_active_tournament()
         tournament_service = self.create_tournament_service()
-        tournament_from_db = tournament_service.get_tournaments(TournamentStatus.ACTIVE)
+        search_parameters = TournamentSearchParameters(status=TournamentStatus.ACTIVE)
+
+        tournament_from_db = tournament_service.get_tournaments(search_parameters)
         self.assertIsInstance(tournament_from_db, list)
         self.assertEqual(len(tournament_from_db), 1)
         self.assertEqual(tournament_from_db[0], expected_tournament)
@@ -71,7 +74,9 @@ class TournamentServiceTest(FantasyLolTestBase):
         TournamentTestUtil.create_completed_tournament()
         TournamentTestUtil.create_upcoming_tournament()
         tournament_service = self.create_tournament_service()
-        tournament_from_db = tournament_service.get_tournaments(TournamentStatus.ACTIVE)
+        search_parameters = TournamentSearchParameters(status=TournamentStatus.ACTIVE)
+
+        tournament_from_db = tournament_service.get_tournaments(search_parameters)
         self.assertIsInstance(tournament_from_db, list)
         self.assertEqual(len(tournament_from_db), 0)
 
@@ -80,7 +85,9 @@ class TournamentServiceTest(FantasyLolTestBase):
         TournamentTestUtil.create_upcoming_tournament()
         expected_tournament = TournamentTestUtil.create_completed_tournament()
         tournament_service = self.create_tournament_service()
-        tournament_from_db = tournament_service.get_tournaments(TournamentStatus.COMPLETED)
+        search_parameters = TournamentSearchParameters(status=TournamentStatus.COMPLETED)
+
+        tournament_from_db = tournament_service.get_tournaments(search_parameters)
         self.assertIsInstance(tournament_from_db, list)
         self.assertEqual(len(tournament_from_db), 1)
         self.assertEqual(tournament_from_db[0], expected_tournament)
@@ -89,7 +96,9 @@ class TournamentServiceTest(FantasyLolTestBase):
         TournamentTestUtil.create_active_tournament()
         TournamentTestUtil.create_upcoming_tournament()
         tournament_service = self.create_tournament_service()
-        tournament_from_db = tournament_service.get_tournaments(TournamentStatus.COMPLETED)
+        search_parameters = TournamentSearchParameters(status=TournamentStatus.COMPLETED)
+
+        tournament_from_db = tournament_service.get_tournaments(search_parameters)
         self.assertIsInstance(tournament_from_db, list)
         self.assertEqual(len(tournament_from_db), 0)
 
@@ -98,7 +107,9 @@ class TournamentServiceTest(FantasyLolTestBase):
         TournamentTestUtil.create_completed_tournament()
         expected_tournament = TournamentTestUtil.create_upcoming_tournament()
         tournament_service = self.create_tournament_service()
-        tournament_from_db = tournament_service.get_tournaments(TournamentStatus.UPCOMING)
+        search_parameters = TournamentSearchParameters(status=TournamentStatus.UPCOMING)
+
+        tournament_from_db = tournament_service.get_tournaments(search_parameters)
         self.assertIsInstance(tournament_from_db, list)
         self.assertEqual(len(tournament_from_db), 1)
         self.assertEqual(tournament_from_db[0], expected_tournament)
@@ -107,7 +118,9 @@ class TournamentServiceTest(FantasyLolTestBase):
         TournamentTestUtil.create_active_tournament()
         TournamentTestUtil.create_completed_tournament()
         tournament_service = self.create_tournament_service()
-        tournament_from_db = tournament_service.get_tournaments(TournamentStatus.UPCOMING)
+        search_parameters = TournamentSearchParameters(status=TournamentStatus.UPCOMING)
+
+        tournament_from_db = tournament_service.get_tournaments(search_parameters)
         self.assertIsInstance(tournament_from_db, list)
         self.assertEqual(len(tournament_from_db), 0)
 
@@ -116,7 +129,9 @@ class TournamentServiceTest(FantasyLolTestBase):
         TournamentTestUtil.create_upcoming_tournament()
         TournamentTestUtil.create_completed_tournament()
         tournament_service = self.create_tournament_service()
-        tournament_from_db = tournament_service.get_tournaments()
+        search_parameters = TournamentSearchParameters()
+
+        tournament_from_db = tournament_service.get_tournaments(search_parameters)
         self.assertIsInstance(tournament_from_db, list)
         self.assertEqual(len(tournament_from_db), 3)
 


### PR DESCRIPTION
All services now use crud.py to interact with the database directly. This cuts down on the amount of repeat code inside of each service. Allows for services to easily access other types of data, (i.e. tournament service getting leagues)

resolves #70