### PR TITLE
handle where event type is not match

### DIFF
--- a/fantasylol/util/riot_api_requester.py
+++ b/fantasylol/util/riot_api_requester.py
@@ -260,6 +260,8 @@ class RiotApiRequester:
         matches_from_response = []
         events = schedule.get("events", [])
         for event in events:
+            if event['type'] != 'match':
+                continue
             match = event['match']
             new_match = schemas.Match(
                 id=match['id'],


### PR DESCRIPTION
Was throwing a key error when trying to get the match data for event types that were not a match.

resolves #168