### PR TITLE
Users can update scoring settings

### DIFF
--- a/src/common/schemas/fantasy_schemas.py
+++ b/src/common/schemas/fantasy_schemas.py
@@ -30,9 +30,10 @@ class User(BaseModel):
 class FantasyLeagueScoringSettings(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
-    fantasy_league_id: str = Field(
-        description="The id of the fantasy league",
-        examples=['aaaaaaaa-1111-bbbb-2222-cccccccccccc']
+    fantasy_league_id: Optional[str] = Field(
+        description="The id of the fantasy league. This field is ignored in update requests",
+        examples=['aaaaaaaa-1111-bbbb-2222-cccccccccccc'],
+        default=None
     )
     kills: int = Field(
         default=2,

--- a/src/db/crud.py
+++ b/src/db/crud.py
@@ -363,6 +363,14 @@ def get_fantasy_league_scoring_settings_by_id(league_id: str) \
             .first()
 
 
+def update_fantasy_league_scoring_settings(
+        scoring_settings: f_schemas.FantasyLeagueScoringSettings):
+    db_scoring_settings = models.FantasyLeagueScoringSettingModel(**scoring_settings.model_dump())
+    with DatabaseConnection() as db:
+        db.merge(db_scoring_settings)
+        db.commit()
+
+
 def update_fantasy_league_settings(
         fantasy_league_id: str,
         settings: f_schemas.FantasyLeagueSettings) -> models.FantasyLeagueModel:

--- a/src/fantasy/endpoints/fantasy_league_endpoint_v1.py
+++ b/src/fantasy/endpoints/fantasy_league_endpoint_v1.py
@@ -85,6 +85,22 @@ def get_fantasy_league_scoring_settings(
     return fantasy_league_service.get_scoring_settings(owner_id, fantasy_league_id)
 
 
+@router.put(
+    path="/leagues/{fantasy_league_id}/scoring",
+    tags=["Fantasy Leagues"],
+    dependencies=[Depends(JWTBearer())],
+    response_model=FantasyLeagueScoringSettings
+)
+def update_fantasy_league_scoring_settings(
+        fantasy_league_id: str,
+        scoring_settings: FantasyLeagueScoringSettings = Body(...),
+        decoded_token: dict = Depends(JWTBearer())):
+    user_id = decoded_token.get("user_id")
+    return fantasy_league_service.update_scoring_settings(
+        fantasy_league_id, user_id, scoring_settings
+    )
+
+
 @router.post(
     path="/leagues/{fantasy_league_id}/invite/{username}",
     tags=["Fantasy Leagues"],

--- a/src/fantasy/service/fantasy_league_service.py
+++ b/src/fantasy/service/fantasy_league_service.py
@@ -111,6 +111,22 @@ class FantasyLeagueService:
         return FantasyLeagueScoringSettings.model_validate(scoring_settings_model)
 
     @staticmethod
+    def update_scoring_settings(
+            fantasy_league_id: str,
+            user_id: str,
+            scoring_settings: FantasyLeagueScoringSettings) -> FantasyLeagueScoringSettings:
+        fantasy_league = fantasy_league_util.validate_league(
+            fantasy_league_id, [FantasyLeagueStatus.PRE_DRAFT]
+        )
+        if fantasy_league.owner_id != user_id:
+            raise ForbiddenException()
+
+        # Ensure that fantasy_league_id for the scoring settings is the one called by the endpoint
+        scoring_settings.fantasy_league_id = fantasy_league_id
+        crud.update_fantasy_league_scoring_settings(scoring_settings)
+        return scoring_settings
+
+    @staticmethod
     def get_users_pending_and_accepted_fantasy_leagues(user_id: str) -> UsersFantasyLeagues:
         pending_fantasy_leagues = crud.get_users_fantasy_leagues_with_membership_status(
             user_id, FantasyLeagueMembershipStatus.PENDING


### PR DESCRIPTION
Users can update the scoring settings on the fantasy leagues that they are the owner of. The fantasy league id in the request body is ignored and the id from the request path will be used in it's place. Fantasy league scoring settings can only be updated when the status of the fantasy league is PRE_DRAFT

resolves #195