### PR TITLE
Select riot leagues to be used in fantasy leagues

### DIFF
--- a/src/common/exceptions/league_not_found_exception.py
+++ b/src/common/exceptions/league_not_found_exception.py
@@ -3,8 +3,8 @@ from http import HTTPStatus
 
 
 class LeagueNotFoundException(HTTPException):
-    def __init__(self):
+    def __init__(self, detail="League not found"):
         super().__init__(
             status_code=HTTPStatus.NOT_FOUND,
-            detail="League not found"
+            detail=detail
         )

--- a/src/common/schemas/fantasy_schemas.py
+++ b/src/common/schemas/fantasy_schemas.py
@@ -88,6 +88,11 @@ class FantasyLeagueSettings(BaseModel):
         description="Number of teams in the fantasy league\n"
                     "Allowed values: 4, 6, 8, 10"
     )
+    available_leagues: list = Field(
+        default=[],
+        description="The IDs for the riot leagues available for drafting players from",
+        examples=[["98767991310872058"]]
+    )
 
     @field_validator('number_of_teams')
     @classmethod

--- a/src/db/crud.py
+++ b/src/db/crud.py
@@ -389,14 +389,15 @@ def update_fantasy_league_settings(
         fantasy_league_id: str,
         settings: f_schemas.FantasyLeagueSettings) -> models.FantasyLeagueModel:
     with DatabaseConnection() as db:
-        league = db.query(models.FantasyLeagueModel).filter_by(id=fantasy_league_id).first()
+        fantasy_league = db.query(models.FantasyLeagueModel).filter_by(id=fantasy_league_id).first()
 
-        league.name = settings.name
-        league.number_of_teams = settings.number_of_teams
+        fantasy_league.name = settings.name
+        fantasy_league.number_of_teams = settings.number_of_teams
+        fantasy_league.available_leagues = settings.available_leagues
 
         db.commit()
-        db.refresh(league)
-        return league
+        db.refresh(fantasy_league)
+        return fantasy_league
 
 
 # --------------------------------------------------

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -6,6 +6,7 @@ from sqlalchemy import Float
 from sqlalchemy import Boolean
 from sqlalchemy import ForeignKey
 from sqlalchemy import PrimaryKeyConstraint
+from sqlalchemy import JSON
 from sqlalchemy.ext.declarative import declarative_base
 import uuid
 
@@ -160,6 +161,7 @@ class FantasyLeagueModel(Base):
     number_of_teams = Column(Integer)
     current_week = Column(Integer, nullable=True)
     current_draft_position = Column(Integer, nullable=True)
+    available_leagues = Column(JSON)
 
 
 class FantasyLeagueMembershipModel(Base):

--- a/src/fantasy/exceptions/fantasy_unavailable_exception.py
+++ b/src/fantasy/exceptions/fantasy_unavailable_exception.py
@@ -1,0 +1,10 @@
+from fastapi import HTTPException
+from http import HTTPStatus
+
+
+class FantasyUnavailableException(HTTPException):
+    def __init__(self, detail):
+        super().__init__(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=detail
+        )

--- a/src/fantasy/service/fantasy_league_service.py
+++ b/src/fantasy/service/fantasy_league_service.py
@@ -3,6 +3,7 @@ from typing import List
 
 from ...db import crud
 
+
 from ...common.schemas.fantasy_schemas import (
     FantasyLeague,
     FantasyLeagueSettings,
@@ -29,13 +30,17 @@ fantasy_league_util = FantasyLeagueUtil()
 class FantasyLeagueService:
     def create_fantasy_league(
             self, owner_id: str, league_settings: FantasyLeagueSettings) -> FantasyLeague:
+        if len(league_settings.available_leagues) > 0:
+            fantasy_league_util.validate_available_leagues(league_settings.available_leagues)
+
         fantasy_league_id = self.generate_new_valid_id()
         new_fantasy_league = FantasyLeague(
             id=fantasy_league_id,
             owner_id=owner_id,
             status=FantasyLeagueStatus.PRE_DRAFT,
             name=league_settings.name,
-            number_of_teams=league_settings.number_of_teams
+            number_of_teams=league_settings.number_of_teams,
+            available_leagues=league_settings.available_leagues
         )
         crud.create_fantasy_league(new_fantasy_league)
 
@@ -67,7 +72,8 @@ class FantasyLeagueService:
 
         league_settings = FantasyLeagueSettings(
             name=fantasy_league_model.name,
-            number_of_teams=fantasy_league_model.number_of_teams
+            number_of_teams=fantasy_league_model.number_of_teams,
+            available_leagues=fantasy_league_model.available_leagues
         )
         return league_settings
 
@@ -93,12 +99,18 @@ class FantasyLeagueService:
                 f"members inside of the fantasy league ({accepted_member_count})"
             )
 
+        if len(updated_league_settings.available_leagues) > 0:
+            fantasy_league_util.validate_available_leagues(
+                updated_league_settings.available_leagues
+            )
+
         updated_fantasy_league_model = crud.update_fantasy_league_settings(
             league_id, updated_league_settings
         )
         updated_fantasy_league_settings = FantasyLeagueSettings(
             name=updated_fantasy_league_model.name,
-            number_of_teams=updated_fantasy_league_model.number_of_teams
+            number_of_teams=updated_fantasy_league_model.number_of_teams,
+            available_leagues=updated_league_settings.available_leagues
         )
         return updated_fantasy_league_settings
 

--- a/src/fantasy/util/fantasy_league_util.py
+++ b/src/fantasy/util/fantasy_league_util.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from ...common.exceptions.league_not_found_exception import LeagueNotFoundException
 from ...common.schemas.fantasy_schemas import FantasyLeagueStatus
 
 from ...db import crud
@@ -8,6 +9,7 @@ from ...db.models import FantasyLeagueModel
 from ..exceptions.fantasy_league_not_found_exception import FantasyLeagueNotFoundException
 from ..exceptions.fantasy_league_invalid_required_state_exception import \
     FantasyLeagueInvalidRequiredStateException
+from ..exceptions.fantasy_unavailable_exception import FantasyUnavailableException
 
 
 class FantasyLeagueUtil:
@@ -24,3 +26,15 @@ class FantasyLeagueUtil:
                 fantasy_league_id, fantasy_league_model.status, required_states
             )
         return fantasy_league_model
+
+    @staticmethod
+    def validate_available_leagues(selected_league_ids: List[str]):
+        riot_leagues = crud.get_leagues()
+        league_dict = {league.id: league for league in riot_leagues}
+
+        for league_id in selected_league_ids:
+            if league_id not in league_dict:
+                raise LeagueNotFoundException(f"Riot league with ID {league_id} not found")
+            if not league_dict[league_id].fantasy_available:
+                raise FantasyUnavailableException(f"Riot league with ID {league_id} not available "
+                                                  f"to be used in Fantasy Leagues")

--- a/src/riot/service/riot_league_service.py
+++ b/src/riot/service/riot_league_service.py
@@ -1,13 +1,13 @@
 import logging
 from typing import List
 
+from ...common.exceptions.league_not_found_exception import LeagueNotFoundException
 from ...common.schemas import riot_data_schemas as schemas
 from ...common.schemas.search_parameters import LeagueSearchParameters
 
 from ...db import crud
 from ...db.models import LeagueModel
 
-from ..exceptions.league_not_found_exception import LeagueNotFoundException
 from ..util.riot_api_requester import RiotApiRequester
 from ..util.job_runner import JobRunner
 

--- a/tests/db/test_crud.py
+++ b/tests/db/test_crud.py
@@ -1346,6 +1346,94 @@ class CrudTest(FantasyLolTestBase):
         # Assert
         self.assertIsNone(fantasy_league_model_from_db)
 
+    def test_update_fantasy_league_settings_name(self):
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        db_util.create_fantasy_league(fantasy_league)
+        updated_fantasy_league_settings = copy.deepcopy(
+            fantasy_fixtures.fantasy_league_settings_fixture
+        )
+        updated_fantasy_league_settings.name = "Updated Fantasy League name"
+
+        # Act
+        updated_fantasy_league_model = crud.update_fantasy_league_settings(
+            fantasy_league.id, updated_fantasy_league_settings
+        )
+
+        # Assert
+        self.assertEqual(updated_fantasy_league_settings.name, updated_fantasy_league_model.name)
+        self.assertEqual(
+            updated_fantasy_league_model.number_of_teams, fantasy_league.number_of_teams
+        )
+        self.assertEqual(
+            updated_fantasy_league_model.available_leagues, fantasy_league.available_leagues
+        )
+        self.assertNotEqual(updated_fantasy_league_settings.name, fantasy_league.name)
+
+    def test_update_fantasy_league_settings_number_of_teams(self):
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        db_util.create_fantasy_league(fantasy_league)
+        updated_fantasy_league_settings = copy.deepcopy(
+            fantasy_fixtures.fantasy_league_settings_fixture
+        )
+        updated_fantasy_league_settings.number_of_teams = 4
+
+        # Act
+        updated_fantasy_league_model = crud.update_fantasy_league_settings(
+            fantasy_league.id, updated_fantasy_league_settings
+        )
+
+        # Assert
+        self.assertEqual(
+            updated_fantasy_league_settings.number_of_teams,
+            updated_fantasy_league_model.number_of_teams
+        )
+        self.assertEqual(
+            updated_fantasy_league_model.name, fantasy_league.name
+        )
+        self.assertEqual(
+            updated_fantasy_league_model.available_leagues, fantasy_league.available_leagues
+        )
+        self.assertNotEqual(
+            updated_fantasy_league_settings.number_of_teams,
+            fantasy_league.number_of_teams
+        )
+
+    def test_update_fantasy_league_settings_available_leagues(self):
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        db_util.create_fantasy_league(fantasy_league)
+        updated_fantasy_league_settings = copy.deepcopy(
+            fantasy_fixtures.fantasy_league_settings_fixture
+        )
+        updated_fantasy_league_settings.available_leagues = ["RiotLeague1"]
+
+        # Act
+        updated_fantasy_league_model = crud.update_fantasy_league_settings(
+            fantasy_league.id, updated_fantasy_league_settings
+        )
+
+        # Assert
+        self.assertEqual(
+            updated_fantasy_league_settings.available_leagues,
+            updated_fantasy_league_model.available_leagues
+        )
+        self.assertEqual(
+            updated_fantasy_league_model.name, fantasy_league.name
+        )
+        self.assertEqual(
+            updated_fantasy_league_model.number_of_teams, fantasy_league.number_of_teams
+        )
+        self.assertNotEqual(
+            updated_fantasy_league_settings.available_leagues,
+            fantasy_league.available_leagues
+        )
+
+    # --------------------------------------------------
+    # ----------- Fantasy Team Operations --------------
+    # --------------------------------------------------
+
     def test_create_fantasy_team(self):
         # Arrange
         fantasy_team = fantasy_fixtures.fantasy_team_week_1

--- a/tests/riot/integration/service/test_league_service.py
+++ b/tests/riot/integration/service/test_league_service.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from src.riot.exceptions.league_not_found_exception import LeagueNotFoundException
+from src.common.exceptions.league_not_found_exception import LeagueNotFoundException
 from src.riot.service.riot_league_service import RiotLeagueService
 from src.common.schemas.search_parameters import LeagueSearchParameters
 from src.common.schemas import riot_data_schemas as schemas

--- a/tests/riot/unit/riot_endpoints/test_league_endpoint_v1.py
+++ b/tests/riot/unit/riot_endpoints/test_league_endpoint_v1.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from tests.test_base import FantasyLolTestBase
 from tests.test_util import riot_fixtures as fixtures
 
-from src.riot.exceptions.league_not_found_exception import LeagueNotFoundException
+from src.common.exceptions.league_not_found_exception import LeagueNotFoundException
 from src.common.schemas.search_parameters import LeagueSearchParameters
 from src.riot import app
 

--- a/tests/test_util/fantasy_fixtures.py
+++ b/tests/test_util/fantasy_fixtures.py
@@ -41,7 +41,8 @@ user_3_fixture = fantasy_schemas.User(
 
 fantasy_league_settings_fixture = fantasy_schemas.FantasyLeagueSettings(
     name="Fantasy League 1",
-    number_of_teams=6
+    number_of_teams=6,
+    available_leagues=[]
 )
 
 fantasy_league_fixture = fantasy_schemas.FantasyLeague(
@@ -50,6 +51,7 @@ fantasy_league_fixture = fantasy_schemas.FantasyLeague(
     status=fantasy_schemas.FantasyLeagueStatus.PRE_DRAFT,
     name=fantasy_league_settings_fixture.name,
     number_of_teams=fantasy_league_settings_fixture.number_of_teams,
+    available_leagues=fantasy_league_settings_fixture.available_leagues,
     current_week=None
 )
 


### PR DESCRIPTION
Owners of fantasy leagues can choose what riot leagues they would like to use inside of their fantasy leagues to draft players from. These leagues can either be set on fantasy league creation or can be updated in the fantasy league settings endpoint while the league is in the `pre_draft` state.

resolves #200