### PR TITLE
Get the current week for a riot league

### DIFF
--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -115,6 +115,10 @@ class DatabaseService:
         with self.connection_provider.get_db() as db:
             match_dao.update_match_has_games(db, match_id, new_has_games)
 
+    def get_matches_for_league_with_active_tournament(self, league_id: RiotLeagueID) -> list[Match]:
+        with self.connection_provider.get_db() as db:
+            return match_dao.get_matches_for_league_with_active_tournament(db, league_id)
+
     def put_player(self, player: ProfessionalPlayer) -> None:
         with self.connection_provider.get_db() as db:
             player_dao.put_player(db, player)


### PR DESCRIPTION
- Gets all active tournaments and matches within those active tournaments for a given riot league ID
- Sifts through those matches start time compared to current date and time to determine current week
- If no current week can be determined, the method returns None

resolves #327