### PR TITLE
fixed a strange edge case

### DIFF
--- a/fantasylol/util/riot_api_requester.py
+++ b/fantasylol/util/riot_api_requester.py
@@ -301,9 +301,11 @@ def parse_team_metadata(team_metadata: dict, game_id: int) \
     for participant in participant_metadata:
         new_player_metadata = schemas.PlayerGameMetadataSchema()
         new_player_metadata.game_id = game_id
-        new_player_metadata.player_id = int(participant['esportsPlayerId'])
         new_player_metadata.participant_id = participant['participantId']
         new_player_metadata.champion_id = participant['championId']
         new_player_metadata.role = participant['role']
+        # Weird edge case where it doesn't exist for some games:
+        new_player_metadata.player_id = int(participant.get(
+            'esportsPlayerId', new_player_metadata.participant_id))
         player_metadata_for_team.append(new_player_metadata)
     return player_metadata_for_team


### PR DESCRIPTION
There is a weird edge case with game id `109993492104521301` where one of the players on the red team completely is missing the esportsPlayerId. This player also does not show up under the professional players. In cases where players are missing their player id, the value of their participant id will be used in its place. This will help if there are ever multiple players that are missing their esports ids on the same team in the same game.

This is not a great fix, but there is nothing that can be done when the data from riot does not exist.