### PR TITLE
Check current draft position

### DIFF
--- a/src/fantasy/endpoints/fantasy_team_endpoint_v1.py
+++ b/src/fantasy/endpoints/fantasy_team_endpoint_v1.py
@@ -27,17 +27,17 @@ def get_fantasy_team_weeks_for_league(
 
 
 @router.put(
-    path="/teams/{fantasy_league_id}/draft/{player_id}",
+    path="/teams/{fantasy_league_id}/pickup/{player_id}",
     tags=["Fantasy Teams"],
     dependencies=[Depends(JWTBearer())],
     response_model=FantasyTeam
 )
-def draft_player(
+def pickup_player(
         fantasy_league_id: str,
         player_id: str,
         decoded_token: dict = Depends(JWTBearer())):
     user_id = decoded_token.get("user_id")
-    return fantasy_team_service.draft_player(fantasy_league_id, user_id, player_id)
+    return fantasy_team_service.pickup_player(fantasy_league_id, user_id, player_id)
 
 
 @router.put(

--- a/src/fantasy/service/fantasy_team_service.py
+++ b/src/fantasy/service/fantasy_team_service.py
@@ -20,7 +20,6 @@ from ..exceptions.fantasy_draft_exception import FantasyDraftException
 from ..util.fantasy_league_util import FantasyLeagueUtil
 from ..util.fantasty_team_util import FantasyTeamUtil
 
-
 fantasy_league_util = FantasyLeagueUtil()
 fantasy_team_util = FantasyTeamUtil()
 
@@ -47,6 +46,14 @@ class FantasyTeamService:
         professional_player = get_player_from_db(player_id)
         fantasy_team_util.validate_player_from_available_league(fantasy_league, player_id)
         validate_user_membership(user_id, fantasy_league_id)
+
+        if (fantasy_league.status == FantasyLeagueStatus.DRAFT) \
+                and not (fantasy_team_util.is_users_position_to_draft(fantasy_league, user_id)):
+            raise FantasyDraftException(
+                f"Invalid user draft position: The draft position for the user "
+                f"with ID {user_id} is not the current draft position for fantasy league "
+                f"with ID {fantasy_league_id}"
+            )
 
         recent_fantasy_team = get_users_most_recent_fantasy_team(fantasy_league, user_id)
         if recent_fantasy_team.get_player_id_for_role(professional_player.role) is not None:

--- a/src/fantasy/service/fantasy_team_service.py
+++ b/src/fantasy/service/fantasy_team_service.py
@@ -39,7 +39,7 @@ class FantasyTeamService:
         return fantasy_team_weeks
 
     @staticmethod
-    def draft_player(fantasy_league_id: str, user_id: str, player_id: str) -> FantasyTeam:
+    def pickup_player(fantasy_league_id: str, user_id: str, player_id: str) -> FantasyTeam:
         fantasy_league = fantasy_league_util.validate_league(
             fantasy_league_id, [FantasyLeagueStatus.DRAFT, FantasyLeagueStatus.ACTIVE]
         )

--- a/src/fantasy/util/fantasty_team_util.py
+++ b/src/fantasy/util/fantasty_team_util.py
@@ -20,3 +20,20 @@ class FantasyTeamUtil:
                 f"one of the available leagues {fantasy_league.available_leagues}, for the "
                 f"fantasy league with ID {fantasy_league.id}"
             )
+
+    @staticmethod
+    def is_users_position_to_draft(fantasy_league: FantasyLeague, user_id: str) -> bool:
+        draft_order = crud.get_fantasy_league_draft_order(fantasy_league.id)
+        users_draft_position = None
+        for draft_position in draft_order:
+            if draft_position.user_id == user_id:
+                users_draft_position = draft_position.position
+        if users_draft_position is None:
+            # This should ideally never be hit since we are validating the users
+            # membership before we call this method.
+            raise FantasyDraftException(
+                f"Could not find draft position for user with ID {user_id} "
+                f"in the fantasy league with ID {fantasy_league.id}"
+            )
+
+        return users_draft_position == fantasy_league.current_draft_position

--- a/tests/fantasy/integration/service/test_fantasy_team_service.py
+++ b/tests/fantasy/integration/service/test_fantasy_team_service.py
@@ -145,11 +145,11 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
                 fantasy_fixtures.user_fixture.id
             )
 
-    # -------------------------------------
-    # ----------- Draft Player  -----------
-    # -------------------------------------
+    # --------------------------------------
+    # ----------- Pickup Player  -----------
+    # --------------------------------------
 
-    def test_draft_player_has_initial_fantasy_team_for_draft_league_successful(self):
+    def test_pickup_player_has_initial_fantasy_team_for_draft_league_successful(self):
         # Arrange
         setup_league_team_player_date()
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_draft_fixture)
@@ -183,7 +183,7 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
         expected_fantasy_team.top_player_id = riot_fixtures.player_1_fixture.id
 
         # Act
-        returned_fantasy_team = fantasy_team_service.draft_player(
+        returned_fantasy_team = fantasy_team_service.pickup_player(
             fantasy_league.id, user_1.id, riot_fixtures.player_1_fixture.id
         )
 
@@ -205,7 +205,7 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
             user_2_fantasy_team, FantasyTeam.model_validate(user_2_fantasy_teams_from_db[0])
         )
 
-    def test_draft_player_has_no_initial_fantasy_team_for_draft_league_successful(self):
+    def test_pickup_player_has_no_initial_fantasy_team_for_draft_league_successful(self):
         # Arrange
         setup_league_team_player_date()
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_draft_fixture)
@@ -235,7 +235,7 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
         expected_fantasy_team.top_player_id = riot_fixtures.player_1_fixture.id
 
         # Act
-        returned_fantasy_team = fantasy_team_service.draft_player(
+        returned_fantasy_team = fantasy_team_service.pickup_player(
             fantasy_league.id, user_1.id, riot_fixtures.player_1_fixture.id
         )
 
@@ -257,7 +257,7 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
             user_2_fantasy_team, FantasyTeam.model_validate(user_2_fantasy_teams_from_db[0])
         )
 
-    def test_draft_player_for_active_league_successful(self):
+    def test_pickup_player_for_active_league_successful(self):
         # Arrange
         setup_league_team_player_date()
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
@@ -285,7 +285,7 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
         expected_fantasy_team.top_player_id = riot_fixtures.player_1_fixture.id
 
         # Act
-        returned_fantasy_team = fantasy_team_service.draft_player(
+        returned_fantasy_team = fantasy_team_service.pickup_player(
             fantasy_league.id, user_1.id, riot_fixtures.player_1_fixture.id
         )
 
@@ -307,7 +307,7 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
             user_2_fantasy_team, FantasyTeam.model_validate(user_2_fantasy_teams_from_db[0])
         )
 
-    def test_draft_player_not_users_current_draft_position_exception(self):
+    def test_pickup_player_not_users_current_draft_position_exception(self):
         # Arrange
         setup_league_team_player_date()
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_draft_fixture)
@@ -341,7 +341,7 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
 
         # Act and Assert
         with self.assertRaises(FantasyDraftException) as context:
-            fantasy_team_service.draft_player(
+            fantasy_team_service.pickup_player(
                 fantasy_league.id, user_1.id, riot_fixtures.player_1_fixture.id
             )
         self.assertIn("Invalid user draft position", str(context.exception))
@@ -351,7 +351,7 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
         self.assertEqual(1, len(db_user_fantasy_teams))
         self.assertEqual(user_1_fantasy_team, FantasyTeam.model_validate(db_user_fantasy_teams[0]))
 
-    def test_draft_player_no_available_leagues_for_fantasy_league_exception(self):
+    def test_pickup_player_no_available_leagues_for_fantasy_league_exception(self):
         # Arrange
         setup_league_team_player_date()
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
@@ -367,14 +367,14 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
 
         # Act and Assert
         with self.assertRaises(FantasyDraftException) as context:
-            fantasy_team_service.draft_player(
+            fantasy_team_service.pickup_player(
                 fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
                 riot_fixtures.player_1_fixture.id
             )
         self.assertIn("Player not in available league", str(context.exception))
 
-    def test_draft_player_not_in_available_leagues_for_fantasy_league_exception(self):
+    def test_pickup_player_not_in_available_leagues_for_fantasy_league_exception(self):
         # Arrange
         setup_league_team_player_date()
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
@@ -390,14 +390,14 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
 
         # Act and Assert
         with self.assertRaises(FantasyDraftException) as context:
-            fantasy_team_service.draft_player(
+            fantasy_team_service.pickup_player(
                 fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
                 riot_fixtures.player_1_fixture.id
             )
         self.assertIn("Player not in available league", str(context.exception))
 
-    def test_draft_player_no_slot_available_to_draft_player_for_role(self):
+    def test_pickup_player_no_slot_available_to_pickup_player_for_role(self):
         # Arrange
         setup_league_team_player_date()
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
@@ -415,14 +415,14 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
 
         # Act and Assert
         with self.assertRaises(FantasyDraftException) as context:
-            fantasy_team_service.draft_player(
+            fantasy_team_service.pickup_player(
                 fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
                 riot_fixtures.player_1_fixture.id
             )
         self.assertIn("Slot not available for role", str(context.exception))
 
-    def test_draft_player_already_drafted_exception(self):
+    def test_pickup_player_already_drafted_exception(self):
         # Arrange
         setup_league_team_player_date()
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
@@ -448,27 +448,27 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
 
         # Act and Assert
         with self.assertRaises(FantasyDraftException) as context:
-            fantasy_team_service.draft_player(
+            fantasy_team_service.pickup_player(
                 fantasy_fixtures.fantasy_league_active_fixture.id,
                 fantasy_fixtures.user_fixture.id,
                 riot_fixtures.player_1_fixture.id
             )
         self.assertIn("Player already drafted", str(context.exception))
 
-    def test_draft_player_fantasy_league_not_found_exception(self):
+    def test_pickup_player_fantasy_league_not_found_exception(self):
         # Arrange
         db_util.create_user(fantasy_fixtures.user_fixture)
         db_util.save_player(pro_player_fixture)
 
         # Act and Assert
         with self.assertRaises(FantasyLeagueNotFoundException):
-            fantasy_team_service.draft_player(
+            fantasy_team_service.pickup_player(
                 "badFantasyLeagueId",
                 fantasy_fixtures.user_fixture.id,
                 pro_player_fixture.id
             )
 
-    def test_draft_player_fantasy_league_not_draft_or_active_state(self):
+    def test_pickup_player_fantasy_league_not_draft_or_active_state(self):
         # Arrange
         bad_states = [
             FantasyLeagueStatus.PRE_DRAFT,
@@ -488,13 +488,13 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
             )
             db_util.create_fantasy_league(bad_fantasy_league)
             with self.assertRaises(FantasyLeagueInvalidRequiredStateException):
-                fantasy_team_service.draft_player(
+                fantasy_team_service.pickup_player(
                     bad_fantasy_league.id,
                     fantasy_fixtures.user_fixture.id,
                     pro_player_fixture.id
                 )
 
-    def test_draft_player_user_not_an_active_member_exception(self):
+    def test_pickup_player_user_not_an_active_member_exception(self):
         # Arrange
         setup_league_team_player_date()
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
@@ -509,13 +509,13 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
 
         # Act and Assert
         with self.assertRaises(FantasyMembershipException):
-            fantasy_team_service.draft_player(
+            fantasy_team_service.pickup_player(
                 fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
                 riot_fixtures.player_1_fixture.id
             )
 
-    def test_draft_player_professional_player_not_found_exception(self):
+    def test_pickup_player_professional_player_not_found_exception(self):
         # Arrange
         setup_league_team_player_date()
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
@@ -530,7 +530,7 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
 
         # Act and Assert
         with self.assertRaises(ProfessionalPlayerNotFoundException):
-            fantasy_team_service.draft_player(
+            fantasy_team_service.pickup_player(
                 fantasy_fixtures.fantasy_league_active_fixture.id,
                 fantasy_fixtures.user_fixture.id,
                 "badProPlayerId"

--- a/tests/fantasy/unit/service/test_fantasy_team_service.py
+++ b/tests/fantasy/unit/service/test_fantasy_team_service.py
@@ -153,7 +153,7 @@ class TestFantasyTeamService(FantasyLolTestBase):
         self.assertEqual(expected_bool, returned_bool)
 
     @patch(f'{BASE_CRUD_PATH}.get_all_fantasy_teams_for_user')
-    def test_validate_user_can_draft_player_for_role_open_spot_available(
+    def test_validate_user_can_pickup_player_for_role_open_spot_available(
             self, mock_get_all_fantasy_teams_for_user):
         # Arrange
         user_id = "someUserId"
@@ -190,7 +190,7 @@ class TestFantasyTeamService(FantasyLolTestBase):
         self.assertEqual(expected_fantasy_team, returned_fantasy_team)
 
     @patch(f'{BASE_CRUD_PATH}.get_all_fantasy_teams_for_user')
-    def test_validate_user_can_draft_player_no_fantasy_teams_yet_saved(
+    def test_validate_user_can_pickup_player_no_fantasy_teams_yet_saved(
             self, mock_get_all_fantasy_teams_for_user):
         # Arrange
         user_id = "someUserId"

--- a/tests/fantasy/unit/util/test_fantasy_team_util.py
+++ b/tests/fantasy/unit/util/test_fantasy_team_util.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 from tests.test_base import FantasyLolTestBase
 from tests.test_util import fantasy_fixtures
 
+from src.db.models import FantasyLeagueDraftOrderModel
+
 from src.fantasy.util.fantasty_team_util import FantasyTeamUtil
 from src.fantasy.exceptions.fantasy_draft_exception import FantasyDraftException
 
@@ -62,3 +64,88 @@ class TestFantasyTeamUtil(FantasyLolTestBase):
             fantasy_team_util.validate_player_from_available_league(fantasy_league, player_id)
         self.assertIn("Player not in available league", str(context.exception))
         self.assertNotEqual(league_ids, available_league_ids)
+
+    @patch(f'{BASE_CRUD_PATH}.get_fantasy_league_draft_order')
+    def test_is_users_position_to_draft_true(self, mock_get_fantasy_league_draft_order):
+        # Arrange
+        user = fantasy_fixtures.user_fixture
+        fantasy_league = fantasy_fixtures.fantasy_league_draft_fixture
+        users_draft_position = FantasyLeagueDraftOrderModel(
+            fantasy_league_id=fantasy_league.id,
+            user_id=user.id,
+            position=1
+        )
+        draft_order = [
+            users_draft_position,
+            FantasyLeagueDraftOrderModel(
+                fantasy_league_id=fantasy_league.id,
+                user_id="someOtherUser",
+                position=2
+            )
+        ]
+        mock_get_fantasy_league_draft_order.return_value = draft_order
+
+        # Act
+        is_turn_to_draft = fantasy_team_util.is_users_position_to_draft(fantasy_league, user.id)
+
+        # Assert
+        self.assertTrue(is_turn_to_draft)
+        self.assertEqual(fantasy_league.current_draft_position, users_draft_position.position)
+        mock_get_fantasy_league_draft_order.assert_called_once_with(fantasy_league.id)
+
+    @patch(f'{BASE_CRUD_PATH}.get_fantasy_league_draft_order')
+    def test_is_users_position_to_draft_false(self, mock_get_fantasy_league_draft_order):
+        # Arrange
+        user = fantasy_fixtures.user_fixture
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_draft_fixture)
+        fantasy_league.current_draft_position = 2
+        users_draft_position = FantasyLeagueDraftOrderModel(
+            fantasy_league_id=fantasy_league.id,
+            user_id=user.id,
+            position=1
+        )
+        draft_order = [
+            users_draft_position,
+            FantasyLeagueDraftOrderModel(
+                fantasy_league_id=fantasy_league.id,
+                user_id="someOtherUser",
+                position=2
+            )
+        ]
+        mock_get_fantasy_league_draft_order.return_value = draft_order
+
+        # Act
+        is_turn_to_draft = fantasy_team_util.is_users_position_to_draft(fantasy_league, user.id)
+
+        # Assert
+        self.assertFalse(is_turn_to_draft)
+        self.assertNotEqual(fantasy_league.current_draft_position, users_draft_position.position)
+        mock_get_fantasy_league_draft_order.assert_called_once_with(fantasy_league.id)
+
+    @patch(f'{BASE_CRUD_PATH}.get_fantasy_league_draft_order')
+    def test_is_users_position_to_draft_no_user_draft_position_found_exception(
+            self, mock_get_fantasy_league_draft_order):
+        # Arrange
+        user = fantasy_fixtures.user_fixture
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_draft_fixture)
+        fantasy_league.current_draft_position = 1
+        users_draft_position = FantasyLeagueDraftOrderModel(
+            fantasy_league_id=fantasy_league.id,
+            user_id=user.id,
+            position=1
+        )
+        draft_order = [
+            users_draft_position,
+            FantasyLeagueDraftOrderModel(
+                fantasy_league_id=fantasy_league.id,
+                user_id="someOtherUser",
+                position=2
+            )
+        ]
+        mock_get_fantasy_league_draft_order.return_value = draft_order
+
+        # Act and Assert
+        with self.assertRaises(FantasyDraftException) as context:
+            fantasy_team_util.is_users_position_to_draft(fantasy_league, "notFoundUserId")
+        self.assertIn("Could not find draft position", str(context.exception))
+        mock_get_fantasy_league_draft_order.assert_called_once_with(fantasy_league.id)

--- a/tests/test_util/fantasy_fixtures.py
+++ b/tests/test_util/fantasy_fixtures.py
@@ -55,12 +55,24 @@ fantasy_league_fixture = fantasy_schemas.FantasyLeague(
     current_week=None
 )
 
+fantasy_league_draft_fixture = fantasy_schemas.FantasyLeague(
+    id=str(uuid.uuid4()),
+    owner_id=user_fixture.id,
+    status=fantasy_schemas.FantasyLeagueStatus.DRAFT,
+    name=fantasy_league_settings_fixture.name,
+    number_of_teams=fantasy_league_settings_fixture.number_of_teams,
+    available_leagues=fantasy_league_settings_fixture.available_leagues,
+    current_draft_position=1,
+    current_week=0
+)
+
 fantasy_league_active_fixture = fantasy_schemas.FantasyLeague(
     id=str(uuid.uuid4()),
     owner_id=user_fixture.id,
     status=fantasy_schemas.FantasyLeagueStatus.ACTIVE,
     name=fantasy_league_settings_fixture.name,
     number_of_teams=fantasy_league_settings_fixture.number_of_teams,
+    available_leagues=fantasy_league_settings_fixture.available_leagues,
     current_week=1
 )
 


### PR DESCRIPTION
- The current draft position is checked if the status of the fantasy league is `DRAFT`
- Renamed the endpoint and methods of `draft player` to `pickup player` as the naming is more consistent to what is happening given that the operation is used in both `DRAFT` and `ACTIVE` status for a fantasy league.

resolves #269 