### PR TITLE
Fixed an issue with game stats getting 204s

### DIFF
--- a/fantasylol/db/models.py
+++ b/fantasylol/db/models.py
@@ -2,6 +2,7 @@ from sqlalchemy import Column
 from sqlalchemy import Enum
 from sqlalchemy import Integer
 from sqlalchemy import String
+from sqlalchemy import Boolean
 from sqlalchemy import ForeignKey
 from sqlalchemy import PrimaryKeyConstraint
 from fantasylol.db.database import Base
@@ -124,6 +125,7 @@ class Game(Base):
     state = Column(Enum(GameState), nullable=False)
     number = Column(Integer)
     match_id = Column(Integer, ForeignKey("matches.id"))
+    has_game_data = Column(Boolean, default=True)
 
     def __eq__(self, other):
         if not isinstance(other, Game):

--- a/fantasylol/schemas/riot_data_schemas.py
+++ b/fantasylol/schemas/riot_data_schemas.py
@@ -142,6 +142,10 @@ class GameSchema(BaseModel):
         default=None,
         description="The ID of the match that the game is in"
     )
+    has_game_data: bool = Field(
+        default=True,
+        description="If this game has player metadata and stats available"
+    )
 
     class ExampleResponse:
         example = {

--- a/fantasylol/service/riot_game_service.py
+++ b/fantasylol/service/riot_game_service.py
@@ -43,12 +43,11 @@ class RiotGameService:
 
     def process_batch_match_ids(self, match_ids: List[int]):
         logger.info(f"Processes batch of match ids: {match_ids}")
-        db_games = []
+        all_fetched_games = []
         for match_id in match_ids:
             fetched_games = self.riot_api_requester.get_games_from_event_details(match_id)
-            for game in fetched_games:
-                db_games.append(Game(**game.dict()))
-        crud.bulk_save_games(db_games)
+            all_fetched_games = all_fetched_games + fetched_games
+        crud.bulk_save_games(all_fetched_games)
 
     @staticmethod
     def get_games(search_parameters: GameSearchParameters) -> List[Game]:

--- a/fantasylol/service/riot_game_stats_service.py
+++ b/fantasylol/service/riot_game_stats_service.py
@@ -53,6 +53,10 @@ class RiotGameStatsService:
         try:
             fetched_player_metadata = self.riot_api_requester.get_player_metadata_for_game(
                                                                     game_id, time_stamp)
+            if len(fetched_player_metadata) == 0:
+                logger.info(f"Game id {game_id} has no player metadata available")
+                crud.update_has_game_data(game_id, False)
+
             for player_metadata in fetched_player_metadata:
                 crud.save_player_metadata(player_metadata)
         except Exception as e:
@@ -90,6 +94,11 @@ class RiotGameStatsService:
         try:
             fetched_player_stats = self.riot_api_requester.get_player_stats_for_game(
                                                                 game_id, time_stamp)
+
+            if len(fetched_player_stats) == 0:
+                logger.info(f"Game id {game_id} has no player stats available")
+                crud.update_has_game_data(game_id, False)
+
             for player_stats in fetched_player_stats:
                 crud.save_player_stats(player_stats)
         except Exception as e:

--- a/fantasylol/util/riot_api_requester.py
+++ b/fantasylol/util/riot_api_requester.py
@@ -159,8 +159,14 @@ class RiotApiRequester:
             f"/livestats/v1/window/{game_id}?hl=en-GB&startingTime={time_stamp}"
         )
         response = self.make_request(url)
-        if response.status_code != HTTPStatus.OK:
-            raise RiotApiStatusCodeAssertException(HTTPStatus.OK, response.status_code, url)
+        if response.status_code != HTTPStatus.OK and response.status_code != HTTPStatus.NO_CONTENT:
+            raise RiotApiStatusCodeAssertException(
+                f"{HTTPStatus.OK} or {HTTPStatus.NO_CONTENT}",
+                response.status_code,
+                url
+            )
+        if response.status_code == HTTPStatus.NO_CONTENT:
+            return []
 
         res_json = response.json()
         game_metadata = res_json.get("gameMetadata", {})
@@ -178,8 +184,14 @@ class RiotApiRequester:
             f"/livestats/v1/details/{game_id}?hl=en-GB&startingTime={time_stamp}"
         )
         response = self.make_request(url)
-        if response.status_code != HTTPStatus.OK:
-            raise RiotApiStatusCodeAssertException(HTTPStatus.OK, response.status_code, url)
+        if response.status_code != HTTPStatus.OK and response.status_code != HTTPStatus.NO_CONTENT:
+            raise RiotApiStatusCodeAssertException(
+                f"{HTTPStatus.OK} or {HTTPStatus.NO_CONTENT}",
+                response.status_code,
+                url
+            )
+        if response.status_code == HTTPStatus.NO_CONTENT:
+            return []
 
         res_json = response.json()
         player_stats_from_response = []


### PR DESCRIPTION
When a game does not have live stats it returns a 204 status code. Before we expected only 200 status codes and it would throw an error. When 204 status code is returned we return an empty list which then sets the has_game_data on the game table to be false.

resolves #131 