### PR TITLE
Start fantasy draft

### DIFF
--- a/src/db/crud.py
+++ b/src/db/crud.py
@@ -415,6 +415,29 @@ def update_fantasy_league_settings(
         return fantasy_league
 
 
+def update_fantasy_league_status(
+        fantasy_league_id: str,
+        new_status: f_schemas.FantasyLeagueStatus) -> models.FantasyLeagueModel:
+    with DatabaseConnection() as db:
+        fantasy_league = db.query(models.FantasyLeagueModel).filter_by(id=fantasy_league_id).first()
+
+        fantasy_league.status = new_status
+        db.commit()
+        db.refresh(fantasy_league)
+        return fantasy_league
+
+
+def update_fantasy_league_current_draft_position(
+        fantasy_league_id: str, new_current_draft_position: int) -> models.FantasyLeagueModel:
+    with DatabaseConnection() as db:
+        fantasy_league = db.query(models.FantasyLeagueModel).filter_by(id=fantasy_league_id).first()
+
+        fantasy_league.current_draft_position = new_current_draft_position
+        db.commit()
+        db.refresh(fantasy_league)
+        return fantasy_league
+
+
 # --------------------------------------------------
 # ------- Fantasy League Invite Operations ---------
 # --------------------------------------------------

--- a/src/fantasy/exceptions/fantasy_league_start_draft_exception.py
+++ b/src/fantasy/exceptions/fantasy_league_start_draft_exception.py
@@ -1,0 +1,10 @@
+from fastapi import HTTPException
+from http import HTTPStatus
+
+
+class FantasyLeagueStartDraftException(HTTPException):
+    def __init__(self, detail):
+        super().__init__(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=detail
+        )


### PR DESCRIPTION
Owners of their fantasy league can start the Fantasy Draft by moving the fantasy league into `DRAFT` status. If the fantasy league has too few or too many members an error is raised. If there are no set available leagues an error is raised. If the fantasy league is not in `PRE_DRAFT` status an error is raised.

resolves #271