### PR TITLE
Move league to active status

### DIFF
--- a/src/fantasy/service/fantasy_team_service.py
+++ b/src/fantasy/service/fantasy_team_service.py
@@ -73,6 +73,9 @@ class FantasyTeamService:
         crud.create_or_update_fantasy_team(recent_fantasy_team)
         if fantasy_league.status == FantasyLeagueStatus.DRAFT:
             fantasy_league_util.update_fantasy_leagues_current_draft_position(fantasy_league)
+            if fantasy_team_util.all_teams_fully_drafted(fantasy_league):
+                crud.update_fantasy_league_status(fantasy_league_id, FantasyLeagueStatus.ACTIVE)
+                # TODO: NEED TO SET THE CURRENT WEEK TO BE THE CURRENT WEEK FOR THE LEAGUE(S)
 
         return recent_fantasy_team
 

--- a/src/fantasy/util/fantasty_team_util.py
+++ b/src/fantasy/util/fantasty_team_util.py
@@ -37,3 +37,30 @@ class FantasyTeamUtil:
             )
 
         return users_draft_position == fantasy_league.current_draft_position
+
+    @staticmethod
+    def all_teams_fully_drafted(fantasy_league: FantasyLeague) -> bool:
+        fantasy_league_teams = crud.get_all_fantasy_teams_for_current_week(
+            fantasy_league.id, fantasy_league.current_week
+        )
+        if len(fantasy_league_teams) != fantasy_league.number_of_teams:
+            return False
+
+        all_teams_fully_draft = True
+        for team in fantasy_league_teams:
+            if team.top_player_id is None:
+                all_teams_fully_draft = False
+                break
+            if team.jungle_player_id is None:
+                all_teams_fully_draft = False
+                break
+            if team.mid_player_id is None:
+                all_teams_fully_draft = False
+                break
+            if team.adc_player_id is None:
+                all_teams_fully_draft = False
+                break
+            if team.support_player_id is None:
+                all_teams_fully_draft = False
+                break
+        return all_teams_fully_draft

--- a/src/fantasy/util/fantasy_league_util.py
+++ b/src/fantasy/util/fantasy_league_util.py
@@ -1,10 +1,9 @@
 from typing import List
 
 from ...common.exceptions.league_not_found_exception import LeagueNotFoundException
-from ...common.schemas.fantasy_schemas import FantasyLeagueStatus
+from ...common.schemas.fantasy_schemas import FantasyLeagueStatus, FantasyLeague
 
 from ...db import crud
-from ...db.models import FantasyLeagueModel
 
 from ..exceptions.fantasy_league_not_found_exception import FantasyLeagueNotFoundException
 from ..exceptions.fantasy_league_invalid_required_state_exception import \
@@ -16,7 +15,7 @@ class FantasyLeagueUtil:
     @staticmethod
     def validate_league(
             fantasy_league_id: str,
-            required_states: List[FantasyLeagueStatus] = None) -> FantasyLeagueModel:
+            required_states: List[FantasyLeagueStatus] = None) -> FantasyLeague:
         fantasy_league_model = crud.get_fantasy_league_by_id(fantasy_league_id)
         if fantasy_league_model is None:
             raise FantasyLeagueNotFoundException()
@@ -25,7 +24,8 @@ class FantasyLeagueUtil:
             raise FantasyLeagueInvalidRequiredStateException(
                 fantasy_league_id, fantasy_league_model.status, required_states
             )
-        return fantasy_league_model
+        fantasy_league = FantasyLeague.model_validate(fantasy_league_model)
+        return fantasy_league
 
     @staticmethod
     def validate_available_leagues(selected_league_ids: List[str]):
@@ -41,7 +41,7 @@ class FantasyLeagueUtil:
                 )
 
     @staticmethod
-    def update_fantasy_leagues_current_draft_position(fantasy_league: FantasyLeagueModel):
+    def update_fantasy_leagues_current_draft_position(fantasy_league: FantasyLeague):
         if fantasy_league.current_draft_position + 1 <= fantasy_league.number_of_teams:
             new_draft_position = fantasy_league.current_draft_position + 1
         else:

--- a/tests/fantasy/unit/util/test_fantasy_team_util.py
+++ b/tests/fantasy/unit/util/test_fantasy_team_util.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from tests.test_base import FantasyLolTestBase
 from tests.test_util import fantasy_fixtures
 
-from src.db.models import FantasyLeagueDraftOrderModel
+from src.db.models import FantasyLeagueDraftOrderModel, FantasyTeamModel
 
 from src.fantasy.util.fantasty_team_util import FantasyTeamUtil
 from src.fantasy.exceptions.fantasy_draft_exception import FantasyDraftException
@@ -149,3 +149,217 @@ class TestFantasyTeamUtil(FantasyLolTestBase):
             fantasy_team_util.is_users_position_to_draft(fantasy_league, "notFoundUserId")
         self.assertIn("Could not find draft position", str(context.exception))
         mock_get_fantasy_league_draft_order.assert_called_once_with(fantasy_league.id)
+
+    @patch(f'{BASE_CRUD_PATH}.get_all_fantasy_teams_for_current_week')
+    def test_all_teams_fully_drafted_true(self, mock_get_all_fantasy_teams_for_current_week):
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_draft_fixture
+        fantasy_teams = [
+            create_fantasy_team_model(fantasy_league.id, str(user_id), fantasy_league.current_week)
+            for user_id in range(fantasy_league.number_of_teams)
+        ]
+        mock_get_all_fantasy_teams_for_current_week.return_value = fantasy_teams
+
+        # Act
+        all_teams_fully_drafted = fantasy_team_util.all_teams_fully_drafted(fantasy_league)
+
+        # Assert
+        self.assertTrue(all_teams_fully_drafted)
+        self.assertEqual(fantasy_league.number_of_teams, len(fantasy_teams))
+        mock_get_all_fantasy_teams_for_current_week.assert_called_once_with(
+            fantasy_league.id, fantasy_league.current_week
+        )
+
+    @patch(f'{BASE_CRUD_PATH}.get_all_fantasy_teams_for_current_week')
+    def test_all_teams_fully_drafted_too_few_fantasy_teams(
+            self, mock_get_all_fantasy_teams_for_current_week):
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_draft_fixture
+        fantasy_teams = [
+            create_fantasy_team_model(fantasy_league.id, str(user_id), fantasy_league.current_week)
+            for user_id in range(fantasy_league.number_of_teams - 1)
+        ]
+        mock_get_all_fantasy_teams_for_current_week.return_value = fantasy_teams
+
+        # Act
+        all_teams_fully_drafted = fantasy_team_util.all_teams_fully_drafted(fantasy_league)
+
+        # Assert
+        self.assertFalse(all_teams_fully_drafted)
+        self.assertNotEqual(fantasy_league.number_of_teams, len(fantasy_teams))
+        mock_get_all_fantasy_teams_for_current_week.assert_called_once_with(
+            fantasy_league.id, fantasy_league.current_week
+        )
+
+    @patch(f'{BASE_CRUD_PATH}.get_all_fantasy_teams_for_current_week')
+    def test_all_teams_fully_drafted_too_many_fantasy_teams(
+            self, mock_get_all_fantasy_teams_for_current_week):
+        # !!!!!!!!!  THIS SHOULD NEVER HAPPEN  !!!!!!!!!!
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_draft_fixture
+        fantasy_teams = [
+            create_fantasy_team_model(fantasy_league.id, str(user_id), fantasy_league.current_week)
+            for user_id in range(fantasy_league.number_of_teams + 1)
+        ]
+        mock_get_all_fantasy_teams_for_current_week.return_value = fantasy_teams
+
+        # Act
+        all_teams_fully_drafted = fantasy_team_util.all_teams_fully_drafted(fantasy_league)
+
+        # Assert
+        self.assertFalse(all_teams_fully_drafted)
+        self.assertNotEqual(fantasy_league.number_of_teams, len(fantasy_teams))
+        mock_get_all_fantasy_teams_for_current_week.assert_called_once_with(
+            fantasy_league.id, fantasy_league.current_week
+        )
+
+    @patch(f'{BASE_CRUD_PATH}.get_all_fantasy_teams_for_current_week')
+    def test_all_teams_fully_drafted_team_missing_top_player(
+            self, mock_get_all_fantasy_teams_for_current_week):
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_draft_fixture
+        fantasy_teams = [
+            create_fantasy_team_model(fantasy_league.id, str(user_id), fantasy_league.current_week)
+            for user_id in range(fantasy_league.number_of_teams - 1)
+        ]
+        missing_top_player_team = create_fantasy_team_model(
+            fantasy_league.id, "123", fantasy_league.current_week, set_top_player_id=False
+        )
+        fantasy_teams.append(missing_top_player_team)
+        mock_get_all_fantasy_teams_for_current_week.return_value = fantasy_teams
+
+        # Act
+        all_teams_fully_drafted = fantasy_team_util.all_teams_fully_drafted(fantasy_league)
+
+        # Assert
+        self.assertFalse(all_teams_fully_drafted)
+        self.assertEqual(fantasy_league.number_of_teams, len(fantasy_teams))
+        self.assertEqual(missing_top_player_team.top_player_id, None)
+        mock_get_all_fantasy_teams_for_current_week.assert_called_once_with(
+            fantasy_league.id, fantasy_league.current_week
+        )
+
+    @patch(f'{BASE_CRUD_PATH}.get_all_fantasy_teams_for_current_week')
+    def test_all_teams_fully_drafted_team_missing_jungle_player(
+            self, mock_get_all_fantasy_teams_for_current_week):
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_draft_fixture
+        fantasy_teams = [
+            create_fantasy_team_model(fantasy_league.id, str(user_id), fantasy_league.current_week)
+            for user_id in range(fantasy_league.number_of_teams - 1)
+        ]
+        missing_jungle_player_team = create_fantasy_team_model(
+            fantasy_league.id, "123", fantasy_league.current_week, set_jungle_player_id=False
+        )
+        fantasy_teams.append(missing_jungle_player_team)
+        mock_get_all_fantasy_teams_for_current_week.return_value = fantasy_teams
+
+        # Act
+        all_teams_fully_drafted = fantasy_team_util.all_teams_fully_drafted(fantasy_league)
+
+        # Assert
+        self.assertFalse(all_teams_fully_drafted)
+        self.assertEqual(fantasy_league.number_of_teams, len(fantasy_teams))
+        self.assertEqual(missing_jungle_player_team.jungle_player_id, None)
+        mock_get_all_fantasy_teams_for_current_week.assert_called_once_with(
+            fantasy_league.id, fantasy_league.current_week
+        )
+
+    @patch(f'{BASE_CRUD_PATH}.get_all_fantasy_teams_for_current_week')
+    def test_all_teams_fully_drafted_team_missing_mid_player(
+            self, mock_get_all_fantasy_teams_for_current_week):
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_draft_fixture
+        fantasy_teams = [
+            create_fantasy_team_model(fantasy_league.id, str(user_id), fantasy_league.current_week)
+            for user_id in range(fantasy_league.number_of_teams - 1)
+        ]
+        missing_mid_player_team = create_fantasy_team_model(
+            fantasy_league.id, "123", fantasy_league.current_week, set_mid_player_id=False
+        )
+        fantasy_teams.append(missing_mid_player_team)
+        mock_get_all_fantasy_teams_for_current_week.return_value = fantasy_teams
+
+        # Act
+        all_teams_fully_drafted = fantasy_team_util.all_teams_fully_drafted(fantasy_league)
+
+        # Assert
+        self.assertFalse(all_teams_fully_drafted)
+        self.assertEqual(fantasy_league.number_of_teams, len(fantasy_teams))
+        self.assertEqual(missing_mid_player_team.mid_player_id, None)
+        mock_get_all_fantasy_teams_for_current_week.assert_called_once_with(
+            fantasy_league.id, fantasy_league.current_week
+        )
+
+    @patch(f'{BASE_CRUD_PATH}.get_all_fantasy_teams_for_current_week')
+    def test_all_teams_fully_drafted_team_missing_adc_player(
+            self, mock_get_all_fantasy_teams_for_current_week):
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_draft_fixture
+        fantasy_teams = [
+            create_fantasy_team_model(fantasy_league.id, str(user_id), fantasy_league.current_week)
+            for user_id in range(fantasy_league.number_of_teams - 1)
+        ]
+        missing_adc_player_team = create_fantasy_team_model(
+            fantasy_league.id, "123", fantasy_league.current_week, set_adc_player_id=False
+        )
+        fantasy_teams.append(missing_adc_player_team)
+        mock_get_all_fantasy_teams_for_current_week.return_value = fantasy_teams
+
+        # Act
+        all_teams_fully_drafted = fantasy_team_util.all_teams_fully_drafted(fantasy_league)
+
+        # Assert
+        self.assertFalse(all_teams_fully_drafted)
+        self.assertEqual(fantasy_league.number_of_teams, len(fantasy_teams))
+        self.assertEqual(missing_adc_player_team.adc_player_id, None)
+        mock_get_all_fantasy_teams_for_current_week.assert_called_once_with(
+            fantasy_league.id, fantasy_league.current_week
+        )
+
+    @patch(f'{BASE_CRUD_PATH}.get_all_fantasy_teams_for_current_week')
+    def test_all_teams_fully_drafted_team_missing_support_player(
+            self, mock_get_all_fantasy_teams_for_current_week):
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_draft_fixture
+        fantasy_teams = [
+            create_fantasy_team_model(fantasy_league.id, str(user_id), fantasy_league.current_week)
+            for user_id in range(fantasy_league.number_of_teams - 1)
+        ]
+        missing_support_player_team = create_fantasy_team_model(
+            fantasy_league.id, "123", fantasy_league.current_week, set_support_player_id=False
+        )
+        fantasy_teams.append(missing_support_player_team)
+        mock_get_all_fantasy_teams_for_current_week.return_value = fantasy_teams
+
+        # Act
+        all_teams_fully_drafted = fantasy_team_util.all_teams_fully_drafted(fantasy_league)
+
+        # Assert
+        self.assertFalse(all_teams_fully_drafted)
+        self.assertEqual(fantasy_league.number_of_teams, len(fantasy_teams))
+        self.assertEqual(missing_support_player_team.support_player_id, None)
+        mock_get_all_fantasy_teams_for_current_week.assert_called_once_with(
+            fantasy_league.id, fantasy_league.current_week
+        )
+
+
+def create_fantasy_team_model(
+        fantasy_league_id: str,
+        user_id: str,
+        week: int,
+        set_top_player_id: bool = True,
+        set_jungle_player_id: bool = True,
+        set_mid_player_id: bool = True,
+        set_adc_player_id: bool = True,
+        set_support_player_id: bool = True) -> FantasyTeamModel:
+    return FantasyTeamModel(
+        fantasy_league_id=fantasy_league_id,
+        user_id=user_id,
+        week=week,
+        top_player_id=f"topId{user_id}" if set_top_player_id else None,
+        jungle_player_id=f"jungleId{user_id}" if set_jungle_player_id else None,
+        mid_player_id=f"midId{user_id}" if set_mid_player_id else None,
+        adc_player_id=f"adcId{user_id}" if set_adc_player_id else None,
+        support_player_id=f"supportId{user_id}" if set_support_player_id else None,
+    )

--- a/tests/test_util/fantasy_fixtures.py
+++ b/tests/test_util/fantasy_fixtures.py
@@ -1,5 +1,6 @@
 import uuid
 import bcrypt
+from random import randint
 
 from src.common.schemas import fantasy_schemas
 
@@ -36,6 +37,13 @@ user_3_fixture = fantasy_schemas.User(
     id=str(uuid.uuid4()),
     username="user3",
     email="user3@email.com",
+    password=user_hashed_password
+)
+
+user_4_fixture = fantasy_schemas.User(
+    id=str(uuid.uuid4()),
+    username="user4",
+    email="user4@email.com",
     password=user_hashed_password
 )
 
@@ -86,6 +94,17 @@ fantasy_league_scoring_settings_fixture = fantasy_schemas.FantasyLeagueScoringSe
     wards_destroyed=0.2,
     kill_participation=15,
     damage_percentage=8
+)
+
+fantasy_team_full = fantasy_schemas.FantasyTeam(
+    fantasy_league_id=fantasy_league_active_fixture.id,
+    user_id=user_fixture.id,
+    week=1,
+    top_player_id=str(randint(10000, 99999)),
+    jungle_player_id=str(randint(10000, 99999)),
+    mid_player_id=str(randint(10000, 99999)),
+    adc_player_id=str(randint(10000, 99999)),
+    support_player_id=str(randint(10000, 99999))
 )
 
 fantasy_team_week_1 = fantasy_schemas.FantasyTeam(


### PR DESCRIPTION
- When all fantasy leagues are fully drafted, the fantasy league is automatically moved to `ACTIVE` status
- Fantasy League Uitl returns the FantasyLeague data model instead of the FantasyLeagueModel which is used by the database.
   - This to me is more proper, returning and using the application data class within the application logic instead of the class used by the database class.

resolves #270 