### PR TITLE
Current draft position updated on successful draft

### DIFF
--- a/src/fantasy/service/fantasy_team_service.py
+++ b/src/fantasy/service/fantasy_team_service.py
@@ -71,6 +71,9 @@ class FantasyTeamService:
             )
 
         crud.create_or_update_fantasy_team(recent_fantasy_team)
+        if fantasy_league.status == FantasyLeagueStatus.DRAFT:
+            fantasy_league_util.update_fantasy_leagues_current_draft_position(fantasy_league)
+
         return recent_fantasy_team
 
     @staticmethod

--- a/src/fantasy/util/fantasy_league_util.py
+++ b/src/fantasy/util/fantasy_league_util.py
@@ -39,3 +39,11 @@ class FantasyLeagueUtil:
                 raise FantasyUnavailableException(
                     f"Riot league with ID {league_id} not available to be used in Fantasy Leagues"
                 )
+
+    @staticmethod
+    def update_fantasy_leagues_current_draft_position(fantasy_league: FantasyLeagueModel):
+        if fantasy_league.current_draft_position + 1 <= fantasy_league.number_of_teams:
+            new_draft_position = fantasy_league.current_draft_position + 1
+        else:
+            new_draft_position = 1
+        crud.update_fantasy_league_current_draft_position(fantasy_league.id, new_draft_position)

--- a/tests/fantasy/integration/service/test_fantasy_team_service.py
+++ b/tests/fantasy/integration/service/test_fantasy_team_service.py
@@ -154,6 +154,7 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
         setup_league_team_player_date()
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_draft_fixture)
         fantasy_league.available_leagues = [riot_fixtures.league_1_fixture.id]
+        fantasy_league.current_draft_position = 1
         db_util.create_fantasy_league(fantasy_league)
         user_1 = fantasy_fixtures.user_fixture
         user_2 = fantasy_fixtures.user_2_fixture
@@ -203,6 +204,10 @@ class FantasyTeamServiceIntegrationTest(FantasyLolTestBase):
         self.assertEqual(1, len(user_2_fantasy_teams_from_db))
         self.assertEqual(
             user_2_fantasy_team, FantasyTeam.model_validate(user_2_fantasy_teams_from_db[0])
+        )
+        db_fantasy_league = db_util.get_fantasy_league_by_id(fantasy_league.id)
+        self.assertEqual(
+            fantasy_league.current_draft_position + 1, db_fantasy_league.current_draft_position
         )
 
     def test_pickup_player_has_no_initial_fantasy_team_for_draft_league_successful(self):


### PR DESCRIPTION
When a user successfully drafts a player while the fantasy league is in `DRAFT` status, the current draft position for the fantasy league is updated.

resolves #268