### PR TITLE
Fixed an issue with getting schedule

### DIFF
--- a/src/riot/service/riot_match_service.py
+++ b/src/riot/service/riot_match_service.py
@@ -71,10 +71,14 @@ class RiotMatchService:
                 self.db.put_match(match)
 
             schedule_pages = self.riot_api_requester.get_pages_from_schedule()
+            if schedule_pages.current_token_key is not None:
+                riot_curr_token = schedule_pages.current_token_key
+            else:
+                riot_curr_token = schedule_pages.older_token_key
             riot_schedule = Schedule(
                 schedule_name="riot_schedule",
                 older_token_key=None,
-                current_token_key=schedule_pages.current_token_key
+                current_token_key=riot_curr_token
             )
 
             # Used as a save point if we encounter an error during back prop

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -7,12 +7,6 @@ from sqlalchemy import MetaData
 os.environ['AUTH_SECRET'] = "1234567890"
 os.environ['AUTH_ALGORITHM'] = "HS256"
 
-from tests.test_util.db_util import TestDatabaseService
-from src.db import models  # type: ignore
-from src.db.database_connection_provider import DatabaseConnectionProvider
-from src.db.database_service import DatabaseService
-
-
 # Email Verification Config Settings:
 os.environ['VERIFICATION_DOMAIN_URL'] = "http://localhost"
 os.environ['VERIFICATION_SENDER_EMAIL'] = "testEmail@gmail.com"
@@ -20,6 +14,10 @@ os.environ['VERIFICATION_SENDER_PASSWORD'] = "testpassword"
 os.environ['VERIFICATION_SMTP_HOST'] = "smtp.gmail.com"
 os.environ['VERIFICATION_SMTP_PORT'] = "465"
 
+from tests.test_util.db_util import TestDatabaseService
+from src.db import models  # type: ignore
+from src.db.database_connection_provider import DatabaseConnectionProvider
+from src.db.database_service import DatabaseService
 
 RIOT_API_REQUESTER_CLOUDSCRAPER_PATH = \
     'src.riot.util.riot_api_requester.cloudscraper.create_scraper'
@@ -30,6 +28,7 @@ TEST_DATABASE_URL = 'sqlite:///:memory:'
 
 
 class TestBase(unittest.TestCase):
+
     db_provider: DatabaseConnectionProvider
     db: DatabaseService
     test_db: TestDatabaseService


### PR DESCRIPTION
When getting schedule, it assumed that there was going to be a next page when getting the default schedule. This is no longer true. Now, when getting the default schedule, it will sent the current as the last, then when we go and get the schedule from the current, we will get the token of the default schedule and set it as the default.