### PR TITLE
Users can only draft players from allowed leagues

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,31 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <DBN-PSQL>
+      <case-options enabled="true">
+        <option name="KEYWORD_CASE" value="lower" />
+        <option name="FUNCTION_CASE" value="lower" />
+        <option name="PARAMETER_CASE" value="lower" />
+        <option name="DATATYPE_CASE" value="lower" />
+        <option name="OBJECT_CASE" value="preserve" />
+      </case-options>
+      <formatting-settings enabled="false" />
+    </DBN-PSQL>
+    <DBN-SQL>
+      <case-options enabled="true">
+        <option name="KEYWORD_CASE" value="lower" />
+        <option name="FUNCTION_CASE" value="lower" />
+        <option name="PARAMETER_CASE" value="lower" />
+        <option name="DATATYPE_CASE" value="lower" />
+        <option name="OBJECT_CASE" value="preserve" />
+      </case-options>
+      <formatting-settings enabled="false">
+        <option name="STATEMENT_SPACING" value="one_line" />
+        <option name="CLAUSE_CHOP_DOWN" value="chop_down_if_statement_long" />
+        <option name="ITERATION_ELEMENTS_WRAPPING" value="chop_down_if_not_single" />
+      </formatting-settings>
+    </DBN-SQL>
+    <codeStyleSettings language="Python">
+      <option name="RIGHT_MARGIN" value="100" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
   </state>
 </component>

--- a/src/db/crud.py
+++ b/src/db/crud.py
@@ -46,6 +46,21 @@ def update_league_fantasy_available_status(league_id: str, new_status: bool) \
         return db_league
 
 
+def get_league_ids_for_player(player_id: str) -> List[str]:
+    sql_query = f"""
+        SELECT DISTINCT l.id
+        FROM professional_players p
+        JOIN professional_teams t ON p.team_id = t.id
+        JOIN leagues l ON t.home_league = l.name
+        WHERE p.id = '{player_id}'
+        """
+    with DatabaseConnection() as db:
+        result = db.execute(text(sql_query))
+        rows = result.fetchall()
+    league_ids = [row[0] for row in rows]
+    return league_ids
+
+
 # --------------------------------------------------
 # ------------- Tournament Operations --------------
 # --------------------------------------------------

--- a/src/fantasy/service/fantasy_team_service.py
+++ b/src/fantasy/service/fantasy_team_service.py
@@ -18,9 +18,11 @@ from ...riot.exceptions.professional_player_not_found_exception import \
 from ..exceptions.fantasy_membership_exception import FantasyMembershipException
 from ..exceptions.fantasy_draft_exception import FantasyDraftException
 from ..util.fantasy_league_util import FantasyLeagueUtil
+from ..util.fantasty_team_util import FantasyTeamUtil
 
 
 fantasy_league_util = FantasyLeagueUtil()
+fantasy_team_util = FantasyTeamUtil()
 
 
 class FantasyTeamService:
@@ -42,8 +44,9 @@ class FantasyTeamService:
         fantasy_league = fantasy_league_util.validate_league(
             fantasy_league_id, [FantasyLeagueStatus.DRAFT, FantasyLeagueStatus.ACTIVE]
         )
-        validate_user_membership(user_id, fantasy_league_id)
         professional_player = get_player_from_db(player_id)
+        fantasy_team_util.validate_player_from_available_league(fantasy_league, player_id)
+        validate_user_membership(user_id, fantasy_league_id)
 
         recent_fantasy_team = get_users_most_recent_fantasy_team(fantasy_league, user_id)
         if recent_fantasy_team.get_player_id_for_role(professional_player.role) is not None:
@@ -95,6 +98,7 @@ class FantasyTeamService:
         validate_user_membership(user_id, fantasy_league_id)
         pro_player_to_drop = get_player_from_db(player_to_drop_id)
         pro_player_to_pickup = get_player_from_db(player_to_pickup_id)
+        fantasy_team_util.validate_player_from_available_league(fantasy_league, player_to_pickup_id)
 
         if pro_player_to_drop.role != pro_player_to_pickup.role:
             raise FantasyDraftException(

--- a/src/fantasy/util/fantasty_team_util.py
+++ b/src/fantasy/util/fantasty_team_util.py
@@ -1,0 +1,22 @@
+from ...common.schemas.fantasy_schemas import FantasyLeague
+
+from ...db import crud
+
+from ..exceptions.fantasy_draft_exception import FantasyDraftException
+
+
+class FantasyTeamUtil:
+    @staticmethod
+    def validate_player_from_available_league(fantasy_league: FantasyLeague, player_id: str):
+        player_league_ids = crud.get_league_ids_for_player(player_id)
+        in_allowed_league = False
+        for available_league_id in fantasy_league.available_leagues:
+            if available_league_id in player_league_ids:
+                in_allowed_league = True
+                break
+        if not in_allowed_league:
+            raise FantasyDraftException(
+                f"Player not in available league: Player with ID {player_id} is not from "
+                f"one of the available leagues {fantasy_league.available_leagues}, for the "
+                f"fantasy league with ID {fantasy_league.id}"
+            )

--- a/src/fantasy/util/fantasy_league_util.py
+++ b/src/fantasy/util/fantasy_league_util.py
@@ -36,5 +36,6 @@ class FantasyLeagueUtil:
             if league_id not in league_dict:
                 raise LeagueNotFoundException(f"Riot league with ID {league_id} not found")
             if not league_dict[league_id].fantasy_available:
-                raise FantasyUnavailableException(f"Riot league with ID {league_id} not available "
-                                                  f"to be used in Fantasy Leagues")
+                raise FantasyUnavailableException(
+                    f"Riot league with ID {league_id} not available to be used in Fantasy Leagues"
+                )

--- a/tests/db/test_crud.py
+++ b/tests/db/test_crud.py
@@ -794,6 +794,37 @@ class CrudTest(FantasyLolTestBase):
         # Assert
         self.assertIsNone(league_model_from_db)
 
+    def test_get_league_ids_for_player_successful(self):
+        # Arrange
+        db_util.save_league(riot_fixtures.league_1_fixture)
+        db_util.save_league(riot_fixtures.league_2_fixture)
+        db_util.save_team(riot_fixtures.team_1_fixture)
+        db_util.save_team(riot_fixtures.team_2_fixture)
+        db_util.save_player(riot_fixtures.player_1_fixture)
+
+        # Act
+        league_ids = crud.get_league_ids_for_player(riot_fixtures.player_1_fixture.id)
+
+        # Assert
+        self.assertIsInstance(league_ids, list)
+        self.assertEqual(1, len(league_ids))
+        self.assertEqual(riot_fixtures.league_1_fixture.id, league_ids[0])
+
+    def test_get_league_ids_for_player_non_existing_player_id(self):
+        # Arrange
+        db_util.save_league(riot_fixtures.league_1_fixture)
+        db_util.save_league(riot_fixtures.league_2_fixture)
+        db_util.save_team(riot_fixtures.team_1_fixture)
+        db_util.save_team(riot_fixtures.team_2_fixture)
+        db_util.save_player(riot_fixtures.player_1_fixture)
+
+        # Act
+        league_ids = crud.get_league_ids_for_player("123")
+
+        # Assert
+        self.assertIsInstance(league_ids, list)
+        self.assertEqual(0, len(league_ids))
+
     # --------------------------------------------------
     # ------------- Tournament Operations --------------
     # --------------------------------------------------

--- a/tests/fantasy/integration/service/test_fantasy_team_service.py
+++ b/tests/fantasy/integration/service/test_fantasy_team_service.py
@@ -2,7 +2,7 @@ import uuid
 from copy import deepcopy
 
 from tests.test_base import FantasyLolTestBase
-from tests.test_util import db_util, fantasy_fixtures
+from tests.test_util import db_util, fantasy_fixtures, riot_fixtures
 
 from src.common.schemas.fantasy_schemas import FantasyTeam
 from src.common.schemas.fantasy_schemas import FantasyLeagueMembership
@@ -41,18 +41,13 @@ pro_player_2_fixture = ProfessionalPlayer(
     role=PlayerRole.JUNGLE
 )
 
-pro_player_3_fixture = ProfessionalPlayer(
-    id=str(uuid.uuid4()),
-    team_id=str(uuid.uuid4()),
-    summoner_name="summonerName2",
-    image="imageUrl2",
-    role=PlayerRole.MID
-)
-
 fantasy_team_service = FantasyTeamService()
 
 
 class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
+    # -------------------------------------
+    # ---- Get All Fantasy Team Weeks  ----
+    # -------------------------------------
     def test_get_all_fantasy_team_weeks_successful(self):
         # Arrange
         db_util.create_fantasy_league(fantasy_fixtures.fantasy_league_active_fixture)
@@ -149,18 +144,25 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
                 fantasy_fixtures.user_fixture.id
             )
 
+    # -------------------------------------
+    # ----------- Draft Player  -----------
+    # -------------------------------------
+
     def test_draft_player_has_initial_fantasy_team_successful(self):
         # Arrange
-        db_util.create_fantasy_league(fantasy_fixtures.fantasy_league_active_fixture)
+        setup_league_team_player_date()
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        fantasy_league.available_leagues = [riot_fixtures.league_1_fixture.id]
+        db_util.create_fantasy_league(fantasy_league)
         db_util.create_user(fantasy_fixtures.user_fixture)
         db_util.create_user(fantasy_fixtures.user_2_fixture)
         create_fantasy_league_membership_for_league(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
+            fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
             FantasyLeagueMembershipStatus.ACCEPTED
         )
         create_fantasy_league_membership_for_league(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
+            fantasy_league.id,
             fantasy_fixtures.user_2_fixture.id,
             FantasyLeagueMembershipStatus.ACCEPTED
         )
@@ -168,22 +170,21 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
         user_2_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
         user_2_fantasy_team.user_id = fantasy_fixtures.user_2_fixture.id
         db_util.create_fantasy_team(user_2_fantasy_team)
-        db_util.save_player(pro_player_fixture)
 
         expected_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
-        expected_fantasy_team.jungle_player_id = pro_player_fixture.id
+        expected_fantasy_team.top_player_id = riot_fixtures.player_1_fixture.id
 
         # Act
         returned_fantasy_team = fantasy_team_service.draft_player(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
+            fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
-            pro_player_fixture.id
+            riot_fixtures.player_1_fixture.id
         )
 
         # Assert
         self.assertEqual(expected_fantasy_team, returned_fantasy_team)
         user_1_fantasy_teams_from_db = crud.get_all_fantasy_teams_for_user(
-            fantasy_fixtures.fantasy_league_active_fixture.id, fantasy_fixtures.user_fixture.id
+            fantasy_league.id, fantasy_fixtures.user_fixture.id
         )
         self.assertEqual(1, len(user_1_fantasy_teams_from_db))
         self.assertEqual(
@@ -191,7 +192,7 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
         )
         # Check that user 2's fantasy team didn't update
         user_2_fantasy_teams_from_db = crud.get_all_fantasy_teams_for_user(
-            fantasy_fixtures.fantasy_league_active_fixture.id, fantasy_fixtures.user_2_fixture.id
+            fantasy_league.id, fantasy_fixtures.user_2_fixture.id
         )
         self.assertEqual(1, len(user_2_fantasy_teams_from_db))
         self.assertEqual(
@@ -200,16 +201,19 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
 
     def test_draft_player_has_no_initial_fantasy_team_successful(self):
         # Arrange
-        db_util.create_fantasy_league(fantasy_fixtures.fantasy_league_active_fixture)
+        setup_league_team_player_date()
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        fantasy_league.available_leagues = [riot_fixtures.league_1_fixture.id]
+        db_util.create_fantasy_league(fantasy_league)
         db_util.create_user(fantasy_fixtures.user_fixture)
         db_util.create_user(fantasy_fixtures.user_2_fixture)
         create_fantasy_league_membership_for_league(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
+            fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
             FantasyLeagueMembershipStatus.ACCEPTED
         )
         create_fantasy_league_membership_for_league(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
+            fantasy_league.id,
             fantasy_fixtures.user_2_fixture.id,
             FantasyLeagueMembershipStatus.ACCEPTED
         )
@@ -217,22 +221,21 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
         user_2_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
         user_2_fantasy_team.user_id = fantasy_fixtures.user_2_fixture.id
         db_util.create_fantasy_team(user_2_fantasy_team)
-        db_util.save_player(pro_player_fixture)
 
         expected_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
-        expected_fantasy_team.jungle_player_id = pro_player_fixture.id
+        expected_fantasy_team.top_player_id = riot_fixtures.player_1_fixture.id
 
         # Act
         returned_fantasy_team = fantasy_team_service.draft_player(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
+            fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
-            pro_player_fixture.id
+            riot_fixtures.player_1_fixture.id
         )
 
         # Assert
         self.assertEqual(expected_fantasy_team, returned_fantasy_team)
         user_1_fantasy_teams_from_db = crud.get_all_fantasy_teams_for_user(
-            fantasy_fixtures.fantasy_league_active_fixture.id, fantasy_fixtures.user_fixture.id
+            fantasy_league.id, fantasy_fixtures.user_fixture.id
         )
         self.assertEqual(1, len(user_1_fantasy_teams_from_db))
         self.assertEqual(
@@ -240,39 +243,90 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
         )
         # Check that user 2's fantasy team didn't update
         user_2_fantasy_teams_from_db = crud.get_all_fantasy_teams_for_user(
-            fantasy_fixtures.fantasy_league_active_fixture.id, fantasy_fixtures.user_2_fixture.id
+            fantasy_league.id, fantasy_fixtures.user_2_fixture.id
         )
         self.assertEqual(1, len(user_2_fantasy_teams_from_db))
         self.assertEqual(
             user_2_fantasy_team, FantasyTeam.model_validate(user_2_fantasy_teams_from_db[0])
         )
 
-    def test_draft_player_no_slot_available_to_draft_player_for_role(self):
+    def test_draft_player_no_available_leagues_for_fantasy_league_exception(self):
         # Arrange
-        db_util.create_fantasy_league(fantasy_fixtures.fantasy_league_active_fixture)
+        setup_league_team_player_date()
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        fantasy_league.available_leagues = []
+        db_util.create_fantasy_league(fantasy_league)
         db_util.create_user(fantasy_fixtures.user_fixture)
         create_fantasy_league_membership_for_league(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
+            fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
             FantasyLeagueMembershipStatus.ACCEPTED
         )
-        user_1_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
-        user_1_fantasy_team.jungle_player_id = "somePlayerId"
-        db_util.create_fantasy_team(user_1_fantasy_team)
-        db_util.save_player(pro_player_fixture)
+        db_util.create_fantasy_team(fantasy_fixtures.fantasy_team_week_1)
 
         # Act and Assert
         with self.assertRaises(FantasyDraftException) as context:
             fantasy_team_service.draft_player(
-                fantasy_fixtures.fantasy_league_active_fixture.id,
+                fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
-                pro_player_fixture.id
+                riot_fixtures.player_1_fixture.id
+            )
+        self.assertIn("Player not in available league", str(context.exception))
+
+    def test_draft_player_not_in_available_leagues_for_fantasy_league_exception(self):
+        # Arrange
+        setup_league_team_player_date()
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        fantasy_league.available_leagues = [riot_fixtures.league_2_fixture.id]
+        db_util.create_fantasy_league(fantasy_league)
+        db_util.create_user(fantasy_fixtures.user_fixture)
+        create_fantasy_league_membership_for_league(
+            fantasy_league.id,
+            fantasy_fixtures.user_fixture.id,
+            FantasyLeagueMembershipStatus.ACCEPTED
+        )
+        db_util.create_fantasy_team(fantasy_fixtures.fantasy_team_week_1)
+
+        # Act and Assert
+        with self.assertRaises(FantasyDraftException) as context:
+            fantasy_team_service.draft_player(
+                fantasy_league.id,
+                fantasy_fixtures.user_fixture.id,
+                riot_fixtures.player_1_fixture.id
+            )
+        self.assertIn("Player not in available league", str(context.exception))
+
+    def test_draft_player_no_slot_available_to_draft_player_for_role(self):
+        # Arrange
+        setup_league_team_player_date()
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        fantasy_league.available_leagues = [riot_fixtures.league_1_fixture.id]
+        db_util.create_fantasy_league(fantasy_league)
+        db_util.create_user(fantasy_fixtures.user_fixture)
+        create_fantasy_league_membership_for_league(
+            fantasy_league.id,
+            fantasy_fixtures.user_fixture.id,
+            FantasyLeagueMembershipStatus.ACCEPTED
+        )
+        user_1_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
+        user_1_fantasy_team.top_player_id = "somePlayerId"
+        db_util.create_fantasy_team(user_1_fantasy_team)
+
+        # Act and Assert
+        with self.assertRaises(FantasyDraftException) as context:
+            fantasy_team_service.draft_player(
+                fantasy_league.id,
+                fantasy_fixtures.user_fixture.id,
+                riot_fixtures.player_1_fixture.id
             )
         self.assertIn("Slot not available for role", str(context.exception))
 
     def test_draft_player_already_drafted_exception(self):
         # Arrange
-        db_util.create_fantasy_league(fantasy_fixtures.fantasy_league_active_fixture)
+        setup_league_team_player_date()
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        fantasy_league.available_leagues = [riot_fixtures.league_1_fixture.id]
+        db_util.create_fantasy_league(fantasy_league)
         db_util.create_user(fantasy_fixtures.user_fixture)
         db_util.create_user(fantasy_fixtures.user_2_fixture)
         create_fantasy_league_membership_for_league(
@@ -288,16 +342,15 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
         db_util.create_fantasy_team(fantasy_fixtures.fantasy_team_week_1)
         user_2_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
         user_2_fantasy_team.user_id = fantasy_fixtures.user_2_fixture.id
-        user_2_fantasy_team.jungle_player_id = pro_player_fixture.id
+        user_2_fantasy_team.top_player_id = riot_fixtures.player_1_fixture.id
         db_util.create_fantasy_team(user_2_fantasy_team)
-        db_util.save_player(pro_player_fixture)
 
         # Act and Assert
         with self.assertRaises(FantasyDraftException) as context:
             fantasy_team_service.draft_player(
                 fantasy_fixtures.fantasy_league_active_fixture.id,
                 fantasy_fixtures.user_fixture.id,
-                pro_player_fixture.id
+                riot_fixtures.player_1_fixture.id
             )
         self.assertIn("Player already drafted", str(context.exception))
 
@@ -342,11 +395,13 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
 
     def test_draft_player_user_not_an_active_member_exception(self):
         # Arrange
-        db_util.create_fantasy_league(fantasy_fixtures.fantasy_league_active_fixture)
+        setup_league_team_player_date()
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        fantasy_league.available_leagues = [riot_fixtures.league_1_fixture.id]
+        db_util.create_fantasy_league(fantasy_league)
         db_util.create_user(fantasy_fixtures.user_fixture)
-        db_util.save_player(pro_player_fixture)
         create_fantasy_league_membership_for_league(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
+            fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
             FantasyLeagueMembershipStatus.PENDING
         )
@@ -354,13 +409,16 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
         # Act and Assert
         with self.assertRaises(FantasyMembershipException):
             fantasy_team_service.draft_player(
-                fantasy_fixtures.fantasy_league_active_fixture.id,
+                fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
-                pro_player_fixture.id
+                riot_fixtures.player_1_fixture.id
             )
 
     def test_draft_player_professional_player_not_found_exception(self):
         # Arrange
+        setup_league_team_player_date()
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        fantasy_league.available_leagues = [riot_fixtures.league_1_fixture.id]
         db_util.create_fantasy_league(fantasy_fixtures.fantasy_league_active_fixture)
         db_util.create_user(fantasy_fixtures.user_fixture)
         create_fantasy_league_membership_for_league(
@@ -376,6 +434,10 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
                 fantasy_fixtures.user_fixture.id,
                 "badProPlayerId"
             )
+
+    # -------------------------------------
+    # ----------- Drop Player  ------------
+    # -------------------------------------
 
     def test_drop_player_successful(self):
         # Arrange
@@ -530,23 +592,32 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
                 "badProPlayerId"
             )
 
+    # -------------------------------------
+    # ------------ Swap Player  -----------
+    # -------------------------------------
+
     def test_swap_players_successful(self):
         # Arrange
-        db_util.create_fantasy_league(fantasy_fixtures.fantasy_league_active_fixture)
+        setup_league_team_player_date()
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        fantasy_league.available_leagues = [riot_fixtures.league_1_fixture.id]
+        db_util.create_fantasy_league(fantasy_league)
         db_util.create_user(fantasy_fixtures.user_fixture)
         db_util.create_user(fantasy_fixtures.user_2_fixture)
         create_fantasy_league_membership_for_league(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
+            fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
             FantasyLeagueMembershipStatus.ACCEPTED
         )
         create_fantasy_league_membership_for_league(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
+            fantasy_league.id,
             fantasy_fixtures.user_2_fixture.id,
             FantasyLeagueMembershipStatus.ACCEPTED
         )
+        jungle_player_1 = riot_fixtures.player_2_fixture
+        jungle_player_2 = riot_fixtures.player_7_fixture
         user_1_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
-        user_1_fantasy_team.jungle_player_id = pro_player_fixture.id
+        user_1_fantasy_team.jungle_player_id = jungle_player_1.id
         db_util.create_fantasy_team(user_1_fantasy_team)
 
         user_2_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
@@ -554,24 +625,21 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
         user_2_fantasy_team.jungle_player_id = "someOtherJunglePlayerId"
         db_util.create_fantasy_team(user_2_fantasy_team)
 
-        db_util.save_player(pro_player_fixture)
-        db_util.save_player(pro_player_2_fixture)
-
         expected_fantasy_team = deepcopy(user_1_fantasy_team)
-        expected_fantasy_team.jungle_player_id = pro_player_2_fixture.id
+        expected_fantasy_team.jungle_player_id = jungle_player_2.id
 
         # Act
         returned_fantasy_team = fantasy_team_service.swap_players(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
+            fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
-            pro_player_fixture.id,
-            pro_player_2_fixture.id
+            jungle_player_1.id,
+            jungle_player_2.id
         )
 
         # Assert
         self.assertEqual(expected_fantasy_team, returned_fantasy_team)
         user_1_fantasy_teams_from_db = crud.get_all_fantasy_teams_for_user(
-            fantasy_fixtures.fantasy_league_active_fixture.id, fantasy_fixtures.user_fixture.id
+            fantasy_league.id, fantasy_fixtures.user_fixture.id
         )
         self.assertEqual(1, len(user_1_fantasy_teams_from_db))
         self.assertEqual(
@@ -579,99 +647,148 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
         )
         # Check that user 2's fantasy team didn't update
         user_2_fantasy_teams_from_db = crud.get_all_fantasy_teams_for_user(
-            fantasy_fixtures.fantasy_league_active_fixture.id, fantasy_fixtures.user_2_fixture.id
+            fantasy_league.id, fantasy_fixtures.user_2_fixture.id
         )
         self.assertEqual(1, len(user_2_fantasy_teams_from_db))
         self.assertEqual(
             user_2_fantasy_team, FantasyTeam.model_validate(user_2_fantasy_teams_from_db[0])
         )
+        self.assertEqual(jungle_player_1.role, jungle_player_2.role)
 
     def test_swap_players_mismatched_player_roles_exception(self):
         # Arrange
-        db_util.create_fantasy_league(fantasy_fixtures.fantasy_league_active_fixture)
+        setup_league_team_player_date()
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        fantasy_league.available_leagues = [riot_fixtures.league_1_fixture.id]
+        db_util.create_fantasy_league(fantasy_league)
         db_util.create_user(fantasy_fixtures.user_fixture)
         create_fantasy_league_membership_for_league(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
+            fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
             FantasyLeagueMembershipStatus.ACCEPTED
         )
+        player_1 = riot_fixtures.player_1_fixture
+        player_2 = riot_fixtures.player_2_fixture
         user_1_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
-        user_1_fantasy_team.jungle_player_id = pro_player_fixture.id
+        user_1_fantasy_team.jungle_player_id = player_2.id
         db_util.create_fantasy_team(user_1_fantasy_team)
-        db_util.save_player(pro_player_fixture)
-        db_util.save_player(pro_player_3_fixture)
 
         # Act and Assert
         with self.assertRaises(FantasyDraftException) as context:
             fantasy_team_service.swap_players(
-                fantasy_fixtures.fantasy_league_active_fixture.id,
+                fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
-                pro_player_fixture.id,
-                pro_player_3_fixture.id
+                player_2.id,
+                player_1.id
             )
         self.assertIn("Mismatching roles", str(context.exception))
+        self.assertNotEqual(player_1.role, player_2.role)
 
     def test_swap_players_user_does_not_have_player_drafted_exception(self):
         # Arrange
-        db_util.create_fantasy_league(fantasy_fixtures.fantasy_league_active_fixture)
+        setup_league_team_player_date()
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        fantasy_league.available_leagues = [riot_fixtures.league_1_fixture.id]
+        db_util.create_fantasy_league(fantasy_league)
         db_util.create_user(fantasy_fixtures.user_fixture)
         create_fantasy_league_membership_for_league(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
+            fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
             FantasyLeagueMembershipStatus.ACCEPTED
         )
+        jungle_player_1 = riot_fixtures.player_2_fixture
+        jungle_player_2 = riot_fixtures.player_7_fixture
         user_1_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
         user_1_fantasy_team.jungle_player_id = "someOtherPlayerId"
         db_util.create_fantasy_team(user_1_fantasy_team)
-        db_util.save_player(pro_player_fixture)
-        db_util.save_player(pro_player_2_fixture)
 
         # Act and Assert
         with self.assertRaises(FantasyDraftException) as context:
             fantasy_team_service.swap_players(
-                fantasy_fixtures.fantasy_league_active_fixture.id,
+                fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
-                pro_player_fixture.id,
-                pro_player_2_fixture.id
+                jungle_player_1.id,
+                jungle_player_2.id
             )
         self.assertIn("Player not drafted", str(context.exception))
+        self.assertEqual(jungle_player_1.role, jungle_player_2.role)
 
     def test_swap_players_already_drafted_exception(self):
         # Arrange
-        db_util.create_fantasy_league(fantasy_fixtures.fantasy_league_active_fixture)
-        db_util.create_user(fantasy_fixtures.user_fixture)
-        db_util.create_user(fantasy_fixtures.user_2_fixture)
+        setup_league_team_player_date()
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        fantasy_league.available_leagues = [riot_fixtures.league_1_fixture.id]
+        db_util.create_fantasy_league(fantasy_league)
+        user_1 = fantasy_fixtures.user_fixture
+        user_2 = fantasy_fixtures.user_2_fixture
+        db_util.create_user(user_1)
+        db_util.create_user(user_2)
         create_fantasy_league_membership_for_league(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
-            fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            fantasy_league.id, user_1.id, FantasyLeagueMembershipStatus.ACCEPTED
         )
         create_fantasy_league_membership_for_league(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
-            fantasy_fixtures.user_2_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            fantasy_league.id, user_2.id, FantasyLeagueMembershipStatus.ACCEPTED
         )
         user_1_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
-        user_1_fantasy_team.jungle_player_id = pro_player_fixture.id
+        user_1_fantasy_team.jungle_player_id = riot_fixtures.player_2_fixture.id
         db_util.create_fantasy_team(user_1_fantasy_team)
 
         user_2_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
-        user_2_fantasy_team.user_id = fantasy_fixtures.user_2_fixture.id
-        user_2_fantasy_team.jungle_player_id = pro_player_2_fixture.id
+        user_2_fantasy_team.user_id = user_2.id
+        user_2_fantasy_team.jungle_player_id = riot_fixtures.player_7_fixture.id
         db_util.create_fantasy_team(user_2_fantasy_team)
-
-        db_util.save_player(pro_player_fixture)
-        db_util.save_player(pro_player_2_fixture)
 
         # Act and Assert
         with self.assertRaises(FantasyDraftException) as context:
             fantasy_team_service.swap_players(
-                fantasy_fixtures.fantasy_league_active_fixture.id,
-                fantasy_fixtures.user_fixture.id,
-                pro_player_fixture.id,
-                pro_player_2_fixture.id
+                fantasy_league.id,
+                user_1.id,
+                riot_fixtures.player_2_fixture.id,
+                riot_fixtures.player_7_fixture.id
             )
         self.assertIn("Player already drafted", str(context.exception))
+        db_user_1_fantasy_teams = crud.get_all_fantasy_teams_for_user(
+            fantasy_league.id, user_1.id
+        )
+        self.assertIsInstance(db_user_1_fantasy_teams, list)
+        self.assertEqual(1, len(db_user_1_fantasy_teams))
+        self.assertEqual(
+            user_1_fantasy_team, FantasyTeam.model_validate(db_user_1_fantasy_teams[0])
+        )
+        db_user_2_fantasy_teams = crud.get_all_fantasy_teams_for_user(
+            fantasy_league.id, user_2.id
+        )
+        self.assertIsInstance(db_user_2_fantasy_teams, list)
+        self.assertEqual(1, len(db_user_2_fantasy_teams))
+        self.assertEqual(
+            user_2_fantasy_team, FantasyTeam.model_validate(db_user_2_fantasy_teams[0])
+        )
+
+    def test_swap_players_player_to_pickup_not_in_available_leagues_exception(self):
+        # Arrange
+        setup_league_team_player_date()
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        fantasy_league.available_leagues = ["12345"]
+        db_util.create_fantasy_league(fantasy_league)
+        db_util.create_user(fantasy_fixtures.user_fixture)
+        create_fantasy_league_membership_for_league(
+            fantasy_league.id,
+            fantasy_fixtures.user_fixture.id,
+            FantasyLeagueMembershipStatus.ACCEPTED
+        )
+        user_1_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
+        user_1_fantasy_team.jungle_player_id = riot_fixtures.player_2_fixture.id
+        db_util.create_fantasy_team(user_1_fantasy_team)
+
+        # Act and Assert
+        with self.assertRaises(FantasyDraftException) as context:
+            fantasy_team_service.swap_players(
+                fantasy_league.id,
+                fantasy_fixtures.user_fixture.id,
+                riot_fixtures.player_2_fixture.id,
+                riot_fixtures.player_7_fixture.id
+            )
+        self.assertIn("Player not in available league", str(context.exception))
 
     def test_swap_players_fantasy_league_not_found_exception(self):
         # Arrange
@@ -787,3 +904,13 @@ def create_fantasy_league_membership_for_league(
         status=status
     )
     db_util.create_fantasy_league_membership(fantasy_league_membership)
+
+
+def setup_league_team_player_date():
+    db_util.save_league(riot_fixtures.league_1_fixture)
+    db_util.save_league(riot_fixtures.league_2_fixture)
+    db_util.save_team(riot_fixtures.team_1_fixture)
+    db_util.save_team(riot_fixtures.team_2_fixture)
+    db_util.save_player(riot_fixtures.player_1_fixture)
+    db_util.save_player(riot_fixtures.player_2_fixture)
+    db_util.save_player(riot_fixtures.player_7_fixture)

--- a/tests/fantasy/unit/util/test_fantasy_team_util.py
+++ b/tests/fantasy/unit/util/test_fantasy_team_util.py
@@ -1,0 +1,64 @@
+from copy import deepcopy
+from unittest.mock import patch
+
+from tests.test_base import FantasyLolTestBase
+from tests.test_util import fantasy_fixtures
+
+from src.fantasy.util.fantasty_team_util import FantasyTeamUtil
+from src.fantasy.exceptions.fantasy_draft_exception import FantasyDraftException
+
+BASE_CRUD_PATH = 'src.db.crud'
+
+fantasy_team_util = FantasyTeamUtil()
+
+
+class TestFantasyTeamUtil(FantasyLolTestBase):
+    @patch(f'{BASE_CRUD_PATH}.get_league_ids_for_player')
+    def test_validate_player_from_available_league_successful(
+            self, mock_get_league_ids_for_player):
+        # Arrange
+        player_id = "321"
+        league_ids = ["1234"]
+        mock_get_league_ids_for_player.return_value = league_ids
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
+        fantasy_league.available_leagues = league_ids
+
+        # Act and Assert
+        try:
+            fantasy_team_util.validate_player_from_available_league(fantasy_league, player_id)
+        except FantasyDraftException:
+            self.fail("Validate player from available league encountered an unexpected exception")
+
+    @patch(f'{BASE_CRUD_PATH}.get_league_ids_for_player')
+    def test_validate_player_from_available_league_player_not_in_available_league_exception(
+            self, mock_get_league_ids_for_player):
+        # Arrange
+        player_id = "321"
+        league_ids = ["1234"]
+        available_league_ids = ["4321"]
+        mock_get_league_ids_for_player.return_value = league_ids
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
+        fantasy_league.available_leagues = available_league_ids
+
+        # Act and Assert
+        with self.assertRaises(FantasyDraftException) as context:
+            fantasy_team_util.validate_player_from_available_league(fantasy_league, player_id)
+        self.assertIn("Player not in available league", str(context.exception))
+        self.assertNotEqual(league_ids, available_league_ids)
+
+    @patch(f'{BASE_CRUD_PATH}.get_league_ids_for_player')
+    def test_validate_player_from_available_league_no_league_ids_returned_exception(
+            self, mock_get_league_ids_for_player):
+        # Arrange
+        player_id = "321"
+        league_ids = []
+        available_league_ids = ["4321"]
+        mock_get_league_ids_for_player.return_value = league_ids
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
+        fantasy_league.available_leagues = available_league_ids
+
+        # Act and Assert
+        with self.assertRaises(FantasyDraftException) as context:
+            fantasy_team_util.validate_player_from_available_league(fantasy_league, player_id)
+        self.assertIn("Player not in available league", str(context.exception))
+        self.assertNotEqual(league_ids, available_league_ids)

--- a/tests/test_util/riot_fixtures.py
+++ b/tests/test_util/riot_fixtures.py
@@ -24,7 +24,7 @@ def generate_random_id():
 
 league_1_fixture = schemas.League(
     id=generate_random_id(),
-    name="Mock Challengers",
+    name="Mock League 1",
     slug="mock-challengers-league",
     region="MOCKED REGION",
     image="http//:mocked-league-image.png",
@@ -34,7 +34,7 @@ league_1_fixture = schemas.League(
 
 league_2_fixture = schemas.League(
     id=generate_random_id(),
-    name="Mock Pro",
+    name="Mock League 2",
     slug="mock-pro-league",
     region="MOCKED REGION2",
     image="http//:mocked-league-2-image.png",


### PR DESCRIPTION
Users can only draft players from the allowed leagues stored on the Fantasy League. If a user tries to draft or swap a player who is not from one of the allowed leagues the user will receive an error message

resolves #266