### PR TITLE
Moved some methods to fantasy league util from service

### DIFF
--- a/src/fantasy/util/fantasy_league_util.py
+++ b/src/fantasy/util/fantasy_league_util.py
@@ -3,8 +3,11 @@ from typing import List, Optional
 from ...common.exceptions.league_not_found_exception import LeagueNotFoundException
 from ...common.schemas.fantasy_schemas import (
     FantasyLeague,
+    FantasyLeagueDraftOrder,
+    FantasyLeagueDraftOrderResponse,
     FantasyLeagueID,
-    FantasyLeagueStatus
+    FantasyLeagueStatus,
+    UserID
 )
 from ...common.schemas.riot_data_schemas import RiotLeagueID
 
@@ -14,6 +17,7 @@ from ..exceptions.fantasy_league_not_found_exception import FantasyLeagueNotFoun
 from ..exceptions.fantasy_league_invalid_required_state_exception import \
     FantasyLeagueInvalidRequiredStateException
 from ..exceptions.fantasy_unavailable_exception import FantasyUnavailableException
+from ..exceptions.draft_order_exception import DraftOrderException
 
 
 class FantasyLeagueUtil:
@@ -51,3 +55,69 @@ class FantasyLeagueUtil:
         else:
             new_draft_position = 1
         crud.update_fantasy_league_current_draft_position(fantasy_league.id, new_draft_position)
+
+    @staticmethod
+    def create_draft_order_entry(user_id: UserID, league_id: FantasyLeagueID) -> None:
+        fantasy_league = crud.get_fantasy_league_by_id(league_id)
+        if fantasy_league is None:
+            raise FantasyLeagueNotFoundException()
+
+        current_draft_order = crud.get_fantasy_league_draft_order(league_id)
+        if len(current_draft_order) == 0:
+            max_position = 0
+        else:
+            max_position = max(
+                current_draft_order, key=lambda draft_position: draft_position.position
+            ).position
+
+        new_draft_position = FantasyLeagueDraftOrder(
+            fantasy_league_id=league_id,
+            user_id=user_id,
+            position=max_position + 1
+        )
+        crud.create_fantasy_league_draft_order(new_draft_position)
+
+    @staticmethod
+    def validate_draft_order(
+            current_draft_order: List[FantasyLeagueDraftOrder],
+            updated_draft_order: List[FantasyLeagueDraftOrderResponse]) -> None:
+        member_ids = [draft_position.user_id for draft_position in current_draft_order]
+
+        if len(updated_draft_order) != len(current_draft_order):
+            raise DraftOrderException(
+                "Draft order contains more or less players than current draft"
+            )
+
+        for draft_order in updated_draft_order:
+            if draft_order.user_id not in member_ids:
+                raise DraftOrderException(f"User {draft_order.user_id} is not in current draft")
+
+        positions = [draft_position.position for draft_position in updated_draft_order]
+        positions.sort()
+        expected_positions = list(range(1, len(current_draft_order) + 1))
+        if positions != expected_positions:
+            raise DraftOrderException(
+                "The positions given in the updated draft order are not valid"
+            )
+
+    @staticmethod
+    def update_draft_order_on_player_leave(user_id: UserID, league_id: FantasyLeagueID) -> None:
+        current_draft_order = crud.get_fantasy_league_draft_order(league_id)
+
+        draft_position_to_delete: Optional[FantasyLeagueDraftOrder] = None
+        for draft_position in current_draft_order:
+            if draft_position.user_id == user_id:
+                draft_position_to_delete = draft_position
+                break
+        if draft_position_to_delete is None:
+            raise DraftOrderException(
+                f"Missing user on draft removal: User with ID {user_id} does not have a draft "
+                f"position in fantasy league with ID {league_id}"
+            )
+
+        crud.delete_fantasy_league_draft_order(draft_position_to_delete)
+        for draft_position in current_draft_order:
+            if draft_position.position > draft_position_to_delete.position:
+                crud.update_fantasy_league_draft_order_position(
+                    draft_position, draft_position.position - 1
+                )

--- a/tests/fantasy/unit/util/test_fantasy_league_util.py
+++ b/tests/fantasy/unit/util/test_fantasy_league_util.py
@@ -1,17 +1,22 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 from tests.test_base import FantasyLolTestBase
 from tests.test_util import fantasy_fixtures
 from tests.test_util import riot_fixtures
 
 from src.common.schemas.fantasy_schemas import (
+    FantasyLeague,
+    FantasyLeagueDraftOrder,
+    FantasyLeagueDraftOrderResponse,
     FantasyLeagueStatus,
-    FantasyLeague
+    FantasyLeagueID
 )
+from src.common.schemas.riot_data_schemas import RiotLeagueID
 from src.common.exceptions.league_not_found_exception import LeagueNotFoundException
 
 from src.fantasy.exceptions.fantasy_league_not_found_exception import \
     FantasyLeagueNotFoundException
+from src.fantasy.exceptions.draft_order_exception import DraftOrderException
 from src.fantasy.exceptions.fantasy_league_invalid_required_state_exception import \
     FantasyLeagueInvalidRequiredStateException
 from src.fantasy.exceptions.fantasy_unavailable_exception import FantasyUnavailableException
@@ -48,7 +53,9 @@ class TestFantasyLeagueUtil(FantasyLolTestBase):
 
         # Act and Assert
         with self.assertRaises(FantasyLeagueNotFoundException):
-            fantasy_league_util.validate_league("someId", [FantasyLeagueStatus.DRAFT])
+            fantasy_league_util.validate_league(
+                FantasyLeagueID("someId"), [FantasyLeagueStatus.DRAFT]
+            )
 
     @patch(f'{BASE_CRUD_PATH}.get_fantasy_league_by_id')
     def test_validate_league_not_in_required_state(self, mock_get_fantasy_league_by_id: MagicMock):
@@ -95,7 +102,7 @@ class TestFantasyLeagueUtil(FantasyLolTestBase):
         # Arrange
         riot_leagues = [riot_fixtures.league_1_fixture, riot_fixtures.league_2_fixture]
         mock_get_leagues.return_value = riot_leagues
-        selected_league_ids = ["badId"]
+        selected_league_ids = [RiotLeagueID("badId")]
 
         # Act and Assert
         with self.assertRaises(LeagueNotFoundException) as context:
@@ -174,3 +181,478 @@ class TestFantasyLeagueUtil(FantasyLolTestBase):
         mock_update_fantasy_league_current_draft_position.assert_called_once_with(
             fantasy_league.id, expected_new_draft_position
         )
+
+    @patch(f'{BASE_CRUD_PATH}.create_fantasy_league_draft_order')
+    @patch(f'{BASE_CRUD_PATH}.get_fantasy_league_draft_order')
+    @patch(f'{BASE_CRUD_PATH}.get_fantasy_league_by_id')
+    def test_create_draft_order_entry_first_draft_order_for_fantasy_league(
+            self,
+            mock_get_fantasy_league_by_id: MagicMock,
+            mock_get_fantasy_league_draft_order: MagicMock,
+            mock_create_fantasy_league_draft_order: MagicMock
+    ):
+        # Arrange
+        user = fantasy_fixtures.user_fixture
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        mock_get_fantasy_league_by_id.return_value = fantasy_league
+        mock_get_fantasy_league_draft_order.return_value = []
+        expected_draft_order_entry = FantasyLeagueDraftOrder(
+            fantasy_league_id=fantasy_league.id, user_id=user.id, position=1
+        )
+
+        # Act
+        fantasy_league_util.create_draft_order_entry(user.id, fantasy_league.id)
+
+        # Assert
+        mock_get_fantasy_league_by_id.assert_called_once_with(fantasy_league.id)
+        mock_get_fantasy_league_draft_order.assert_called_once_with(fantasy_league.id)
+        mock_create_fantasy_league_draft_order.assert_called_once_with(expected_draft_order_entry)
+
+    @patch(f'{BASE_CRUD_PATH}.create_fantasy_league_draft_order')
+    @patch(f'{BASE_CRUD_PATH}.get_fantasy_league_draft_order')
+    @patch(f'{BASE_CRUD_PATH}.get_fantasy_league_by_id')
+    def test_create_draft_order_entry_with_an_existing_draft_entry(
+            self,
+            mock_get_fantasy_league_by_id: MagicMock,
+            mock_get_fantasy_league_draft_order: MagicMock,
+            mock_create_fantasy_league_draft_order: MagicMock
+    ):
+        # Arrange
+        user = fantasy_fixtures.user_fixture
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        mock_get_fantasy_league_by_id.return_value = fantasy_league
+        mock_get_fantasy_league_draft_order.return_value = [
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id="someOtherId", position=1
+            )
+        ]
+        expected_draft_order_entry = FantasyLeagueDraftOrder(
+            fantasy_league_id=fantasy_league.id, user_id=user.id, position=2
+        )
+
+        # Act
+        fantasy_league_util.create_draft_order_entry(user.id, fantasy_league.id)
+
+        # Assert
+        mock_get_fantasy_league_by_id.assert_called_once_with(fantasy_league.id)
+        mock_get_fantasy_league_draft_order.assert_called_once_with(fantasy_league.id)
+        mock_create_fantasy_league_draft_order.assert_called_once_with(expected_draft_order_entry)
+
+    @patch(f'{BASE_CRUD_PATH}.create_fantasy_league_draft_order')
+    @patch(f'{BASE_CRUD_PATH}.get_fantasy_league_draft_order')
+    @patch(f'{BASE_CRUD_PATH}.get_fantasy_league_by_id')
+    def test_create_draft_order_entry_fantasy_league_not_found_exception(
+            self,
+            mock_get_fantasy_league_by_id: MagicMock,
+            mock_get_fantasy_league_draft_order: MagicMock,
+            mock_create_fantasy_league_draft_order: MagicMock
+    ):
+        # Arrange
+        user = fantasy_fixtures.user_fixture
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        mock_get_fantasy_league_by_id.return_value = None
+
+        # Act and Assert
+        with self.assertRaises(FantasyLeagueNotFoundException):
+            fantasy_league_util.create_draft_order_entry(user.id, fantasy_league.id)
+            mock_get_fantasy_league_by_id.assert_called_once_with(fantasy_league.id)
+            mock_get_fantasy_league_draft_order.assert_not_called()
+            mock_create_fantasy_league_draft_order.assert_not_called()
+
+    def test_validate_draft_order_no_changes_successful(self):
+        # Arrange
+        user_1 = fantasy_fixtures.user_fixture
+        user_2 = fantasy_fixtures.user_2_fixture
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        current_draft_order = [
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_1.id, position=1
+            ),
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
+            )
+        ]
+        updated_draft_order = [
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_1.id, username=user_1.username, position=1
+            ),
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_2.id, username=user_2.username, position=2
+            ),
+        ]
+
+        # Act and Assert
+        try:
+            fantasy_league_util.validate_draft_order(current_draft_order, updated_draft_order)
+        except Exception:
+            self.fail("Validate draft order got an unexpected exception")
+        self.assertTrue(len(current_draft_order) == len(updated_draft_order))
+        for i in range(len(current_draft_order)):
+            self.assertEqual(current_draft_order[i].user_id, updated_draft_order[i].user_id)
+            self.assertEqual(current_draft_order[i].position, updated_draft_order[i].position)
+
+    def test_validate_draft_order_swapped_positions_successful(self):
+        # Arrange
+        user_1 = fantasy_fixtures.user_fixture
+        user_2 = fantasy_fixtures.user_2_fixture
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        current_draft_order = [
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_1.id, position=1
+            ),
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
+            )
+        ]
+        updated_draft_order = [
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_1.id, username=user_1.username, position=2
+            ),
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_2.id, username=user_2.username, position=1
+            ),
+        ]
+
+        # Act and Assert
+        try:
+            fantasy_league_util.validate_draft_order(current_draft_order, updated_draft_order)
+        except Exception:
+            self.fail("Validate draft order got an unexpected exception")
+        self.assertTrue(len(current_draft_order) == len(updated_draft_order))
+        for i in range(len(current_draft_order)):
+            self.assertEqual(current_draft_order[i].user_id, updated_draft_order[i].user_id)
+            self.assertNotEqual(current_draft_order[i].position, updated_draft_order[i].position)
+
+    def test_validate_draft_order_too_few_entries_for_updated_draft_order_exception(self):
+        # Arrange
+        user_1 = fantasy_fixtures.user_fixture
+        user_2 = fantasy_fixtures.user_2_fixture
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        current_draft_order = [
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_1.id, position=1
+            ),
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
+            )
+        ]
+        updated_draft_order = [
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_1.id, username=user_1.username, position=1
+            )
+        ]
+
+        # Act and Assert
+        with self.assertRaises(DraftOrderException) as context:
+            fantasy_league_util.validate_draft_order(current_draft_order, updated_draft_order)
+        self.assertIn("Draft order contains more or less", str(context.exception))
+        self.assertTrue(len(updated_draft_order) < len(current_draft_order))
+
+    def test_validate_draft_order_too_many_entries_for_updated_draft_order_exception(self):
+        # Arrange
+        user_1 = fantasy_fixtures.user_fixture
+        user_2 = fantasy_fixtures.user_2_fixture
+        user_3 = fantasy_fixtures.user_3_fixture
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        current_draft_order = [
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_1.id, position=1
+            ),
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
+            )
+        ]
+        updated_draft_order = [
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_1.id, username=user_1.username, position=1
+            ),
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_2.id, username=user_2.username, position=2
+            ),
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_3.id, username=user_3.username, position=3
+            )
+        ]
+
+        # Act and Assert
+        with self.assertRaises(DraftOrderException) as context:
+            fantasy_league_util.validate_draft_order(current_draft_order, updated_draft_order)
+        self.assertIn("Draft order contains more or less", str(context.exception))
+        self.assertTrue(len(updated_draft_order) > len(current_draft_order))
+
+    def test_validate_draft_order_user_not_in_the_current_draft_exception(self):
+        # Arrange
+        user_1 = fantasy_fixtures.user_fixture
+        user_2 = fantasy_fixtures.user_2_fixture
+        user_3 = fantasy_fixtures.user_3_fixture
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        current_draft_order = [
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_1.id, position=1
+            ),
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
+            )
+        ]
+        updated_draft_order = [
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_1.id, username=user_1.username, position=1
+            ),
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_3.id, username=user_3.username, position=2
+            )
+        ]
+
+        # Act and Assert
+        with self.assertRaises(DraftOrderException) as context:
+            fantasy_league_util.validate_draft_order(current_draft_order, updated_draft_order)
+        self.assertIn(f"User {user_3.id} is not in current draft", str(context.exception))
+
+    def test_validate_draft_order_invalid_positions_same_numbers_exception(self):
+        # Arrange
+        user_1 = fantasy_fixtures.user_fixture
+        user_2 = fantasy_fixtures.user_2_fixture
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        current_draft_order = [
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_1.id, position=1
+            ),
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
+            )
+        ]
+        updated_draft_order = [
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_1.id, username=user_1.username, position=1
+            ),
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_2.id, username=user_2.username, position=1
+            )
+        ]
+
+        # Act and Assert
+        with self.assertRaises(DraftOrderException) as context:
+            fantasy_league_util.validate_draft_order(current_draft_order, updated_draft_order)
+        self.assertIn(
+            "The positions given in the updated draft order are not valid",
+            str(context.exception)
+        )
+
+    def test_validate_draft_order_invalid_positions_negatives_of_positions_exception(self):
+        # Arrange
+        user_1 = fantasy_fixtures.user_fixture
+        user_2 = fantasy_fixtures.user_2_fixture
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        current_draft_order = [
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_1.id, position=1
+            ),
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
+            )
+        ]
+        updated_draft_order = [
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_1.id, username=user_1.username, position=-1
+            ),
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_2.id, username=user_2.username, position=-2
+            )
+        ]
+
+        # Act and Assert
+        with self.assertRaises(DraftOrderException) as context:
+            fantasy_league_util.validate_draft_order(current_draft_order, updated_draft_order)
+        self.assertIn(
+            "The positions given in the updated draft order are not valid",
+            str(context.exception)
+        )
+
+    def test_validate_draft_order_invalid_positions_gap_between_positions_exception(self):
+        # Arrange
+        user_1 = fantasy_fixtures.user_fixture
+        user_2 = fantasy_fixtures.user_2_fixture
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        current_draft_order = [
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_1.id, position=1
+            ),
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
+            )
+        ]
+        updated_draft_order = [
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_1.id, username=user_1.username, position=1
+            ),
+            FantasyLeagueDraftOrderResponse(
+                user_id=user_2.id, username=user_2.username, position=3
+            )
+        ]
+
+        # Act and Assert
+        with self.assertRaises(DraftOrderException) as context:
+            fantasy_league_util.validate_draft_order(current_draft_order, updated_draft_order)
+        self.assertIn(
+            "The positions given in the updated draft order are not valid",
+            str(context.exception)
+        )
+
+    @patch(f'{BASE_CRUD_PATH}.update_fantasy_league_draft_order_position')
+    @patch(f'{BASE_CRUD_PATH}.delete_fantasy_league_draft_order')
+    @patch(f'{BASE_CRUD_PATH}.get_fantasy_league_draft_order')
+    def test_update_draft_order_on_player_leave_middle_position_successful(
+            self,
+            mock_get_fantasy_league_draft_order: MagicMock,
+            mock_delete_fantasy_league_draft_order: MagicMock,
+            mock_update_fantasy_league_draft_order_position: MagicMock
+    ):
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        user_1 = fantasy_fixtures.user_fixture
+        user_2 = fantasy_fixtures.user_2_fixture
+        user_3 = fantasy_fixtures.user_3_fixture
+        expected_position_to_delete = FantasyLeagueDraftOrder(
+            fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
+        )
+        user_id_to_remove = expected_position_to_delete.user_id
+        current_draft_order = [
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_1.id, position=1
+            ),
+            expected_position_to_delete,
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_3.id, position=3
+            )
+        ]
+        mock_get_fantasy_league_draft_order.return_value = current_draft_order
+
+        # Act and Assert
+        try:
+            fantasy_league_util.update_draft_order_on_player_leave(
+                user_id_to_remove, fantasy_league.id
+            )
+        except DraftOrderException:
+            self.fail("Update draft order on player leave failed with an unexpected exception")
+        mock_get_fantasy_league_draft_order.assert_called_once_with(fantasy_league.id)
+        mock_delete_fantasy_league_draft_order.assert_called_once_with(expected_position_to_delete)
+        mock_update_fantasy_league_draft_order_position.assert_called_once_with(
+            current_draft_order[2], 2
+        )
+
+    @patch(f'{BASE_CRUD_PATH}.update_fantasy_league_draft_order_position')
+    @patch(f'{BASE_CRUD_PATH}.delete_fantasy_league_draft_order')
+    @patch(f'{BASE_CRUD_PATH}.get_fantasy_league_draft_order')
+    def test_update_draft_order_on_player_leave_first_position_successful(
+            self,
+            mock_get_fantasy_league_draft_order: MagicMock,
+            mock_delete_fantasy_league_draft_order: MagicMock,
+            mock_update_fantasy_league_draft_order_position: MagicMock
+    ):
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        user_1 = fantasy_fixtures.user_fixture
+        user_2 = fantasy_fixtures.user_2_fixture
+        user_3 = fantasy_fixtures.user_3_fixture
+        expected_position_to_delete = FantasyLeagueDraftOrder(
+            fantasy_league_id=fantasy_league.id, user_id=user_1.id, position=1
+        )
+        user_id_to_remove = expected_position_to_delete.user_id
+        current_draft_order = [
+            expected_position_to_delete,
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
+            ),
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_3.id, position=3
+            )
+        ]
+        mock_get_fantasy_league_draft_order.return_value = current_draft_order
+
+        # Act and Assert
+        try:
+            fantasy_league_util.update_draft_order_on_player_leave(
+                user_id_to_remove, fantasy_league.id
+            )
+        except DraftOrderException:
+            self.fail("Update draft order on player leave failed with an unexpected exception")
+        mock_get_fantasy_league_draft_order.assert_called_once_with(fantasy_league.id)
+        mock_delete_fantasy_league_draft_order.assert_called_once_with(expected_position_to_delete)
+        expected_calls = [
+            call.update_fantasy_league_draft_order_position(current_draft_order[1], 1),
+            call.update_fantasy_league_draft_order_position(current_draft_order[2], 2)
+        ]
+        mock_update_fantasy_league_draft_order_position.assert_has_calls(expected_calls)
+        self.assertEqual(mock_update_fantasy_league_draft_order_position.call_count, 2)
+
+    @patch(f'{BASE_CRUD_PATH}.update_fantasy_league_draft_order_position')
+    @patch(f'{BASE_CRUD_PATH}.delete_fantasy_league_draft_order')
+    @patch(f'{BASE_CRUD_PATH}.get_fantasy_league_draft_order')
+    def test_update_draft_order_on_player_leave_last_position_successful(
+            self,
+            mock_get_fantasy_league_draft_order: MagicMock,
+            mock_delete_fantasy_league_draft_order: MagicMock,
+            mock_update_fantasy_league_draft_order_position: MagicMock
+    ):
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        user_1 = fantasy_fixtures.user_fixture
+        user_2 = fantasy_fixtures.user_2_fixture
+        user_3 = fantasy_fixtures.user_3_fixture
+        expected_position_to_delete = FantasyLeagueDraftOrder(
+            fantasy_league_id=fantasy_league.id, user_id=user_3.id, position=3
+        )
+        user_id_to_remove = expected_position_to_delete.user_id
+        current_draft_order = [
+            expected_position_to_delete,
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_1.id, position=1
+            ),
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
+            )
+        ]
+        mock_get_fantasy_league_draft_order.return_value = current_draft_order
+
+        # Act and Assert
+        try:
+            fantasy_league_util.update_draft_order_on_player_leave(
+                user_id_to_remove, fantasy_league.id
+            )
+        except DraftOrderException:
+            self.fail("Update draft order on player leave failed with an unexpected exception")
+        mock_get_fantasy_league_draft_order.assert_called_once_with(fantasy_league.id)
+        mock_delete_fantasy_league_draft_order.assert_called_once_with(expected_position_to_delete)
+        mock_update_fantasy_league_draft_order_position.assert_not_called()
+
+    @patch(f'{BASE_CRUD_PATH}.update_fantasy_league_draft_order_position')
+    @patch(f'{BASE_CRUD_PATH}.delete_fantasy_league_draft_order')
+    @patch(f'{BASE_CRUD_PATH}.get_fantasy_league_draft_order')
+    def test_update_draft_order_on_player_leave_user_has_no_draft_position_exception(
+            self,
+            mock_get_fantasy_league_draft_order: MagicMock,
+            mock_delete_fantasy_league_draft_order: MagicMock,
+            mock_update_fantasy_league_draft_order_position: MagicMock
+    ):
+        # Arrange
+        fantasy_league = fantasy_fixtures.fantasy_league_fixture
+        user_1 = fantasy_fixtures.user_fixture
+        user_2 = fantasy_fixtures.user_2_fixture
+        user_3 = fantasy_fixtures.user_3_fixture
+        current_draft_order = [
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_1.id, position=1
+            ),
+            FantasyLeagueDraftOrder(
+                fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
+            )
+        ]
+        mock_get_fantasy_league_draft_order.return_value = current_draft_order
+
+        # Act and Assert
+        with self.assertRaises(DraftOrderException) as context:
+            fantasy_league_util.update_draft_order_on_player_leave(user_3.id, fantasy_league.id)
+        self.assertIn("Missing user on draft removal", str(context.exception))
+        mock_get_fantasy_league_draft_order.assert_called_once_with(fantasy_league.id)
+        mock_delete_fantasy_league_draft_order.assert_not_called()
+        mock_update_fantasy_league_draft_order_position.assert_not_called()


### PR DESCRIPTION
Moved the following methods to the Fantasy League Util out of the Fantasy League Service and added unit tests that were missing for these methods:
- validate_draft_order
- update-draft_order_on_player_leave
- create_draft_order_entry

resolves #283