### PR TITLE
Riot leagues configurable for Fantasy league usage

### DIFF
--- a/src/common/schemas/riot_data_schemas.py
+++ b/src/common/schemas/riot_data_schemas.py
@@ -36,6 +36,11 @@ class League(BaseModel):
         description="The priority of league in list ranking order",
         examples=[300]
     )
+    fantasy_available: bool = Field(
+        default=False,
+        description="Riot league is available for use in Fantasy Leagues",
+        examples=[False]
+    )
 
 
 class TournamentStatus(str, Enum):

--- a/src/common/schemas/search_parameters.py
+++ b/src/common/schemas/search_parameters.py
@@ -26,6 +26,7 @@ class MatchSearchParameters(BaseModel):
 class LeagueSearchParameters(BaseModel):
     name: Optional[str] = None
     region: Optional[str] = None
+    fantasy_available: Optional[bool] = None
 
 
 class TeamSearchParameters(BaseModel):

--- a/src/db/crud.py
+++ b/src/db/crud.py
@@ -1,6 +1,7 @@
 from typing import List
 from sqlalchemy import text
 from sqlalchemy import and_
+from typing import Optional
 
 from .database import DatabaseConnection
 from . import models
@@ -30,6 +31,19 @@ def get_leagues(filters: list = None) -> List[models.LeagueModel]:
 def get_league_by_id(league_id: str) -> models.LeagueModel:
     with DatabaseConnection() as db:
         return db.query(models.LeagueModel).filter(models.LeagueModel.id == league_id).first()
+
+
+def update_league_fantasy_available_status(league_id: str, new_status: bool) \
+        -> Optional[models.LeagueModel]:
+    with DatabaseConnection() as db:
+        db_league = db.query(models.LeagueModel).filter(models.LeagueModel.id == league_id).first()
+        if db_league is None:
+            return None
+        db_league.fantasy_available = new_status
+        db.merge(db_league)
+        db.commit()
+        db.refresh(db_league)
+        return db_league
 
 
 # --------------------------------------------------

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -30,6 +30,7 @@ class LeagueModel(Base):
     region = Column(String)
     image = Column(String)
     priority = Column(Integer)
+    fantasy_available = Column(Boolean)
 
 
 class TournamentModel(Base):

--- a/src/riot/endpoints/league_endpoint_v1.py
+++ b/src/riot/endpoints/league_endpoint_v1.py
@@ -25,10 +25,12 @@ league_service = RiotLeagueService()
 )
 def get_riot_leagues(
         name: str = Query(None, description="Filter by league name"),
-        region: str = Query(None, description="Filter by league region")):
+        region: str = Query(None, description="Filter by league region"),
+        fantasy_available: bool = Query(None, description="Filter by availability in Fantasy LoL")):
     search_parameters = LeagueSearchParameters(
         name=name,
-        region=region
+        region=region,
+        fantasy_available=fantasy_available
     )
     leagues = league_service.get_leagues(search_parameters)
     return paginate(leagues)
@@ -55,3 +57,26 @@ def get_riot_leagues(
 )
 def get_riot_league_by_id(league_id: str):
     return league_service.get_league_by_id(league_id)
+
+
+@router.put(
+    path="/league/{league_id}/{new_status}",
+    description="Update league to be available for fantasy leagues",
+    tags=["Leagues"],
+    response_model=League,
+    responses={
+        200: {
+            "model": League
+        },
+        404: {
+            "description": "Not Found",
+            "content": {
+                "application/json": {
+                    "example": {"detail": "League not found"}
+                }
+            }
+        }
+    }
+)
+def update_riot_league_fantasy_available(league_id: str, new_status: bool):
+    return league_service.update_fantasy_available(league_id, new_status)

--- a/src/riot/service/riot_league_service.py
+++ b/src/riot/service/riot_league_service.py
@@ -38,6 +38,8 @@ class RiotLeagueService:
             filters.append(LeagueModel.name == search_parameters.name)
         if search_parameters.region is not None:
             filters.append(LeagueModel.region == search_parameters.region)
+        if search_parameters.fantasy_available is not None:
+            filters.append(LeagueModel.fantasy_available == search_parameters.fantasy_available)
         orm_leagues = crud.get_leagues(filters)
         leagues = [schemas.League.model_validate(league_orm) for league_orm in orm_leagues]
         return leagues
@@ -45,6 +47,14 @@ class RiotLeagueService:
     @staticmethod
     def get_league_by_id(league_id: str) -> schemas.League:
         league_orm = crud.get_league_by_id(league_id)
+        if league_orm is None:
+            raise LeagueNotFoundException()
+        league = schemas.League.model_validate(league_orm)
+        return league
+
+    @staticmethod
+    def update_fantasy_available(league_id: str, status: bool) -> schemas.League:
+        league_orm = crud.update_league_fantasy_available_status(league_id, status)
         if league_orm is None:
             raise LeagueNotFoundException()
         league = schemas.League.model_validate(league_orm)

--- a/tests/riot/unit/riot_endpoints/test_league_endpoint_v1.py
+++ b/tests/riot/unit/riot_endpoints/test_league_endpoint_v1.py
@@ -86,6 +86,29 @@ class LeagueEndpointV1Test(FantasyLolTestBase):
             LeagueSearchParameters(region=league_fixture.region)
         )
 
+    @patch(GET_LEAGUES_MOCK_PATH)
+    def test_get_leagues_endpoint_fantasy_available_filter_existing_league(self, mock_get_leagues):
+        # Arrange
+        league_fixture = fixtures.league_1_fixture
+        expected_league_response = league_fixture.model_dump()
+        mock_get_leagues.return_value = [league_fixture]
+
+        # Act
+        response = self.client.get(
+            f"{LEAGUE_BASE_URL}?fantasy_available={league_fixture.fantasy_available}"
+        )
+
+        # Assert
+        self.assertEqual(HTTPStatus.OK, response.status_code)
+        response_json: dict = response.json()
+        leagues = response_json.get('items')
+        self.assertIsInstance(leagues, list)
+        self.assertEqual(1, len(leagues))
+        self.assertEqual(expected_league_response, leagues[0])
+        mock_get_leagues.assert_called_once_with(
+            LeagueSearchParameters(fantasy_available=league_fixture.fantasy_available)
+        )
+
     @patch(GET_LEAGUE_BY_ID_MOCK_PATH)
     def test_get_league_by_id_endpoint_successful(self, mock_get_league_by_id):
         # Arrange

--- a/tests/test_util/riot_fixtures.py
+++ b/tests/test_util/riot_fixtures.py
@@ -28,7 +28,8 @@ league_1_fixture = schemas.League(
     slug="mock-challengers-league",
     region="MOCKED REGION",
     image="http//:mocked-league-image.png",
-    priority=1
+    priority=1,
+    fantasy_available=False
 )
 
 league_2_fixture = schemas.League(
@@ -37,7 +38,8 @@ league_2_fixture = schemas.League(
     slug="mock-pro-league",
     region="MOCKED REGION2",
     image="http//:mocked-league-2-image.png",
-    priority=2
+    priority=2,
+    fantasy_available=True
 )
 
 tournament_fixture = schemas.Tournament(


### PR DESCRIPTION
Riot leagues can be configured to be used for selection in fantasy leagues

resolves #281