### PR TITLE
Replace custom AppConfig with pydantic-settings BaseSettings

### DIFF
--- a/.idea/runConfigurations/Riot_App.xml
+++ b/.idea/runConfigurations/Riot_App.xml
@@ -22,7 +22,7 @@
         <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
       </ENTRIES>
     </EXTENSION>
-    <option name="SCRIPT_NAME" value="D:\dev\FantasyLoL\src\riot\app.py" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/src/riot/app.py" />
     <option name="PARAMETERS" value="" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -1,69 +1,61 @@
-import os
-import json
-import sys
-from dotenv import load_dotenv
-from typing import get_type_hints
-
-from .exceptions import AppConfigException
-
-load_dotenv()
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class AppConfig:
-    # Configure config default values
+class ScheduleConfig(BaseModel):
+    trigger: str
+    day: str | None = None
+    week: str | None = None
+    hour: str | None = None
+    minute: str | None = None
+    second: str | None = None
+    # interval fields
+    weeks: int = 0
+    days: int = 0
+    hours: int = 0
+    minutes: int = 0
+    seconds: int = 0
+
+
+class AppConfig(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    # Database
     DATABASE_URL: str = "postgresql://postgres:postgres@localhost:5432/fantasy_lol"
     DEBUG_LOGGING: bool = False
-    TESTS_RUNNING = 'test*.py' in sys.argv
 
     # Auth
     AUTH_SECRET: str
-    AUTH_ALGORITHM: str
+    AUTH_ALGORITHM: str = "HS256"
 
-    # Api Requester:
-    RIOT_API_KEY: str = "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"  # This is a public key
+    # Riot API
+    RIOT_API_KEY: str = "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"
     ESPORTS_API_URL: str = "https://esports-api.lolesports.com/persisted/gw"
     ESPORTS_FEED_URL: str = "https://feed.lolesports.com/livestats/v1"
 
-    # Job schedules:
-    LEAGUE_SERVICE_SCHEDULE: dict = \
-        '{"trigger": "cron", "hour": "10", "minute": "00"}'  # type: ignore
-    TOURNAMENT_SERVICE_SCHEDULE: dict = \
-        '{"trigger": "cron", "hour": "10", "minute": "05"}'  # type: ignore
-    TEAM_SERVICE_SCHEDULE: dict = \
-        '{"trigger": "cron", "hour": "10", "minute": "10"}'  # type: ignore
-    MATCH_SERVICE_SCHEDULE: dict = \
-        '{"trigger": "cron", "minute": "30"}'  # type: ignore
-    GAME_SERVICE_SCHEDULE: dict = \
-        '{"trigger": "cron", "minute": "45"}'  # type: ignore
-    GAME_STATS_SERVICE_SCHEDULE: dict = \
-        '{"trigger": "cron", "minute": "*/5"}'  # type: ignore
-
-    def __init__(self, env):
-        for field in self.__annotations__:
-            if not field.isupper():
-                continue
-
-            default_value = getattr(self, field, None)
-            if default_value is None and env.get(field) is None:
-                raise AppConfigException(f"The {field} field is required")
-
-            try:
-                var_type = get_type_hints(AppConfig)[field]
-                if var_type == dict:
-                    value = json.loads(env.get(field, default_value))
-                else:
-                    value = var_type(env.get(field, default_value))
-
-                self.__setattr__(field, value)
-            except ValueError:
-                raise AppConfigException(
-                    'Unable to cast value of "{}" to type "{}" for "{}" field'.format(
-                        env[field], var_type, field
-                    )
-                )
-
-    def __repr__(self):
-        return str(self.__dict__)
+    # Job schedules
+    LEAGUE_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(
+        trigger="cron", hour="10", minute="00"
+    )
+    TOURNAMENT_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(
+        trigger="cron", hour="10", minute="05"
+    )
+    TEAM_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(
+        trigger="cron", hour="10", minute="10"
+    )
+    MATCH_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(
+        trigger="cron", minute="30"
+    )
+    GAME_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(
+        trigger="cron", minute="45"
+    )
+    GAME_STATS_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(
+        trigger="cron", minute="*/5"
+    )
 
 
-app_config = AppConfig(os.environ)
+app_config = AppConfig()  # type: ignore[call-arg]

--- a/src/common/exceptions/AppConfigException.py
+++ b/src/common/exceptions/AppConfigException.py
@@ -1,2 +1,0 @@
-class AppConfigException(Exception):
-    pass

--- a/src/common/exceptions/__init__.py
+++ b/src/common/exceptions/__init__.py
@@ -1,4 +1,3 @@
-from .AppConfigException import AppConfigException  # noqa: F401
 from .fantasy_lol_exception import FantasyLolException  # noqa: F401
 from .league_not_found_exception import LeagueNotFoundException  # noqa: F401
 from .professional_player_not_found_exception import \

--- a/src/common/logger.py
+++ b/src/common/logger.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from logging.handlers import RotatingFileHandler
 
-from .config import app_config  # type: ignore
+from .config import app_config
 
 
 def configure_logger(logger_name: str):

--- a/src/riot_scraper/job_scheduler.py
+++ b/src/riot_scraper/job_scheduler.py
@@ -7,6 +7,7 @@ from apscheduler.triggers.cron import CronTrigger  # type: ignore
 from apscheduler.triggers.interval import IntervalTrigger  # type: ignore
 
 from src.common import app_config
+from src.common.config import ScheduleConfig
 from src.riot.exceptions import JobConfigException
 
 logger = logging.getLogger('scraper')
@@ -103,28 +104,28 @@ class JobScheduler:
             job_id='player_stats_job'
         )
 
-    def schedule_job(self, job_function, job_config: dict, job_id: str, replace: bool = True):
-        trigger = job_config.get('trigger', None)
-
-        if trigger == 'cron':
+    def schedule_job(self, job_function, job_config: ScheduleConfig,
+                     job_id: str, replace: bool = True):
+        if job_config.trigger == 'cron':
             job_trigger = CronTrigger(
-                day=job_config.get('day', None),
-                week=job_config.get('week', None),
-                hour=job_config.get('hour', None),
-                minute=job_config.get('minute', None),
-                second=job_config.get('second', None),
+                day=job_config.day,
+                week=job_config.week,
+                hour=job_config.hour,
+                minute=job_config.minute,
+                second=job_config.second,
             )
-        elif trigger == 'interval':
+        elif job_config.trigger == 'interval':
             job_trigger = IntervalTrigger(
-                weeks=job_config.get('weeks', 0),
-                days=job_config.get('days', 0),
-                hours=job_config.get('hours', 0),
-                minutes=job_config.get('minutes', 0),
-                seconds=job_config.get('seconds', 0)
+                weeks=job_config.weeks,
+                days=job_config.days,
+                hours=job_config.hours,
+                minutes=job_config.minutes,
+                seconds=job_config.seconds
             )
         else:
             raise JobConfigException(
-                f"Invalid trigger ({trigger}) when scheduling job with id: {job_id}"
+                f"Invalid trigger ({job_config.trigger}) "
+                f"when scheduling job with id: {job_id}"
             )
 
         self.scheduler.add_job(


### PR DESCRIPTION
   - Replace manual env parsing with pydantic-settings BaseSettings which handles .env loading, type coercion, and validation natively
   - Add typed ScheduleConfig model for job schedule fields, replacing JSON string defaults with # type: ignore hacks
   - Update job_scheduler.py to use ScheduleConfig attribute access instead of dict .get() calls
   - Remove TESTS_RUNNING (defined but never used anywhere)
   - Remove AppConfigException (no longer needed)
   - Remove # type: ignore from logger.py import