### PR TITLE
Users can get their pending and accepted fantasy leagues

### DIFF
--- a/src/common/schemas/fantasy_schemas.py
+++ b/src/common/schemas/fantasy_schemas.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from pydantic import BaseModel, ConfigDict, Field, field_validator
-from typing import Optional
+from typing import Optional, List
 
 
 class UserCreate(BaseModel):
@@ -125,6 +125,13 @@ class FantasyLeagueMembership(BaseModel):
     league_id: str
     user_id: str
     status: FantasyLeagueMembershipStatus
+
+
+class UsersFantasyLeagues(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    pending: List[FantasyLeague]
+    accepted: List[FantasyLeague]
 
 
 class FantasyLeagueDraftOrder(BaseModel):

--- a/src/db/crud.py
+++ b/src/db/crud.py
@@ -417,6 +417,20 @@ def get_user_membership_for_fantasy_league(
                     models.FantasyLeagueMembershipModel.user_id == user_id).first()
 
 
+def get_users_fantasy_leagues_with_membership_status(
+        user_id: str,
+        membership_status: f_schemas.FantasyLeagueMembershipStatus) \
+            -> List[models.FantasyLeagueModel]:
+    with DatabaseConnection() as db:
+        return db.query(models.FantasyLeagueModel) \
+            .join(models.FantasyLeagueMembershipModel,
+                  models.FantasyLeagueModel.id == models.FantasyLeagueMembershipModel.league_id) \
+            .filter(and_(
+                models.FantasyLeagueMembershipModel.user_id == user_id,
+                models.FantasyLeagueMembershipModel.status == membership_status
+            )).all()
+
+
 # --------------------------------------------------
 # ----- Fantasy League Draft Order Operations ------
 # --------------------------------------------------

--- a/src/fantasy/endpoints/fantasy_league_endpoint_v1.py
+++ b/src/fantasy/endpoints/fantasy_league_endpoint_v1.py
@@ -7,6 +7,7 @@ from ...common.schemas.fantasy_schemas import (
     FantasyLeague,
     FantasyLeagueSettings,
     FantasyLeagueScoringSettings,
+    UsersFantasyLeagues,
     FantasyLeagueDraftOrderResponse
 )
 
@@ -16,6 +17,18 @@ from ..service.fantasy_league_service import FantasyLeagueService
 VERSION = "v1"
 router = APIRouter(prefix=f"/{VERSION}")
 fantasy_league_service = FantasyLeagueService()
+
+
+@router.get(
+    path="/leagues",
+    tags=["Fantasy Leagues"],
+    dependencies=[Depends(JWTBearer())],
+    response_model=UsersFantasyLeagues
+)
+def get_my_fantasy_leagues(
+        decoded_token: dict = Depends(JWTBearer())):
+    user_id = decoded_token.get("user_id")
+    return fantasy_league_service.get_users_pending_and_accepted_fantasy_leagues(user_id)
 
 
 @router.post(

--- a/src/fantasy/service/fantasy_league_service.py
+++ b/src/fantasy/service/fantasy_league_service.py
@@ -9,6 +9,7 @@ from ...common.schemas.fantasy_schemas import (
     FantasyLeagueStatus,
     FantasyLeagueMembership,
     FantasyLeagueMembershipStatus,
+    UsersFantasyLeagues,
     FantasyLeagueScoringSettings,
     FantasyLeagueDraftOrder,
     FantasyLeagueDraftOrderResponse
@@ -108,6 +109,20 @@ class FantasyLeagueService:
             raise ForbiddenException()
         scoring_settings_model = crud.get_fantasy_league_scoring_settings_by_id(league_id)
         return FantasyLeagueScoringSettings.model_validate(scoring_settings_model)
+
+    @staticmethod
+    def get_users_pending_and_accepted_fantasy_leagues(user_id: str) -> UsersFantasyLeagues:
+        pending_fantasy_leagues = crud.get_users_fantasy_leagues_with_membership_status(
+            user_id, FantasyLeagueMembershipStatus.PENDING
+        )
+        accepted_fantasy_leagues = crud.get_users_fantasy_leagues_with_membership_status(
+            user_id, FantasyLeagueMembershipStatus.ACCEPTED
+        )
+        users_fantasy_leagues = UsersFantasyLeagues(
+            pending=pending_fantasy_leagues,
+            accepted=accepted_fantasy_leagues
+        )
+        return users_fantasy_leagues
 
     @staticmethod
     def send_fantasy_league_invite(owner_id: str, league_id: str, username: str):


### PR DESCRIPTION
Users can call the leagues endpoints with a GET method to get all of the fantasy leagues that they have a PENDING or ACCEPTED membership to

resolves #204