### PR TITLE
Replace autopep8 + flake8 with ruff for linting and formatting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 100
-ignore = E402, W503, W504
-exclude = .github,__pycache__,.vscode,venv,.venv,.idea,out

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,7 +29,11 @@ jobs:
 
       - name: Check code formatting
         run: |
-          python -m flake8
+          ruff format --check .
+
+      - name: Check code linting
+        run: |
+          ruff check .
 
       - name: Check typing in src
         run: |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ MythicForge is composed of three microservices:
 - JWT authentication (PyJWT + bcrypt)
 - Docker + Docker Compose
 - GitHub Actions (CI/CD)
-- mypy, flake8, autopep8 (code quality)
+- mypy, ruff (code quality)
 
 ## Project Structure
 
@@ -121,11 +121,11 @@ pip install ".[dev]"
 ### Linting
 
 ```bash
-# Run all linters (flake8 + mypy)
+# Run all checks (ruff lint + ruff format check + mypy)
 ./scripts/linter.sh
 
 # Individual checks
-./scripts/linter.sh --flake8
+./scripts/linter.sh --lint
 ./scripts/linter.sh --mypy
 
 # Auto-format code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,15 +29,18 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "autopep8==2.0.4",
-    "flake8==6.1.0",
+    "ruff==0.4.8",
     "mypy==1.10.0",
     "types-pytz==2024.1.0.20240417",
     "types-requests==2.32.0.20240602",
 ]
 
-[tool.autopep8]
-max-line-length = 100
+[tool.ruff]
+line-length = 100
+exclude = [".github", "__pycache__", ".vscode", "venv", ".venv", ".idea", "out"]
+
+[tool.ruff.lint]
+ignore = ["E402"]
 
 [tool.mypy]
 plugins = ["sqlalchemy.ext.mypy.plugin"]

--- a/scripts/linter.sh
+++ b/scripts/linter.sh
@@ -3,9 +3,9 @@
 source "$(dirname "$0")/find_python.sh"
 
 # Ensure required tools are installed
-for tool in autopep8 flake8 mypy; do
+for tool in ruff mypy; do
     if ! $PYTHON -m pip show "$tool" > /dev/null 2>&1; then
-        echo "Error: $tool is not installed. Install it using: $PYTHON -m pip install $tool" >&2
+        echo "Error: $tool is not installed. Install it using: pip install \".[dev]\"" >&2
         exit 1
     fi
 done
@@ -13,22 +13,23 @@ done
 # Check command-line argument
 case "$1" in
     "--files")
-        # Run autopep8 in diff mode to show files that would be modified
-        $PYTHON -m autopep8 --diff --recursive . | grep -E '^--- original/\.' | sed 's/--- original\/\.//; s/\\//'
+        # Show files that would be reformatted
+        $PYTHON -m ruff format --diff .
         ;;
     "--format")
-        # Run autopep8 in place to format files
-        $PYTHON -m autopep8 --in-place --recursive .
+        # Format files in place
+        $PYTHON -m ruff format .
         ;;
-    "--flake8")
-        $PYTHON -m flake8
+    "--lint")
+        $PYTHON -m ruff check .
         ;;
     "--mypy")
         $PYTHON -m mypy src
         $PYTHON -m mypy tests
         ;;
     *)
-        $PYTHON -m flake8
+        $PYTHON -m ruff check .
+        $PYTHON -m ruff format --check .
         $PYTHON -m mypy src
         $PYTHON -m mypy tests
         ;;

--- a/src/auth/auth_bearer.py
+++ b/src/auth/auth_bearer.py
@@ -4,7 +4,7 @@ import logging
 
 from .auth_handler import decode_jwt  # type: ignore
 
-logger = logging.getLogger('fantasy-lol')
+logger = logging.getLogger("fantasy-lol")
 
 
 class JWTBearer(HTTPBearer):

--- a/src/auth/auth_handler.py
+++ b/src/auth/auth_handler.py
@@ -4,16 +4,14 @@ import logging
 
 from src.common import app_config
 
-logger = logging.getLogger('fantasy-lol')
+logger = logging.getLogger("fantasy-lol")
 
 JWT_SECRET = app_config.AUTH_SECRET
 JWT_ALGORITHM = app_config.AUTH_ALGORITHM
 
 
 def token_response(token: str):
-    return {
-        "access_token": token
-    }
+    return {"access_token": token}
 
 
 def sign_jwt(user_id: str, permissions: list[str]) -> dict[str, str]:
@@ -21,7 +19,7 @@ def sign_jwt(user_id: str, permissions: list[str]) -> dict[str, str]:
         "user_id": user_id,
         "permissions": permissions,
         "exp": time.time() + 86400,  # Token is valid for 24 hours
-        "iat": time.time()
+        "iat": time.time(),
     }
     token = jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
 

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -38,24 +38,14 @@ class AppConfig(BaseSettings):
     ESPORTS_FEED_URL: str = "https://feed.lolesports.com/livestats/v1"
 
     # Job schedules
-    LEAGUE_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(
-        trigger="cron", hour="10", minute="00"
-    )
+    LEAGUE_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(trigger="cron", hour="10", minute="00")
     TOURNAMENT_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(
         trigger="cron", hour="10", minute="05"
     )
-    TEAM_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(
-        trigger="cron", hour="10", minute="10"
-    )
-    MATCH_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(
-        trigger="cron", minute="30"
-    )
-    GAME_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(
-        trigger="cron", minute="45"
-    )
-    GAME_STATS_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(
-        trigger="cron", minute="*/5"
-    )
+    TEAM_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(trigger="cron", hour="10", minute="10")
+    MATCH_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(trigger="cron", minute="30")
+    GAME_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(trigger="cron", minute="45")
+    GAME_STATS_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(trigger="cron", minute="*/5")
 
 
 app_config = AppConfig()  # type: ignore[call-arg]

--- a/src/common/exceptions/__init__.py
+++ b/src/common/exceptions/__init__.py
@@ -1,4 +1,3 @@
 from .fantasy_lol_exception import FantasyLolException  # noqa: F401
 from .league_not_found_exception import LeagueNotFoundException  # noqa: F401
-from .professional_player_not_found_exception import \
-    ProfessionalPlayerNotFoundException  # noqa: F401
+from .professional_player_not_found_exception import ProfessionalPlayerNotFoundException  # noqa: F401

--- a/src/common/exceptions/league_not_found_exception.py
+++ b/src/common/exceptions/league_not_found_exception.py
@@ -7,7 +7,4 @@ from src.common.schemas.riot_data_schemas import RiotLeagueID
 class LeagueNotFoundException(HTTPException):
     def __init__(self, league_id: RiotLeagueID):
         error_msg = f"Riot league with ID {league_id} not found"
-        super().__init__(
-            status_code=HTTPStatus.NOT_FOUND,
-            detail=error_msg
-        )
+        super().__init__(status_code=HTTPStatus.NOT_FOUND, detail=error_msg)

--- a/src/common/exceptions/professional_player_not_found_exception.py
+++ b/src/common/exceptions/professional_player_not_found_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class ProfessionalPlayerNotFoundException(HTTPException):
     def __init__(self) -> None:
-        super().__init__(
-            status_code=HTTPStatus.NOT_FOUND,
-            detail="Professional Player not found"
-        )
+        super().__init__(status_code=HTTPStatus.NOT_FOUND, detail="Professional Player not found")

--- a/src/common/logger.py
+++ b/src/common/logger.py
@@ -24,7 +24,7 @@ def configure_logger(logger_name: str):
         mode="a+",
         maxBytes=max_file_size,
         backupCount=backup_count,
-        encoding="utf-8"
+        encoding="utf-8",
     )
     file_handler.setLevel(logging_level)
     file_handler.setFormatter(formatter)

--- a/src/common/schemas/fantasy_schemas.py
+++ b/src/common/schemas/fantasy_schemas.py
@@ -4,8 +4,8 @@ from typing import NewType
 
 from .riot_data_schemas import RiotLeagueID, ProPlayerID, PlayerRole  # type: ignore
 
-UserID = NewType('UserID', str)
-FantasyLeagueID = NewType('FantasyLeagueID', str)
+UserID = NewType("UserID", str)
+FantasyLeagueID = NewType("FantasyLeagueID", str)
 
 
 class UserAccountStatus(Enum):
@@ -21,16 +21,16 @@ class UserCreate(BaseModel):
     email: EmailStr
     password: str
 
-    @field_validator('username')
+    @field_validator("username")
     def validate_username(cls, username: str):
         if len(username) < 3:
-            raise ValueError('Username must be at least 3 characters long')
+            raise ValueError("Username must be at least 3 characters long")
         return username
 
-    @field_validator('password')
+    @field_validator("password")
     def validate_password(cls, password: str):
         if len(password) < 8:
-            raise ValueError('Password must be at least 8 characters long')
+            raise ValueError("Password must be at least 8 characters long")
         return password
 
 
@@ -54,10 +54,10 @@ class User(BaseModel):
     verification_token: str | None = None
 
     def set_permissions(self, permissions_list):
-        self.permissions = ','.join(permissions_list)
+        self.permissions = ",".join(permissions_list)
 
     def get_permissions(self):
-        return self.permissions.split(',') if self.permissions else []
+        return self.permissions.split(",") if self.permissions else []
 
 
 class EmailRequest(BaseModel):
@@ -69,69 +69,66 @@ class FantasyLeagueScoringSettings(BaseModel):
 
     fantasy_league_id: FantasyLeagueID | None = Field(
         description="The id of the fantasy league. This field is ignored in update requests",
-        examples=['aaaaaaaa-1111-bbbb-2222-cccccccccccc'],
-        default=None
+        examples=["aaaaaaaa-1111-bbbb-2222-cccccccccccc"],
+        default=None,
     )
     kills: int = Field(
         default=2,
         description="The number of points kills are worth in a given fantasy league",
-        examples=[2]
+        examples=[2],
     )
     deaths: int = Field(
         default=-1,
         description="The number of points deaths are worth in a given fantasy league",
-        examples=[-1]
+        examples=[-1],
     )
     assists: float = Field(
         default=0.5,
         description="The number of points assists are worth in a given fantasy league",
-        examples=[0.5]
+        examples=[0.5],
     )
     creep_score: float = Field(
         default=0.05,
         description="The number of points creeps score are worth in a given fantasy league",
-        examples=[0.05]
+        examples=[0.05],
     )
     wards_placed: float = Field(
         default=0.1,
         description="The number of points wards placed are worth in a given fantasy league",
-        examples=[0.1]
+        examples=[0.1],
     )
     wards_destroyed: float = Field(
         default=0.1,
         description="The number of points wards destroyed are worth in a given fantasy league",
-        examples=[0.1]
+        examples=[0.1],
     )
     kill_participation: int = Field(
         default=10,
         description="The number of points kill participation is worth in a given fantasy league",
-        examples=[10]
+        examples=[10],
     )
     damage_percentage: int = Field(
         default=5,
         description="The number of points damage percentage is worth in a given fantasy league",
-        examples=[5]
+        examples=[5],
     )
 
 
 class FantasyLeagueSettings(BaseModel):
     name: str = Field(
-        default=None,
-        description="The name of the fantasy league",
-        examples=["My Fantasy League"]
+        default=None, description="The name of the fantasy league", examples=["My Fantasy League"]
     )
     number_of_teams: int = Field(
         default=6,
-        description="Number of teams in the fantasy league\n"
-                    "Allowed values: 4, 6, 8, 10"
+        description="Number of teams in the fantasy league\n" "Allowed values: 4, 6, 8, 10",
     )
     available_leagues: list[RiotLeagueID] = Field(
         default=[],
         description="The IDs for the riot leagues available for drafting players from",
-        examples=[["98767991310872058"]]
+        examples=[["98767991310872058"]],
     )
 
-    @field_validator('number_of_teams')
+    @field_validator("number_of_teams")
     @classmethod
     def valid_team_size(cls, value: str):
         valid_values = {4, 6, 8, 10}

--- a/src/common/schemas/riot_data_schemas.py
+++ b/src/common/schemas/riot_data_schemas.py
@@ -2,51 +2,37 @@ from enum import Enum
 from typing import NewType
 from pydantic import BaseModel, Field, ConfigDict
 
-RiotLeagueID = NewType('RiotLeagueID', str)
-RiotTournamentID = NewType('RiotTournamentID', str)
-RiotMatchID = NewType('RiotMatchID', str)
-RiotGameID = NewType('RiotGameID', str)
-ProTeamID = NewType('ProTeamID', str)
-ProPlayerID = NewType('ProPlayerID', str)
+RiotLeagueID = NewType("RiotLeagueID", str)
+RiotTournamentID = NewType("RiotTournamentID", str)
+RiotMatchID = NewType("RiotMatchID", str)
+RiotGameID = NewType("RiotGameID", str)
+ProTeamID = NewType("ProTeamID", str)
+ProPlayerID = NewType("ProPlayerID", str)
 
 
 class League(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: RiotLeagueID = Field(
-        default=None,
-        description="The ID of the league",
-        examples=["98767975604431411"]
+        default=None, description="The ID of the league", examples=["98767975604431411"]
     )
-    slug: str = Field(
-        default=None,
-        description="The SLUG of the league",
-        examples=["worlds"]
-    )
-    name: str = Field(
-        default=None,
-        description="The name of the league",
-        examples=["Worlds"]
-    )
+    slug: str = Field(default=None, description="The SLUG of the league", examples=["worlds"])
+    name: str = Field(default=None, description="The name of the league", examples=["Worlds"])
     region: str = Field(
-        default=None,
-        description="The region of the league",
-        examples=["INTERNATIONAL"]
+        default=None, description="The region of the league", examples=["INTERNATIONAL"]
     )
     image: str = Field(
         default=None,
         description="The image url of the league",
-        examples=["http://static.lolesports.com/leagues/1592594612171_WorldsDarkBG.png"]
+        examples=["http://static.lolesports.com/leagues/1592594612171_WorldsDarkBG.png"],
     )
     priority: int = Field(
-        default=None,
-        description="The priority of league in list ranking order",
-        examples=[300]
+        default=None, description="The priority of league in list ranking order", examples=[300]
     )
     fantasy_available: bool = Field(
         default=False,
         description="Riot league is available for use in Fantasy Leagues",
-        examples=[False]
+        examples=[False],
     )
 
 
@@ -60,29 +46,21 @@ class Tournament(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: RiotTournamentID = Field(
-        default=None,
-        description="The ID of the tournament",
-        examples=["110852926142971547"]
+        default=None, description="The ID of the tournament", examples=["110852926142971547"]
     )
     slug: str = Field(
-        default=None,
-        description="The SLUG of the tournament",
-        examples=["worlds_2023"]
+        default=None, description="The SLUG of the tournament", examples=["worlds_2023"]
     )
     start_date: str = Field(
-        default=None,
-        description="The start date of the tournament",
-        examples=["2023-10-09"]
+        default=None, description="The start date of the tournament", examples=["2023-10-09"]
     )
     end_date: str = Field(
-        default=None,
-        description="The end date of the tournament",
-        examples=["2023-11-19"]
+        default=None, description="The end date of the tournament", examples=["2023-11-19"]
     )
     league_id: RiotLeagueID = Field(
         default=None,
         description="The ID of the league the tournament is being held in",
-        examples=["98767975604431411"]
+        examples=["98767975604431411"],
     )
 
 
@@ -96,74 +74,52 @@ class Match(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: RiotMatchID = Field(
-        default=None,
-        description="The ID of the match",
-        examples=["110853020184706765"]
+        default=None, description="The ID of the match", examples=["110853020184706765"]
     )
     start_time: str = Field(
-        default=None,
-        description="The start time of the match",
-        examples=["2023-11-19T08:00:00Z"]
+        default=None, description="The start time of the match", examples=["2023-11-19T08:00:00Z"]
     )
     block_name: str = Field(
-        default=None,
-        description="The block name of the match",
-        examples=["Finals"]
+        default=None, description="The block name of the match", examples=["Finals"]
     )
     league_slug: str = Field(
-        default=None,
-        description="The slug of the league the match is in",
-        examples=["worlds"]
+        default=None, description="The slug of the league the match is in", examples=["worlds"]
     )
     strategy_type: str = Field(
-        default=None,
-        description="The strategy type of the match",
-        examples=["bestOf"]
+        default=None, description="The strategy type of the match", examples=["bestOf"]
     )
     strategy_count: int = Field(
-        default=None,
-        description="The number of games for the strategy type",
-        examples=[5]
+        default=None, description="The number of games for the strategy type", examples=[5]
     )
     tournament_id: RiotTournamentID = Field(
         default=None,
         description="The id of the tournament the match is taking place in",
-        examples=["110852926142971547"]
+        examples=["110852926142971547"],
     )
     team_1_name: str = Field(
         default=None,
         description="The name of the first team participating in the match",
-        examples=["WeiboGaming FAW AUDI"]
+        examples=["WeiboGaming FAW AUDI"],
     )
     team_2_name: str = Field(
         default=None,
         description="The name of the second team participating in the match",
-        examples=["T1"]
+        examples=["T1"],
     )
     has_games: bool = Field(
-        default=True,
-        description="If this match has game data available",
-        examples=[True]
+        default=True, description="If this match has game data available", examples=[True]
     )
     state: MatchState = Field(
-        default=None,
-        description="The state of the match",
-        examples=["completed"]
+        default=None, description="The state of the match", examples=["completed"]
     )
     team_1_wins: int | None = Field(
-        default=None,
-        description="The number of game wins for team 1",
-        examples=[2]
+        default=None, description="The number of game wins for team 1", examples=[2]
     )
     team_2_wins: int | None = Field(
-        default=None,
-        description="The number of game wins for team 2",
-        examples=[3]
+        default=None, description="The number of game wins for team 2", examples=[3]
     )
     winning_team: str | None = Field(
-        default=None,
-        description="The name of the winning team for the match",
-        examples=["T1"]
+        default=None, description="The name of the winning team for the match", examples=["T1"]
     )
 
 
@@ -184,44 +140,38 @@ class Game(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: RiotGameID = Field(
-        default=None,
-        description="The ID of the game",
-        examples=["110853020184706766"]
+        default=None, description="The ID of the game", examples=["110853020184706766"]
     )
     state: GameState = Field(
-        default=None,
-        description="The state of the game",
-        examples=["completed"]
+        default=None, description="The state of the game", examples=["completed"]
     )
     number: int = Field(
-        default=None,
-        description="The game number within the strategy type and count",
-        examples=[1]
+        default=None, description="The game number within the strategy type and count", examples=[1]
     )
     red_team: ProTeamID = Field(
         default=None,
         description="The team ID playing on the red side",
-        examples=["113770064260414203"]
+        examples=["113770064260414203"],
     )
     blue_team: ProTeamID = Field(
         default=None,
         description="The team ID playing on the blue side",
-        examples=["109642680932009857"]
+        examples=["109642680932009857"],
     )
     match_id: RiotMatchID = Field(
         default=None,
         description="The ID of the match that the game is in",
-        examples=["110853020184706765"]
+        examples=["110853020184706765"],
     )
     has_game_data: bool = Field(
         default=True,
         description="If this game has player metadata and stats available",
-        examples=[True]
+        examples=[True],
     )
     last_stats_fetch: bool = Field(
         default=False,
         description="Game is completed and marked to fetch game stats one last time.",
-        examples=[True]
+        examples=[True],
     )
 
 
@@ -234,49 +184,29 @@ class ProfessionalTeam(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: ProTeamID = Field(
-        default=None,
-        description="The ID of the team",
-        examples=["98767991853197861"]
+        default=None, description="The ID of the team", examples=["98767991853197861"]
     )
-    slug: str = Field(
-        default=None,
-        description="The SLUG of the team",
-        examples=["t1"]
-    )
-    name: str = Field(
-        default=None,
-        description="The name of the team",
-        examples=["T1"]
-    )
-    code: str = Field(
-        default=None,
-        description="The code of the team",
-        examples=["T1"]
-    )
+    slug: str = Field(default=None, description="The SLUG of the team", examples=["t1"])
+    name: str = Field(default=None, description="The name of the team", examples=["T1"])
+    code: str = Field(default=None, description="The code of the team", examples=["T1"])
     image: str = Field(
         default=None,
         description="The image url of the team",
-        examples=["http://static.lolesports.com/teams/1704375161752_T1_esports.png"]
+        examples=["http://static.lolesports.com/teams/1704375161752_T1_esports.png"],
     )
     alternative_image: str | None = Field(
         default=None,
         description="The alternative image url of the team",
-        examples=["http://static.lolesports.com/teams/1704375161753_T1_esports.png"]
+        examples=["http://static.lolesports.com/teams/1704375161753_T1_esports.png"],
     )
     background_image: str | None = Field(
         default=None,
         description="The background image url of the team",
-        examples=["http://static.lolesports.com/teams/1596305556675_T1T1.png"]
+        examples=["http://static.lolesports.com/teams/1596305556675_T1T1.png"],
     )
-    status: str = Field(
-        default=None,
-        description="The status of the team",
-        examples=["active"]
-    )
+    status: str = Field(default=None, description="The status of the team", examples=["active"])
     home_league: str | None = Field(
-        default=None,
-        description="The home league name of the team",
-        examples=["LCK"]
+        default=None, description="The home league name of the team", examples=["LCK"]
     )
 
 
@@ -295,27 +225,23 @@ class ProfessionalPlayer(BaseModel):
     id: ProPlayerID = Field(
         default=None,
         description="The esports id of the player given by RIOT",
-        examples=["98767991747728851"]
+        examples=["98767991747728851"],
     )
     summoner_name: str = Field(
-        default=None,
-        description="The summoner name of the player",
-        examples=["Faker"]
+        default=None, description="The summoner name of the player", examples=["Faker"]
     )
     image: str = Field(
         default=None,
         description="The url for the players image",
-        examples=["http://static.lolesports.com/players/1686475867148_T1_Faker.png"]
+        examples=["http://static.lolesports.com/players/1686475867148_T1_Faker.png"],
     )
     role: PlayerRole = Field(
-        default=None,
-        description="The role that the player plays",
-        examples=["mid"]
+        default=None, description="The role that the player plays", examples=["mid"]
     )
     team_id: ProTeamID = Field(
         default=None,
         description="The id of the team that the player is on",
-        examples=["98767991853197861"]
+        examples=["98767991853197861"],
     )
 
 
@@ -323,73 +249,41 @@ class PlayerGameMetadata(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     game_id: RiotGameID = Field(
-        default=None,
-        description="The id of the game this players metadata is for"
+        default=None, description="The id of the game this players metadata is for"
     )
-    player_id: ProPlayerID = Field(
-        default=None,
-        description="The id of the player given by riot"
-    )
+    player_id: ProPlayerID = Field(default=None, description="The id of the player given by riot")
     participant_id: int = Field(
-        default=None,
-        description="The participant id for the game given by riot"
+        default=None, description="The participant id for the game given by riot"
     )
     champion_id: str = Field(
-        default=None,
-        description="The id of the champion the player played in the game"
+        default=None, description="The id of the champion the player played in the game"
     )
-    role: PlayerRole = Field(
-        default=None,
-        description="The role the player played in the game"
-    )
+    role: PlayerRole = Field(default=None, description="The role the player played in the game")
 
 
 class PlayerGameStats(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     game_id: RiotGameID = Field(
-        default=None,
-        description="The id of the game this players metadata is for"
+        default=None, description="The id of the game this players metadata is for"
     )
     participant_id: int = Field(
-        default=None,
-        description="The participant id for the game given by riot"
+        default=None, description="The participant id for the game given by riot"
     )
-    kills: int = Field(
-        default=None,
-        description="The number of kills the player got"
-    )
-    deaths: int = Field(
-        default=None,
-        description="The number of deaths for the player"
-    )
-    assists: int = Field(
-        default=None,
-        description="The number of assists for the players"
-    )
-    total_gold: int = Field(
-        default=None,
-        description="The total gold the player had"
-    )
-    creep_score: int = Field(
-        default=None,
-        description="The creep score the player had"
-    )
+    kills: int = Field(default=None, description="The number of kills the player got")
+    deaths: int = Field(default=None, description="The number of deaths for the player")
+    assists: int = Field(default=None, description="The number of assists for the players")
+    total_gold: int = Field(default=None, description="The total gold the player had")
+    creep_score: int = Field(default=None, description="The creep score the player had")
     kill_participation: int = Field(
-        default=None,
-        description="The kill participation the player had"
+        default=None, description="The kill participation the player had"
     )
     champion_damage_share: int = Field(
-        default=None,
-        description="The damage percentage of the team the player did to champions"
+        default=None, description="The damage percentage of the team the player did to champions"
     )
-    wards_placed: int = Field(
-        default=None,
-        description="The number of wards the player placed"
-    )
+    wards_placed: int = Field(default=None, description="The number of wards the player placed")
     wards_destroyed: int = Field(
-        default=None,
-        description="The number of enemy wards the player destroyed"
+        default=None, description="The number of enemy wards the player destroyed"
     )
 
 
@@ -399,73 +293,50 @@ class PlayerGameData(BaseModel):
     game_id: RiotGameID = Field(
         default=None,
         description="The id of the game this players metadata is for",
-        examples=["110853020184706766"]
+        examples=["110853020184706766"],
     )
     player_id: ProPlayerID = Field(
         default=None,
         description="The id of the player given by riot",
-        examples=["98767991747728851"]
-
+        examples=["98767991747728851"],
     )
     participant_id: int = Field(
-        default=None,
-        description="The participant id for the game given by riot",
-        examples=[8]
+        default=None, description="The participant id for the game given by riot", examples=[8]
     )
     champion_id: str = Field(
         default=None,
         description="The id of the champion the player played in the game",
-        examples=["Ahri"]
+        examples=["Ahri"],
     )
     role: PlayerRole = Field(
-        default=None,
-        description="The role the player played in the game",
-        examples=["mid"]
+        default=None, description="The role the player played in the game", examples=["mid"]
     )
-    kills: int = Field(
-        default=None,
-        description="The number of kills the player got",
-        examples=[1]
-    )
+    kills: int = Field(default=None, description="The number of kills the player got", examples=[1])
     deaths: int = Field(
-        default=None,
-        description="The number of deaths for the player",
-        examples=[2]
+        default=None, description="The number of deaths for the player", examples=[2]
     )
     assists: int = Field(
-        default=None,
-        description="The number of assists for the players",
-        examples=[4]
+        default=None, description="The number of assists for the players", examples=[4]
     )
     total_gold: int = Field(
-        default=None,
-        description="The total gold the player had",
-        examples=[11643]
+        default=None, description="The total gold the player had", examples=[11643]
     )
     creep_score: int = Field(
-        default=None,
-        description="The creep score the player had",
-        examples=[248]
+        default=None, description="The creep score the player had", examples=[248]
     )
     kill_participation: int = Field(
-        default=None,
-        description="The kill participation the player had",
-        examples=[33]
+        default=None, description="The kill participation the player had", examples=[33]
     )
     champion_damage_share: int = Field(
         default=None,
         description="The damage percentage of the team the player did to champions",
-        examples=[15]
+        examples=[15],
     )
     wards_placed: int = Field(
-        default=None,
-        description="The number of wards the player placed",
-        examples=[7]
+        default=None, description="The number of wards the player placed", examples=[7]
     )
     wards_destroyed: int = Field(
-        default=None,
-        description="The number of enemy wards the player destroyed",
-        examples=[7]
+        default=None, description="The number of enemy wards the player destroyed", examples=[7]
     )
 
 

--- a/src/common/schemas/search_parameters.py
+++ b/src/common/schemas/search_parameters.py
@@ -8,7 +8,7 @@ from .riot_data_schemas import (
     ProPlayerID,
     ProTeamID,
     PlayerRole,
-    TournamentStatus
+    TournamentStatus,
 )
 
 

--- a/src/common/schemas/verification_email_config.py
+++ b/src/common/schemas/verification_email_config.py
@@ -17,7 +17,7 @@ class VerificationConfig(BaseModel):
     def __init__(self, **kwargs):
         for field_name in self.__fields__:
             if field_name not in kwargs:
-                env_value = os.getenv(f'VERIFICATION_{field_name.upper()}')
+                env_value = os.getenv(f"VERIFICATION_{field_name.upper()}")
                 if env_value is not None:
                     kwargs[field_name] = env_value
 

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -10,7 +10,7 @@ from src.common.schemas.fantasy_schemas import (
     FantasyTeam,
     User,
     UserAccountStatus,
-    UserID
+    UserID,
 )
 from src.common.schemas.riot_data_schemas import (
     League,
@@ -29,7 +29,8 @@ from src.common.schemas.riot_data_schemas import (
     PlayerGameMetadata,
     PlayerGameData,
     PlayerGameStats,
-    StoredSchedule, TeamGameStats
+    StoredSchedule,
+    TeamGameStats,
 )
 from src.db.database_connection_provider import DatabaseConnectionProvider
 from src.db.fantasy_dao import (
@@ -37,7 +38,7 @@ from src.db.fantasy_dao import (
     fantasy_league_dao,
     fantasy_team_dao,
     membership_dao,
-    user_dao
+    user_dao,
 )
 from src.db.riot_dao import (
     game_dao,
@@ -49,7 +50,7 @@ from src.db.riot_dao import (
     schedule_dao,
     team_dao,
     team_stats_dao,
-    tournament_dao
+    tournament_dao,
 )
 
 
@@ -141,7 +142,7 @@ class DatabaseService:
             player_metadata_dao.put_player_metadata(db, player_metadata)
 
     def get_player_metadata(
-            self, player_id: ProPlayerID, game_id: RiotGameID
+        self, player_id: ProPlayerID, game_id: RiotGameID
     ) -> PlayerGameMetadata | None:
         with self.connection_provider.get_db() as db:
             return player_metadata_dao.get_player_metadata(db, player_id, game_id)
@@ -154,9 +155,7 @@ class DatabaseService:
         with self.connection_provider.get_db() as db:
             player_stats_dao.put_player_stats(db, player_stats)
 
-    def get_player_stats(
-            self, game_id: RiotGameID, participant_id: int
-    ) -> PlayerGameStats | None:
+    def get_player_stats(self, game_id: RiotGameID, participant_id: int) -> PlayerGameStats | None:
         with self.connection_provider.get_db() as db:
             return player_stats_dao.get_player_stats(db, game_id, participant_id)
 
@@ -185,7 +184,7 @@ class DatabaseService:
             return riot_league_dao.get_league_by_id(db, league_id)
 
     def update_league_fantasy_available_status(
-            self, league_id: RiotLeagueID, new_status: bool
+        self, league_id: RiotLeagueID, new_status: bool
     ) -> League | None:
         with self.connection_provider.get_db() as db:
             return riot_league_dao.update_league_fantasy_available_status(db, league_id, new_status)
@@ -234,7 +233,7 @@ class DatabaseService:
             draft_order_dao.create_fantasy_league_draft_order(db, draft_order)
 
     def get_fantasy_league_draft_order(
-            self, fantasy_league_id: FantasyLeagueID
+        self, fantasy_league_id: FantasyLeagueID
     ) -> list[FantasyLeagueDraftOrder]:
         with self.connection_provider.get_db() as db:
             return draft_order_dao.get_fantasy_league_draft_order(db, fantasy_league_id)
@@ -244,7 +243,7 @@ class DatabaseService:
             draft_order_dao.delete_fantasy_league_draft_order(db, draft_order)
 
     def update_fantasy_league_draft_order_position(
-            self, draft_order: FantasyLeagueDraftOrder, new_position: int
+        self, draft_order: FantasyLeagueDraftOrder, new_position: int
     ) -> None:
         with self.connection_provider.get_db() as db:
             draft_order_dao.update_fantasy_league_draft_order_position(
@@ -255,20 +254,18 @@ class DatabaseService:
         with self.connection_provider.get_db() as db:
             fantasy_league_dao.create_fantasy_league(db, fantasy_league)
 
-    def get_fantasy_league_by_id(
-            self, fantasy_league_id: FantasyLeagueID
-    ) -> FantasyLeague | None:
+    def get_fantasy_league_by_id(self, fantasy_league_id: FantasyLeagueID) -> FantasyLeague | None:
         with self.connection_provider.get_db() as db:
             return fantasy_league_dao.get_fantasy_league_by_id(db, fantasy_league_id)
 
     def put_fantasy_league_scoring_settings(
-            self, scoring_settings: FantasyLeagueScoringSettings
+        self, scoring_settings: FantasyLeagueScoringSettings
     ) -> None:
         with self.connection_provider.get_db() as db:
             fantasy_league_dao.put_fantasy_league_scoring_settings(db, scoring_settings)
 
     def get_fantasy_league_scoring_settings_by_id(
-            self, fantasy_league_id: FantasyLeagueID
+        self, fantasy_league_id: FantasyLeagueID
     ) -> FantasyLeagueScoringSettings | None:
         with self.connection_provider.get_db() as db:
             return fantasy_league_dao.get_fantasy_league_scoring_settings_by_id(
@@ -276,7 +273,7 @@ class DatabaseService:
             )
 
     def update_fantasy_league_settings(
-            self, fantasy_league_id: FantasyLeagueID, settings: FantasyLeagueSettings
+        self, fantasy_league_id: FantasyLeagueID, settings: FantasyLeagueSettings
     ) -> FantasyLeague:
         with self.connection_provider.get_db() as db:
             return fantasy_league_dao.update_fantasy_league_settings(
@@ -284,7 +281,7 @@ class DatabaseService:
             )
 
     def update_fantasy_league_status(
-            self, fantasy_league_id: FantasyLeagueID, new_status: FantasyLeagueStatus
+        self, fantasy_league_id: FantasyLeagueID, new_status: FantasyLeagueStatus
     ) -> FantasyLeague:
         with self.connection_provider.get_db() as db:
             return fantasy_league_dao.update_fantasy_league_status(
@@ -292,7 +289,7 @@ class DatabaseService:
             )
 
     def update_fantasy_league_current_draft_position(
-            self, fantasy_league_id: FantasyLeagueID, new_current_draft_position: int
+        self, fantasy_league_id: FantasyLeagueID, new_current_draft_position: int
     ) -> FantasyLeague:
         with self.connection_provider.get_db() as db:
             return fantasy_league_dao.update_fantasy_league_current_draft_position(
@@ -304,44 +301,45 @@ class DatabaseService:
             fantasy_team_dao.put_fantasy_team(db, fantasy_team)
 
     def get_all_fantasy_teams_for_user(
-            self, fantasy_league_id: FantasyLeagueID, user_id: UserID
+        self, fantasy_league_id: FantasyLeagueID, user_id: UserID
     ) -> list[FantasyTeam]:
         with self.connection_provider.get_db() as db:
             return fantasy_team_dao.get_all_fantasy_teams_for_user(db, fantasy_league_id, user_id)
 
     def get_all_fantasy_teams_for_week(
-            self, fantasy_league_id: FantasyLeagueID, week: int
+        self, fantasy_league_id: FantasyLeagueID, week: int
     ) -> list[FantasyTeam]:
         with self.connection_provider.get_db() as db:
             return fantasy_team_dao.get_all_fantasy_teams_for_week(db, fantasy_league_id, week)
 
     def create_fantasy_league_membership(
-            self, fantasy_league_membership: FantasyLeagueMembership
+        self, fantasy_league_membership: FantasyLeagueMembership
     ) -> None:
         with self.connection_provider.get_db() as db:
             membership_dao.create_fantasy_league_membership(db, fantasy_league_membership)
 
     def get_pending_and_accepted_members_for_league(
-            self, fantasy_league_id: FantasyLeagueID
+        self, fantasy_league_id: FantasyLeagueID
     ) -> list[FantasyLeagueMembership]:
         with self.connection_provider.get_db() as db:
             return membership_dao.get_pending_and_accepted_members_for_league(db, fantasy_league_id)
 
     def update_fantasy_league_membership_status(
-            self, membership: FantasyLeagueMembership, new_status: FantasyLeagueMembershipStatus
+        self, membership: FantasyLeagueMembership, new_status: FantasyLeagueMembershipStatus
     ) -> None:
         with self.connection_provider.get_db() as db:
             membership_dao.update_fantasy_league_membership_status(db, membership, new_status)
 
     def get_user_membership_for_fantasy_league(
-            self, user_id: UserID, fantasy_league_id: FantasyLeagueID
+        self, user_id: UserID, fantasy_league_id: FantasyLeagueID
     ) -> FantasyLeagueMembership | None:
         with self.connection_provider.get_db() as db:
-            return membership_dao.get_user_membership_for_fantasy_league(db, user_id,
-                                                                         fantasy_league_id)
+            return membership_dao.get_user_membership_for_fantasy_league(
+                db, user_id, fantasy_league_id
+            )
 
     def get_users_fantasy_leagues_with_membership_status(
-            self, user_id: UserID, membership_status: FantasyLeagueMembershipStatus
+        self, user_id: UserID, membership_status: FantasyLeagueMembershipStatus
     ) -> list[FantasyLeague]:
         with self.connection_provider.get_db() as db:
             return membership_dao.get_users_fantasy_leagues_with_membership_status(
@@ -365,7 +363,7 @@ class DatabaseService:
             return user_dao.get_user_by_email(db, email)
 
     def update_user_account_status(
-            self, user_id: UserID, account_status: UserAccountStatus
+        self, user_id: UserID, account_status: UserAccountStatus
     ) -> None:
         with self.connection_provider.get_db() as db:
             user_dao.update_user_account_status(db, user_id, account_status)
@@ -379,9 +377,7 @@ class DatabaseService:
             return user_dao.get_user_by_verification_token(db, verification_token)
 
     def update_user_verification_token(
-            self,
-            user_id: UserID,
-            verification_token: str | None
+        self, user_id: UserID, verification_token: str | None
     ) -> None:
         with self.connection_provider.get_db() as db:
             user_dao.update_user_verification_token(db, user_id, verification_token)

--- a/src/db/fantasy_dao/draft_order_dao.py
+++ b/src/db/fantasy_dao/draft_order_dao.py
@@ -9,36 +9,35 @@ def create_fantasy_league_draft_order(session, draft_order: FantasyLeagueDraftOr
 
 
 def get_fantasy_league_draft_order(
-        session,
-        fantasy_league_id: FantasyLeagueID
+    session, fantasy_league_id: FantasyLeagueID
 ) -> list[FantasyLeagueDraftOrder]:
-    db_draft_orders: list[FantasyLeagueDraftOrderModel] = session\
-        .query(FantasyLeagueDraftOrderModel)\
-        .filter(FantasyLeagueDraftOrderModel.fantasy_league_id == fantasy_league_id)\
+    db_draft_orders: list[FantasyLeagueDraftOrderModel] = (
+        session.query(FantasyLeagueDraftOrderModel)
+        .filter(FantasyLeagueDraftOrderModel.fantasy_league_id == fantasy_league_id)
         .all()
-    draft_orders = [FantasyLeagueDraftOrder.model_validate(db_draft_order)
-                    for db_draft_order in db_draft_orders]
+    )
+    draft_orders = [
+        FantasyLeagueDraftOrder.model_validate(db_draft_order) for db_draft_order in db_draft_orders
+    ]
     return draft_orders
 
 
-def delete_fantasy_league_draft_order(
-        session,
-        draft_order: FantasyLeagueDraftOrder
-) -> None:
-    db_draft_order: FantasyLeagueDraftOrderModel | None = session\
-        .query(FantasyLeagueDraftOrderModel)\
-        .filter(FantasyLeagueDraftOrderModel.fantasy_league_id == draft_order.fantasy_league_id,
-                FantasyLeagueDraftOrderModel.user_id == draft_order.user_id)\
+def delete_fantasy_league_draft_order(session, draft_order: FantasyLeagueDraftOrder) -> None:
+    db_draft_order: FantasyLeagueDraftOrderModel | None = (
+        session.query(FantasyLeagueDraftOrderModel)
+        .filter(
+            FantasyLeagueDraftOrderModel.fantasy_league_id == draft_order.fantasy_league_id,
+            FantasyLeagueDraftOrderModel.user_id == draft_order.user_id,
+        )
         .first()
-    assert (db_draft_order is not None)
+    )
+    assert db_draft_order is not None
     session.delete(db_draft_order)
     session.commit()
 
 
 def update_fantasy_league_draft_order_position(
-        session,
-        draft_order: FantasyLeagueDraftOrder,
-        new_position: int
+    session, draft_order: FantasyLeagueDraftOrder, new_position: int
 ) -> None:
     draft_order.position = new_position
     db_draft_order = FantasyLeagueDraftOrderModel(**draft_order.model_dump())

--- a/src/db/fantasy_dao/fantasy_league_dao.py
+++ b/src/db/fantasy_dao/fantasy_league_dao.py
@@ -14,12 +14,10 @@ def create_fantasy_league(session, fantasy_league: FantasyLeague) -> None:
     session.commit()
 
 
-def get_fantasy_league_by_id(
-        session,
-        fantasy_league_id: FantasyLeagueID
-) -> FantasyLeague | None:
-    db_fantasy_league: FantasyLeague | None = session.query(FantasyLeagueModel) \
-        .filter(FantasyLeagueModel.id == fantasy_league_id).first()
+def get_fantasy_league_by_id(session, fantasy_league_id: FantasyLeagueID) -> FantasyLeague | None:
+    db_fantasy_league: FantasyLeague | None = (
+        session.query(FantasyLeagueModel).filter(FantasyLeagueModel.id == fantasy_league_id).first()
+    )
     if db_fantasy_league is None:
         return None
     else:
@@ -27,8 +25,7 @@ def get_fantasy_league_by_id(
 
 
 def put_fantasy_league_scoring_settings(
-        session,
-        scoring_settings: FantasyLeagueScoringSettings
+    session, scoring_settings: FantasyLeagueScoringSettings
 ) -> None:
     db_scoring_settings = FantasyLeagueScoringSettingModel(**scoring_settings.model_dump())
     session.merge(db_scoring_settings)
@@ -36,13 +33,13 @@ def put_fantasy_league_scoring_settings(
 
 
 def get_fantasy_league_scoring_settings_by_id(
-        session,
-        fantasy_league_id: FantasyLeagueID
+    session, fantasy_league_id: FantasyLeagueID
 ) -> FantasyLeagueScoringSettings | None:
-    db_scoring_setting: FantasyLeagueScoringSettingModel | None = session\
-        .query(FantasyLeagueScoringSettingModel)\
-        .filter(FantasyLeagueScoringSettingModel.fantasy_league_id == fantasy_league_id)\
+    db_scoring_setting: FantasyLeagueScoringSettingModel | None = (
+        session.query(FantasyLeagueScoringSettingModel)
+        .filter(FantasyLeagueScoringSettingModel.fantasy_league_id == fantasy_league_id)
         .first()
+    )
     if db_scoring_setting is None:
         return None
     else:
@@ -50,14 +47,12 @@ def get_fantasy_league_scoring_settings_by_id(
 
 
 def update_fantasy_league_settings(
-        session,
-        fantasy_league_id: FantasyLeagueID,
-        settings: FantasyLeagueSettings
+    session, fantasy_league_id: FantasyLeagueID, settings: FantasyLeagueSettings
 ) -> FantasyLeague:
-    db_fantasy_league: FantasyLeague | None = session.query(FantasyLeagueModel)\
-        .filter_by(id=fantasy_league_id)\
-        .first()
-    assert (db_fantasy_league is not None)
+    db_fantasy_league: FantasyLeague | None = (
+        session.query(FantasyLeagueModel).filter_by(id=fantasy_league_id).first()
+    )
+    assert db_fantasy_league is not None
 
     db_fantasy_league.name = settings.name
     db_fantasy_league.number_of_teams = settings.number_of_teams
@@ -69,14 +64,12 @@ def update_fantasy_league_settings(
 
 
 def update_fantasy_league_status(
-        session,
-        fantasy_league_id: FantasyLeagueID,
-        new_status: FantasyLeagueStatus
+    session, fantasy_league_id: FantasyLeagueID, new_status: FantasyLeagueStatus
 ) -> FantasyLeague:
-    db_fantasy_league: FantasyLeague | None = session.query(FantasyLeagueModel)\
-        .filter_by(id=fantasy_league_id)\
-        .first()
-    assert (db_fantasy_league is not None)
+    db_fantasy_league: FantasyLeague | None = (
+        session.query(FantasyLeagueModel).filter_by(id=fantasy_league_id).first()
+    )
+    assert db_fantasy_league is not None
 
     db_fantasy_league.status = new_status
     session.commit()
@@ -85,14 +78,12 @@ def update_fantasy_league_status(
 
 
 def update_fantasy_league_current_draft_position(
-        session,
-        fantasy_league_id: FantasyLeagueID,
-        new_current_draft_position: int
+    session, fantasy_league_id: FantasyLeagueID, new_current_draft_position: int
 ) -> FantasyLeague:
-    db_fantasy_league: FantasyLeague | None = session.query(FantasyLeagueModel)\
-        .filter_by(id=fantasy_league_id)\
-        .first()
-    assert (db_fantasy_league is not None)
+    db_fantasy_league: FantasyLeague | None = (
+        session.query(FantasyLeagueModel).filter_by(id=fantasy_league_id).first()
+    )
+    assert db_fantasy_league is not None
 
     db_fantasy_league.current_draft_position = new_current_draft_position
     session.commit()

--- a/src/db/fantasy_dao/fantasy_team_dao.py
+++ b/src/db/fantasy_dao/fantasy_team_dao.py
@@ -9,28 +9,33 @@ def put_fantasy_team(session, fantasy_team: FantasyTeam) -> None:
 
 
 def get_all_fantasy_teams_for_user(
-        session,
-        fantasy_league_id: FantasyLeagueID,
-        user_id: UserID
+    session, fantasy_league_id: FantasyLeagueID, user_id: UserID
 ) -> list[FantasyTeam]:
-    db_fantasy_teams: list[FantasyTeamModel] = session.query(FantasyTeamModel)\
-        .filter(FantasyTeamModel.fantasy_league_id == fantasy_league_id,
-                FantasyTeamModel.user_id == user_id)\
+    db_fantasy_teams: list[FantasyTeamModel] = (
+        session.query(FantasyTeamModel)
+        .filter(
+            FantasyTeamModel.fantasy_league_id == fantasy_league_id,
+            FantasyTeamModel.user_id == user_id,
+        )
         .all()
-    fantasy_teams = [FantasyTeam.model_validate(db_fantasy_team)
-                     for db_fantasy_team in db_fantasy_teams]
+    )
+    fantasy_teams = [
+        FantasyTeam.model_validate(db_fantasy_team) for db_fantasy_team in db_fantasy_teams
+    ]
     return fantasy_teams
 
 
 def get_all_fantasy_teams_for_week(
-        session,
-        fantasy_league_id: FantasyLeagueID,
-        week: int
+    session, fantasy_league_id: FantasyLeagueID, week: int
 ) -> list[FantasyTeam]:
-    db_fantasy_teams: list[FantasyTeamModel] = session.query(FantasyTeamModel)\
-        .filter(FantasyTeamModel.fantasy_league_id == fantasy_league_id,
-                FantasyTeamModel.week == week)\
+    db_fantasy_teams: list[FantasyTeamModel] = (
+        session.query(FantasyTeamModel)
+        .filter(
+            FantasyTeamModel.fantasy_league_id == fantasy_league_id, FantasyTeamModel.week == week
+        )
         .all()
-    fantasy_teams = [FantasyTeam.model_validate(db_fantasy_team)
-                     for db_fantasy_team in db_fantasy_teams]
+    )
+    fantasy_teams = [
+        FantasyTeam.model_validate(db_fantasy_team) for db_fantasy_team in db_fantasy_teams
+    ]
     return fantasy_teams

--- a/src/db/fantasy_dao/membership_dao.py
+++ b/src/db/fantasy_dao/membership_dao.py
@@ -5,44 +5,42 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueID,
     FantasyLeagueMembership,
     FantasyLeagueMembershipStatus,
-    UserID
+    UserID,
 )
 from src.db.models import FantasyLeagueModel, FantasyLeagueMembershipModel
 
 
 def create_fantasy_league_membership(
-        session,
-        fantasy_league_membership: FantasyLeagueMembership
+    session, fantasy_league_membership: FantasyLeagueMembership
 ) -> None:
-    db_membership = FantasyLeagueMembershipModel(
-        **fantasy_league_membership.model_dump()
-    )
+    db_membership = FantasyLeagueMembershipModel(**fantasy_league_membership.model_dump())
     session.add(db_membership)
     session.commit()
 
 
 def get_pending_and_accepted_members_for_league(
-        session,
-        fantasy_league_id: FantasyLeagueID
+    session, fantasy_league_id: FantasyLeagueID
 ) -> list[FantasyLeagueMembership]:
-    db_memberships: list[FantasyLeagueMembershipModel] = session\
-        .query(FantasyLeagueMembershipModel)\
-        .filter(and_(FantasyLeagueMembershipModel.league_id == fantasy_league_id,
-                     FantasyLeagueMembershipModel.status.in_(
-                         [
-                             FantasyLeagueMembershipStatus.PENDING,
-                             FantasyLeagueMembershipStatus.ACCEPTED
-                         ]))
-                ).all()
-    memberships = [FantasyLeagueMembership.model_validate(db_membership)
-                   for db_membership in db_memberships]
+    db_memberships: list[FantasyLeagueMembershipModel] = (
+        session.query(FantasyLeagueMembershipModel)
+        .filter(
+            and_(
+                FantasyLeagueMembershipModel.league_id == fantasy_league_id,
+                FantasyLeagueMembershipModel.status.in_(
+                    [FantasyLeagueMembershipStatus.PENDING, FantasyLeagueMembershipStatus.ACCEPTED]
+                ),
+            )
+        )
+        .all()
+    )
+    memberships = [
+        FantasyLeagueMembership.model_validate(db_membership) for db_membership in db_memberships
+    ]
     return memberships
 
 
 def update_fantasy_league_membership_status(
-        session,
-        membership: FantasyLeagueMembership,
-        new_status: FantasyLeagueMembershipStatus
+    session, membership: FantasyLeagueMembership, new_status: FantasyLeagueMembershipStatus
 ) -> None:
     membership.status = new_status
     db_membership = FantasyLeagueMembershipModel(**membership.model_dump())
@@ -51,14 +49,16 @@ def update_fantasy_league_membership_status(
 
 
 def get_user_membership_for_fantasy_league(
-        session,
-        user_id: UserID,
-        fantasy_league_id: FantasyLeagueID
+    session, user_id: UserID, fantasy_league_id: FantasyLeagueID
 ) -> FantasyLeagueMembership | None:
-    db_membership: FantasyLeagueMembershipModel | None = session\
-        .query(FantasyLeagueMembershipModel)\
-        .filter(FantasyLeagueMembershipModel.league_id == fantasy_league_id,
-                FantasyLeagueMembershipModel.user_id == user_id).first()
+    db_membership: FantasyLeagueMembershipModel | None = (
+        session.query(FantasyLeagueMembershipModel)
+        .filter(
+            FantasyLeagueMembershipModel.league_id == fantasy_league_id,
+            FantasyLeagueMembershipModel.user_id == user_id,
+        )
+        .first()
+    )
     if db_membership is None:
         return None
     else:
@@ -66,17 +66,23 @@ def get_user_membership_for_fantasy_league(
 
 
 def get_users_fantasy_leagues_with_membership_status(
-        session,
-        user_id: UserID,
-        membership_status: FantasyLeagueMembershipStatus
+    session, user_id: UserID, membership_status: FantasyLeagueMembershipStatus
 ) -> list[FantasyLeague]:
-    db_fantasy_leagues: list[FantasyLeagueModel] = session.query(FantasyLeagueModel)\
-        .join(FantasyLeagueMembershipModel,
-              FantasyLeagueModel.id == FantasyLeagueMembershipModel.league_id)\
-        .filter(and_(
-            FantasyLeagueMembershipModel.user_id == user_id,
-            FantasyLeagueMembershipModel.status == membership_status
-        )).all()
-    fantasy_leagues = [FantasyLeague.model_validate(db_fantasy_league)
-                       for db_fantasy_league in db_fantasy_leagues]
+    db_fantasy_leagues: list[FantasyLeagueModel] = (
+        session.query(FantasyLeagueModel)
+        .join(
+            FantasyLeagueMembershipModel,
+            FantasyLeagueModel.id == FantasyLeagueMembershipModel.league_id,
+        )
+        .filter(
+            and_(
+                FantasyLeagueMembershipModel.user_id == user_id,
+                FantasyLeagueMembershipModel.status == membership_status,
+            )
+        )
+        .all()
+    )
+    fantasy_leagues = [
+        FantasyLeague.model_validate(db_fantasy_league) for db_fantasy_league in db_fantasy_leagues
+    ]
     return fantasy_leagues

--- a/src/db/fantasy_dao/user_dao.py
+++ b/src/db/fantasy_dao/user_dao.py
@@ -10,9 +10,7 @@ def create_user(session: Session, user: User) -> None:
 
 
 def get_user_by_id(session: Session, user_id: UserID) -> User | None:
-    db_user: UserModel | None = session.query(UserModel)\
-        .filter(UserModel.id == user_id)\
-        .first()
+    db_user: UserModel | None = session.query(UserModel).filter(UserModel.id == user_id).first()
     if db_user is None:
         return None
     else:
@@ -20,9 +18,9 @@ def get_user_by_id(session: Session, user_id: UserID) -> User | None:
 
 
 def get_user_by_username(session: Session, username: str) -> User | None:
-    db_user: UserModel | None = session.query(UserModel)\
-        .filter(UserModel.username == username)\
-        .first()
+    db_user: UserModel | None = (
+        session.query(UserModel).filter(UserModel.username == username).first()
+    )
     if db_user is None:
         return None
     else:
@@ -30,9 +28,7 @@ def get_user_by_username(session: Session, username: str) -> User | None:
 
 
 def get_user_by_email(session: Session, email: str) -> User | None:
-    db_user: UserModel | None = session.query(UserModel)\
-        .filter(UserModel.email == email)\
-        .first()
+    db_user: UserModel | None = session.query(UserModel).filter(UserModel.email == email).first()
     if db_user is None:
         return None
     else:
@@ -40,9 +36,7 @@ def get_user_by_email(session: Session, email: str) -> User | None:
 
 
 def update_user_account_status(
-        session: Session,
-        user_id: UserID,
-        account_status: UserAccountStatus
+    session: Session, user_id: UserID, account_status: UserAccountStatus
 ) -> None:
     db_user: UserModel | None = session.query(UserModel).filter(UserModel.id == user_id).first()
     if db_user:
@@ -60,8 +54,9 @@ def update_user_verified(session: Session, user_id: UserID, verified: bool) -> N
 
 
 def get_user_by_verification_token(session: Session, verification_token: str) -> User | None:
-    db_user: UserModel | None = session.query(UserModel)\
-        .filter(UserModel.verification_token == verification_token).first()
+    db_user: UserModel | None = (
+        session.query(UserModel).filter(UserModel.verification_token == verification_token).first()
+    )
     if db_user is None:
         return None
     else:
@@ -69,9 +64,7 @@ def get_user_by_verification_token(session: Session, verification_token: str) ->
 
 
 def update_user_verification_token(
-        session: Session,
-        user_id: UserID,
-        verification_token: str | None
+    session: Session, user_id: UserID, verification_token: str | None
 ) -> None:
     db_user: UserModel | None = session.query(UserModel).filter(UserModel.id == user_id).first()
     if db_user:

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -7,7 +7,7 @@ from sqlalchemy import (
     JSON,
     LargeBinary,
     PrimaryKeyConstraint,
-    String
+    String,
 )
 from sqlalchemy.ext.declarative import declarative_base
 import uuid
@@ -16,7 +16,7 @@ from src.common.schemas.riot_data_schemas import GameState, PlayerRole, MatchSta
 from src.common.schemas.fantasy_schemas import (
     FantasyLeagueStatus,
     FantasyLeagueMembershipStatus,
-    UserAccountStatus
+    UserAccountStatus,
 )
 
 
@@ -103,9 +103,7 @@ class ProfessionalPlayerModel(Base):  # type: ignore
     image = Column(String)
     role = Column(Enum(PlayerRole), nullable=False)
 
-    __table_args__ = (
-        PrimaryKeyConstraint('id', 'team_id'),
-    )
+    __table_args__ = (PrimaryKeyConstraint("id", "team_id"),)
 
 
 class PlayerGameMetadataModel(Base):  # type: ignore
@@ -117,9 +115,7 @@ class PlayerGameMetadataModel(Base):  # type: ignore
     champion_id = Column(String)
     role = Column(Enum(PlayerRole), nullable=False)
 
-    __table_args__ = (
-        PrimaryKeyConstraint('game_id', 'player_id'),
-    )
+    __table_args__ = (PrimaryKeyConstraint("game_id", "player_id"),)
 
 
 class PlayerGameStatsModel(Base):  # type: ignore
@@ -137,9 +133,7 @@ class PlayerGameStatsModel(Base):  # type: ignore
     wards_placed = Column(Integer)
     wards_destroyed = Column(Integer)
 
-    __table_args__ = (
-        PrimaryKeyConstraint('game_id', 'participant_id'),
-    )
+    __table_args__ = (PrimaryKeyConstraint("game_id", "participant_id"),)
 
 
 class TeamGameStatsModel(Base):
@@ -153,9 +147,7 @@ class TeamGameStatsModel(Base):
     barons = Column(Integer)
     total_kills = Column(Integer)
 
-    __table_args__ = (
-        PrimaryKeyConstraint('game_id', 'team_id'),
-    )
+    __table_args__ = (PrimaryKeyConstraint("game_id", "team_id"),)
 
 
 class ScheduleModel(Base):  # type: ignore
@@ -172,8 +164,9 @@ class ScheduleModel(Base):  # type: ignore
 class UserModel(Base):  # type: ignore
     __tablename__ = "users"
 
-    id = Column(String, primary_key=True, default=lambda: str(uuid.uuid4()),
-                unique=True, nullable=False)
+    id = Column(
+        String, primary_key=True, default=lambda: str(uuid.uuid4()), unique=True, nullable=False
+    )
     username = Column(String, unique=True, nullable=False)
     email = Column(String, unique=True, nullable=False)
     password = Column(LargeBinary, nullable=False)
@@ -183,10 +176,10 @@ class UserModel(Base):  # type: ignore
     verification_token = Column(String)
 
     def set_permissions(self, permissions_list):
-        self.permissions = ','.join(permissions_list)
+        self.permissions = ",".join(permissions_list)
 
     def get_permissions(self):
-        return self.permissions.split(',') if self.permissions else []
+        return self.permissions.split(",") if self.permissions else []
 
 
 class FantasyLeagueModel(Base):  # type: ignore
@@ -209,9 +202,7 @@ class FantasyLeagueMembershipModel(Base):  # type: ignore
     user_id = Column(String, primary_key=True, nullable=False)
     status = Column(Enum(FantasyLeagueMembershipStatus), nullable=False)
 
-    __table_args__ = (
-        PrimaryKeyConstraint('league_id', 'user_id'),
-    )
+    __table_args__ = (PrimaryKeyConstraint("league_id", "user_id"),)
 
 
 class FantasyLeagueScoringSettingModel(Base):  # type: ignore
@@ -235,9 +226,7 @@ class FantasyLeagueDraftOrderModel(Base):  # type: ignore
     user_id = Column(String, primary_key=True, nullable=False)
     position = Column(Integer, nullable=False)
 
-    __table_args__ = (
-        PrimaryKeyConstraint('fantasy_league_id', 'user_id'),
-    )
+    __table_args__ = (PrimaryKeyConstraint("fantasy_league_id", "user_id"),)
 
 
 class FantasyTeamModel(Base):  # type: ignore
@@ -252,6 +241,4 @@ class FantasyTeamModel(Base):  # type: ignore
     adc_player_id = Column(String, nullable=True)
     support_player_id = Column(String, nullable=True)
 
-    __table_args__ = (
-        PrimaryKeyConstraint('fantasy_league_id', 'user_id', 'week'),
-    )
+    __table_args__ = (PrimaryKeyConstraint("fantasy_league_id", "user_id", "week"),)

--- a/src/db/riot_dao/game_dao.py
+++ b/src/db/riot_dao/game_dao.py
@@ -41,9 +41,9 @@ def update_game_last_stats_fetch(session, game_id: RiotGameID, last_fetch: bool)
 
 
 def get_games_with_last_stats_fetch(session, last_stats_fetch: bool) -> list[Game]:
-    game_models = session.query(GameModel).filter(
-        GameModel.last_stats_fetch == last_stats_fetch
-    ).all()
+    game_models = (
+        session.query(GameModel).filter(GameModel.last_stats_fetch == last_stats_fetch).all()
+    )
     return [Game.model_validate(game_model) for game_model in game_models]
 
 
@@ -73,9 +73,7 @@ def get_games_to_check_state(session) -> list[RiotGameID]:
 
 
 def get_game_by_id(session, game_id: RiotGameID) -> Game | None:
-    game_model: GameModel | None = session.query(GameModel).filter(
-        GameModel.id == game_id
-    ).first()
+    game_model: GameModel | None = session.query(GameModel).filter(GameModel.id == game_id).first()
     if game_model is None:
         return None
     else:

--- a/src/db/riot_dao/match_dao.py
+++ b/src/db/riot_dao/match_dao.py
@@ -22,9 +22,9 @@ def get_matches(session, filters: list | None = None) -> list[Match]:
 
 
 def get_match_by_id(session, match_id: RiotMatchID) -> Match | None:
-    db_match: MatchModel | None = session.query(MatchModel).filter(
-        MatchModel.id == match_id
-    ).first()
+    db_match: MatchModel | None = (
+        session.query(MatchModel).filter(MatchModel.id == match_id).first()
+    )
     if db_match is None:
         return None
     else:
@@ -45,10 +45,10 @@ def get_match_ids_without_games(session) -> list[RiotMatchID]:
 
 
 def update_match_has_games(session, match_id: RiotMatchID, new_has_games: bool) -> None:
-    db_match: MatchModel | None = (session.query(MatchModel)
-                                   .filter(MatchModel.id == match_id)
-                                   .first())
-    assert (db_match is not None)
+    db_match: MatchModel | None = (
+        session.query(MatchModel).filter(MatchModel.id == match_id).first()
+    )
+    assert db_match is not None
     db_match.has_games = new_has_games
     session.merge(db_match)
     session.commit()
@@ -62,11 +62,11 @@ def get_matches_for_league_with_active_tournament(session, league_id: RiotLeague
         .where(
             LeagueModel.id == league_id,
             func.current_date().between(
-                cast(TournamentModel.start_date, Date),
-                cast(TournamentModel.end_date, Date)
+                cast(TournamentModel.start_date, Date), cast(TournamentModel.end_date, Date)
             ),
-            func.substr(MatchModel.start_time, 1, 10)
-            .between(TournamentModel.start_date, TournamentModel.end_date)
+            func.substr(MatchModel.start_time, 1, 10).between(
+                TournamentModel.start_date, TournamentModel.end_date
+            ),
         )
     )
 
@@ -77,18 +77,16 @@ def get_matches_for_league_with_active_tournament(session, league_id: RiotLeague
 
 
 def get_miss_data_matches(session) -> list[Match]:
-    match_models = session.execute(
-        select(MatchModel).where(
-            or_(
+    match_models = (
+        session.execute(
+            select(MatchModel).where(
                 or_(
-                    MatchModel.team_1_name == "TBD",
-                    MatchModel.team_2_name == "TBD"
-                ),
-                or_(
-                    MatchModel.state == "UNSTARTED",
-                    MatchModel.state == "INPROGRESS"
+                    or_(MatchModel.team_1_name == "TBD", MatchModel.team_2_name == "TBD"),
+                    or_(MatchModel.state == "UNSTARTED", MatchModel.state == "INPROGRESS"),
                 )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     return [Match.model_validate(match_model) for match_model in match_models]

--- a/src/db/riot_dao/player_dao.py
+++ b/src/db/riot_dao/player_dao.py
@@ -19,9 +19,11 @@ def get_players(session, filters: list | None = None) -> list[ProfessionalPlayer
 
 
 def get_player_by_id(session, player_id: ProPlayerID) -> ProfessionalPlayer | None:
-    db_player: ProfessionalPlayerModel | None = session.query(ProfessionalPlayerModel)\
-        .filter(ProfessionalPlayerModel.id == player_id)\
+    db_player: ProfessionalPlayerModel | None = (
+        session.query(ProfessionalPlayerModel)
+        .filter(ProfessionalPlayerModel.id == player_id)
         .first()
+    )
     if db_player is None:
         return None
     else:

--- a/src/db/riot_dao/player_metadata_dao.py
+++ b/src/db/riot_dao/player_metadata_dao.py
@@ -11,11 +11,16 @@ def put_player_metadata(session, player_metadata: PlayerGameMetadata) -> None:
 
 
 def get_player_metadata(
-        session, player_id: ProPlayerID, game_id: RiotGameID
+    session, player_id: ProPlayerID, game_id: RiotGameID
 ) -> PlayerGameMetadata | None:
-    db_player_metadata: PlayerGameMetadataModel | None = session.query(PlayerGameMetadataModel)\
-        .filter(PlayerGameMetadataModel.player_id == player_id,
-                PlayerGameMetadataModel.game_id == game_id).first()
+    db_player_metadata: PlayerGameMetadataModel | None = (
+        session.query(PlayerGameMetadataModel)
+        .filter(
+            PlayerGameMetadataModel.player_id == player_id,
+            PlayerGameMetadataModel.game_id == game_id,
+        )
+        .first()
+    )
     if db_player_metadata is None:
         return None
     else:

--- a/src/db/riot_dao/player_stats_dao.py
+++ b/src/db/riot_dao/player_stats_dao.py
@@ -11,14 +11,15 @@ def put_player_stats(session, player_stats: PlayerGameStats) -> None:
     session.commit()
 
 
-def get_player_stats(
-        session,
-        game_id: RiotGameID,
-        participant_id: int
-) -> PlayerGameStats | None:
-    db_player_game_stats: PlayerGameStatsModel | None = session.query(PlayerGameStatsModel)\
-        .filter(PlayerGameStatsModel.game_id == game_id,
-                PlayerGameStatsModel.participant_id == participant_id).first()
+def get_player_stats(session, game_id: RiotGameID, participant_id: int) -> PlayerGameStats | None:
+    db_player_game_stats: PlayerGameStatsModel | None = (
+        session.query(PlayerGameStatsModel)
+        .filter(
+            PlayerGameStatsModel.game_id == game_id,
+            PlayerGameStatsModel.participant_id == participant_id,
+        )
+        .first()
+    )
     if db_player_game_stats is None:
         return None
     else:
@@ -49,6 +50,8 @@ def get_player_game_stats(session, filters: list | None = None) -> list[PlayerGa
         query = session.query(PlayerGameView)
 
     db_player_game_stat: list[PlayerGameView] = query.all()
-    player_game_data = [PlayerGameData.model_validate(db_player_game_stat)
-                        for db_player_game_stat in db_player_game_stat]
+    player_game_data = [
+        PlayerGameData.model_validate(db_player_game_stat)
+        for db_player_game_stat in db_player_game_stat
+    ]
     return player_game_data

--- a/src/db/riot_dao/riot_league_dao.py
+++ b/src/db/riot_dao/riot_league_dao.py
@@ -1,10 +1,6 @@
 from sqlalchemy import text
 
-from src.common.schemas.riot_data_schemas import (
-    League,
-    RiotLeagueID,
-    ProPlayerID
-)
+from src.common.schemas.riot_data_schemas import League, RiotLeagueID, ProPlayerID
 from src.db.models import LeagueModel
 
 
@@ -26,9 +22,9 @@ def get_leagues(session, filters: list | None = None) -> list[League]:
 
 
 def get_league_by_id(session, league_id: RiotLeagueID) -> League | None:
-    db_league: LeagueModel | None = session.query(LeagueModel)\
-        .filter(LeagueModel.id == league_id)\
-        .first()
+    db_league: LeagueModel | None = (
+        session.query(LeagueModel).filter(LeagueModel.id == league_id).first()
+    )
     if db_league is None:
         return None
     else:
@@ -36,11 +32,11 @@ def get_league_by_id(session, league_id: RiotLeagueID) -> League | None:
 
 
 def update_league_fantasy_available_status(
-        session, league_id: RiotLeagueID, new_status: bool
+    session, league_id: RiotLeagueID, new_status: bool
 ) -> League | None:
-    db_league: LeagueModel | None = session.query(LeagueModel)\
-        .filter(LeagueModel.id == league_id)\
-        .first()
+    db_league: LeagueModel | None = (
+        session.query(LeagueModel).filter(LeagueModel.id == league_id).first()
+    )
 
     if db_league is None:
         return None

--- a/src/db/riot_dao/schedule_dao.py
+++ b/src/db/riot_dao/schedule_dao.py
@@ -3,9 +3,9 @@ from src.db.models import ScheduleModel
 
 
 def get_schedule(session, schedule_name: str) -> StoredSchedule | None:
-    db_schedule: ScheduleModel | None = session.query(ScheduleModel)\
-        .filter(ScheduleModel.schedule_name == schedule_name)\
-        .first()
+    db_schedule: ScheduleModel | None = (
+        session.query(ScheduleModel).filter(ScheduleModel.schedule_name == schedule_name).first()
+    )
     if db_schedule is None:
         return None
     else:

--- a/src/db/riot_dao/team_dao.py
+++ b/src/db/riot_dao/team_dao.py
@@ -20,9 +20,9 @@ def get_teams(session, filters: list | None = None) -> list[ProfessionalTeam]:
 
 
 def get_team_by_id(session, team_id: ProTeamID) -> ProfessionalTeam | None:
-    db_team: ProfessionalTeamModel | None = session.query(ProfessionalTeamModel)\
-        .filter(ProfessionalTeamModel.id == team_id)\
-        .first()
+    db_team: ProfessionalTeamModel | None = (
+        session.query(ProfessionalTeamModel).filter(ProfessionalTeamModel.id == team_id).first()
+    )
     if db_team is None:
         return None
     else:

--- a/src/db/riot_dao/tournament_dao.py
+++ b/src/db/riot_dao/tournament_dao.py
@@ -14,17 +14,14 @@ def get_tournaments(session, filters: list) -> list[Tournament]:
     else:
         query = session.query(TournamentModel)
     db_tournaments: list[TournamentModel] = query.all()
-    tournaments = [
-        Tournament.model_validate(db_tournament)
-        for db_tournament in db_tournaments
-    ]
+    tournaments = [Tournament.model_validate(db_tournament) for db_tournament in db_tournaments]
     return tournaments
 
 
 def get_tournament_by_id(session, tournament_id: RiotTournamentID) -> Tournament | None:
-    db_tournament: TournamentModel | None = session.query(TournamentModel)\
-        .filter(TournamentModel.id == tournament_id)\
-        .first()
+    db_tournament: TournamentModel | None = (
+        session.query(TournamentModel).filter(TournamentModel.id == tournament_id).first()
+    )
     if db_tournament is None:
         return None
     else:

--- a/src/db/views.py
+++ b/src/db/views.py
@@ -24,9 +24,7 @@ class PlayerGameView(Base):  # type: ignore
     wards_placed = Column(Integer)
     wards_destroyed = Column(Integer)
 
-    __table_args__ = (
-        PrimaryKeyConstraint('game_id', 'player_id'),
-    )
+    __table_args__ = (PrimaryKeyConstraint("game_id", "player_id"),)
 
 
 create_player_game_view_query = text("""

--- a/src/fantasy/app.py
+++ b/src/fantasy/app.py
@@ -4,21 +4,12 @@ import sys
 from src.db import DatabaseConnectionProvider, DatabaseService
 from src.common.config import app_config
 from src.fantasy import app
-from src.fantasy.service import (
-    FantasyLeagueService,
-    FantasyTeamService,
-    UserService
-)
-from src.fantasy.endpoints import (
-    FantasyLeagueEndpoint,
-    FantasyTeamEndpoint,
-    UserEndpointV1
-)
+from src.fantasy.service import FantasyLeagueService, FantasyTeamService, UserService
+from src.fantasy.endpoints import FantasyLeagueEndpoint, FantasyTeamEndpoint, UserEndpointV1
 from src.common.logger import configure_logger
 
 
 def main():
-
     configure_logger("fantasy-lol")
 
     # Create database service

--- a/src/fantasy/endpoints/fantasy_league_endpoint_v1.py
+++ b/src/fantasy/endpoints/fantasy_league_endpoint_v1.py
@@ -9,7 +9,7 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueScoringSettings,
     UsersFantasyLeagues,
     FantasyLeagueDraftOrderResponse,
-    UserID
+    UserID,
 )
 from src.fantasy.service import FantasyLeagueService
 
@@ -24,11 +24,10 @@ class FantasyLeagueEndpoint(Routable):
         description="Get a list of Fantasy Leagues the calling user belongs to",
         tags=["Fantasy Leagues"],
         dependencies=[Depends(JWTBearer([Permissions.FANTASY_READ]))],
-        response_model=UsersFantasyLeagues
+        response_model=UsersFantasyLeagues,
     )
     def get_my_fantasy_leagues(
-            self,
-            decoded_token: dict = Depends(JWTBearer())
+        self, decoded_token: dict = Depends(JWTBearer())
     ) -> UsersFantasyLeagues:
         user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_league_service.get_users_pending_and_accepted_fantasy_leagues(user_id)
@@ -38,12 +37,12 @@ class FantasyLeagueEndpoint(Routable):
         description="Create a Fantasy League",
         tags=["Fantasy Leagues"],
         dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
-        response_model=FantasyLeague
+        response_model=FantasyLeague,
     )
     def create_fantasy_league(
-            self,
-            decoded_token: dict = Depends(JWTBearer()),
-            fantasy_league: FantasyLeagueSettings = Body(...)
+        self,
+        decoded_token: dict = Depends(JWTBearer()),
+        fantasy_league: FantasyLeagueSettings = Body(...),
     ) -> FantasyLeague:
         owner_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_league_service.create_fantasy_league(owner_id, fantasy_league)
@@ -51,52 +50,48 @@ class FantasyLeagueEndpoint(Routable):
     @get(
         path="/leagues/{fantasy_league_id}/settings",
         description="Get the settings for a given Fantasy League. "
-                    "The caller must be the owner of the Fantasy League.",
+        "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
         dependencies=[Depends(JWTBearer([Permissions.FANTASY_READ]))],
-        response_model=FantasyLeagueSettings
+        response_model=FantasyLeagueSettings,
     )
     def get_fantasy_league_settings(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            decoded_token: dict = Depends(JWTBearer())
+        self, fantasy_league_id: FantasyLeagueID, decoded_token: dict = Depends(JWTBearer())
     ) -> FantasyLeagueSettings:
         owner_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_league_service.get_fantasy_league_settings(
-            owner_id,
-            fantasy_league_id
+            owner_id, fantasy_league_id
         )
 
     @put(
         path="/leagues/{fantasy_league_id}/settings",
         description="Update the settings for a given Fantasy League. "
-                    "The caller must be the owner of the Fantasy League.",
+        "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
         dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
-        response_model=FantasyLeagueSettings
+        response_model=FantasyLeagueSettings,
     )
     def update_fantasy_league_settings(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            fantasy_league_settings: FantasyLeagueSettings = Body(...),
-            decoded_token: dict = Depends(JWTBearer())
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        fantasy_league_settings: FantasyLeagueSettings = Body(...),
+        decoded_token: dict = Depends(JWTBearer()),
     ) -> FantasyLeagueSettings:
         owner_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_league_service.update_fantasy_league_settings(
-            owner_id, fantasy_league_id, fantasy_league_settings)
+            owner_id, fantasy_league_id, fantasy_league_settings
+        )
 
     @get(
         path="/leagues/{fantasy_league_id}/scoring",
         description="Get the scoring settings for a given Fantasy League. "
-                    "The caller must be the owner of the Fantasy League.",
+        "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
         dependencies=[Depends(JWTBearer([Permissions.FANTASY_READ]))],
-        response_model=FantasyLeagueScoringSettings
+        response_model=FantasyLeagueScoringSettings,
     )
     def get_fantasy_league_scoring_settings(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            decoded_token: dict = Depends(JWTBearer())
+        self, fantasy_league_id: FantasyLeagueID, decoded_token: dict = Depends(JWTBearer())
     ) -> FantasyLeagueScoringSettings:
         owner_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_league_service.get_scoring_settings(owner_id, fantasy_league_id)
@@ -104,16 +99,16 @@ class FantasyLeagueEndpoint(Routable):
     @put(
         path="/leagues/{fantasy_league_id}/scoring",
         description="Update the scoring settings for a given Fantasy League. "
-                    "The caller must be the owner of the Fantasy League.",
+        "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
         dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
-        response_model=FantasyLeagueScoringSettings
+        response_model=FantasyLeagueScoringSettings,
     )
     def update_fantasy_league_scoring_settings(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            scoring_settings: FantasyLeagueScoringSettings = Body(...),
-            decoded_token: dict = Depends(JWTBearer())
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        scoring_settings: FantasyLeagueScoringSettings = Body(...),
+        decoded_token: dict = Depends(JWTBearer()),
     ) -> FantasyLeagueScoringSettings:
         user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_league_service.update_scoring_settings(
@@ -123,33 +118,29 @@ class FantasyLeagueEndpoint(Routable):
     @post(
         path="/leagues/{fantasy_league_id}/invite/{username}",
         description="Invite a user to the given Fantasy League. "
-                    "The caller must be the owner of the Fantasy League.",
+        "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))]
+        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
     )
     def send_invite_user_to_fantasy_league(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            username: str,
-            decoded_token: dict = Depends(JWTBearer())
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        username: str,
+        decoded_token: dict = Depends(JWTBearer()),
     ) -> None:
         owner_id = UserID(decoded_token.get("user_id"))  # type: ignore
         self.__fantasy_league_service.send_fantasy_league_invite(
-            owner_id,
-            fantasy_league_id,
-            username
+            owner_id, fantasy_league_id, username
         )
 
     @post(
         path="/leagues/{fantasy_league_id}/join",
         description="Join a Fantasy League the calling user has a pending invitation for",
         tags=["Fantasy Leagues"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))]
+        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
     )
     def join_fantasy_league(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            decoded_token: dict = Depends(JWTBearer())
+        self, fantasy_league_id: FantasyLeagueID, decoded_token: dict = Depends(JWTBearer())
     ) -> None:
         user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         self.__fantasy_league_service.join_fantasy_league(user_id, fantasy_league_id)
@@ -158,12 +149,10 @@ class FantasyLeagueEndpoint(Routable):
         path="/leagues/{fantasy_league_id}/leave",
         description="Leave the given Fantasy League.",
         tags=["Fantasy Leagues"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))]
+        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
     )
     def leave_fantasy_league(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            decoded_token: dict = Depends(JWTBearer())
+        self, fantasy_league_id: FantasyLeagueID, decoded_token: dict = Depends(JWTBearer())
     ) -> None:
         user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         self.__fantasy_league_service.leave_fantasy_league(user_id, fantasy_league_id)
@@ -171,59 +160,52 @@ class FantasyLeagueEndpoint(Routable):
     @post(
         path="/leagues/{fantasy_league_id}/revoke/{user_id_to_revoke}",
         description="Revoke a membership of an active member within the Fantasy League. "
-                    "The caller must be the owner of the Fantasy League.",
+        "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
         status_code=204,
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))]
+        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
     )
     def revoke_from_fantasy_league(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            user_id_to_revoke: UserID,
-            decoded_token: dict = Depends(JWTBearer())
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        user_id_to_revoke: UserID,
+        decoded_token: dict = Depends(JWTBearer()),
     ) -> None:
         user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         self.__fantasy_league_service.revoke_from_fantasy_league(
-            fantasy_league_id,
-            user_id,
-            user_id_to_revoke
+            fantasy_league_id, user_id, user_id_to_revoke
         )
 
     @get(
         path="/leagues/{fantasy_league_id}/draft-order",
         description="Get draft order of the Fantasy League. "
-                    "The caller must be the owner of the Fantasy League.",
+        "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
         response_model=list[FantasyLeagueDraftOrderResponse],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_READ]))]
+        dependencies=[Depends(JWTBearer([Permissions.FANTASY_READ]))],
     )
     def get_fantasy_league_draft_order(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            decoded_token: dict = Depends(JWTBearer())
+        self, fantasy_league_id: FantasyLeagueID, decoded_token: dict = Depends(JWTBearer())
     ) -> list[FantasyLeagueDraftOrderResponse]:
         user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_league_service.get_fantasy_league_draft_order(
-            user_id,
-            fantasy_league_id
+            user_id, fantasy_league_id
         )
 
     @put(
         path="/leagues/{fantasy_league_id}/draft-order",
         description="Update draft order of the Fantasy League. "
-                    "The caller must be the owner of the Fantasy League.",
+        "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))]
+        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
     )
     def update_fantasy_league_draft_order(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            decoded_token: dict = Depends(JWTBearer()),
-            updated_draft_order: list[FantasyLeagueDraftOrderResponse] = Body(...)
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        decoded_token: dict = Depends(JWTBearer()),
+        updated_draft_order: list[FantasyLeagueDraftOrderResponse] = Body(...),
     ) -> None:
         user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         self.__fantasy_league_service.update_fantasy_league_draft_order(
-            user_id,
-            fantasy_league_id,
-            updated_draft_order
+            user_id, fantasy_league_id, updated_draft_order
         )

--- a/src/fantasy/endpoints/fantasy_team_endpoint_v1.py
+++ b/src/fantasy/endpoints/fantasy_team_endpoint_v1.py
@@ -17,12 +17,10 @@ class FantasyTeamEndpoint(Routable):
         description="Get all of the callers teams by week for a Fantasy League.",
         tags=["Fantasy Teams"],
         dependencies=[Depends(JWTBearer([Permissions.FANTASY_READ]))],
-        response_model=list[FantasyTeam]
+        response_model=list[FantasyTeam],
     )
     def get_fantasy_team_weeks_for_league(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            decoded_token: dict = Depends(JWTBearer())
+        self, fantasy_league_id: FantasyLeagueID, decoded_token: dict = Depends(JWTBearer())
     ) -> list[FantasyTeam]:
         user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_team_service.get_all_fantasy_team_weeks(fantasy_league_id, user_id)
@@ -32,13 +30,13 @@ class FantasyTeamEndpoint(Routable):
         description="Pickup a player for the current week within a Fantasy League.",
         tags=["Fantasy Teams"],
         dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
-        response_model=FantasyTeam
+        response_model=FantasyTeam,
     )
     def pickup_player(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            player_id: ProPlayerID,
-            decoded_token: dict = Depends(JWTBearer())
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        player_id: ProPlayerID,
+        decoded_token: dict = Depends(JWTBearer()),
     ) -> FantasyTeam:
         user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_team_service.pickup_player(fantasy_league_id, user_id, player_id)
@@ -48,13 +46,13 @@ class FantasyTeamEndpoint(Routable):
         description="Drop a player for the current week within a Fantasy League.",
         tags=["Fantasy Teams"],
         dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
-        response_model=FantasyTeam
+        response_model=FantasyTeam,
     )
     def drop_player(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            player_id: ProPlayerID,
-            decoded_token: dict = Depends(JWTBearer())
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        player_id: ProPlayerID,
+        decoded_token: dict = Depends(JWTBearer()),
     ) -> FantasyTeam:
         user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_team_service.drop_player(fantasy_league_id, user_id, player_id)
@@ -64,19 +62,16 @@ class FantasyTeamEndpoint(Routable):
         description="Swap a player for another player in the current week within a Fantasy League.",
         tags=["Fantasy Teams"],
         dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
-        response_model=FantasyTeam
+        response_model=FantasyTeam,
     )
     def swap_players(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            player_to_drop_id: ProPlayerID,
-            player_to_pickup_id: ProPlayerID,
-            decoded_token: dict = Depends(JWTBearer())
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        player_to_drop_id: ProPlayerID,
+        player_to_pickup_id: ProPlayerID,
+        decoded_token: dict = Depends(JWTBearer()),
     ) -> FantasyTeam:
         user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_team_service.swap_players(
-            fantasy_league_id,
-            user_id,
-            player_to_drop_id,
-            player_to_pickup_id
+            fantasy_league_id, user_id, player_to_drop_id, player_to_pickup_id
         )

--- a/src/fantasy/endpoints/user_endpoint_v1.py
+++ b/src/fantasy/endpoints/user_endpoint_v1.py
@@ -15,12 +15,9 @@ class UserEndpointV1(Routable):
         path="/user/signup",
         description="Signup for Fantasy League of Legends.",
         tags=["Users"],
-        response_model=None
+        response_model=None,
     )
-    def user_signup(
-            self,
-            user: UserCreate = Body(...)
-    ) -> dict:
+    def user_signup(self, user: UserCreate = Body(...)) -> dict:
         response_message = self.__user_service.user_signup(user)
         return {"message": response_message}
 
@@ -28,12 +25,9 @@ class UserEndpointV1(Routable):
         path="/user/login",
         description="Login to a Fantasy League of Legends account.",
         tags=["Users"],
-        response_model=None
+        response_model=None,
     )
-    def user_login(
-            self,
-            credentials: UserLogin = Body(...)
-    ) -> dict:
+    def user_login(self, credentials: UserLogin = Body(...)) -> dict:
         return self.__user_service.login_user(credentials)
 
     @put(
@@ -41,12 +35,9 @@ class UserEndpointV1(Routable):
         description="Delete a Fantasy League of Legends account.",
         tags=["Users"],
         dependencies=[Depends(JWTBearer())],
-        status_code=204
+        status_code=204,
     )
-    def user_delete(
-            self,
-            decoded_token: dict = Depends(JWTBearer())
-    ):
+    def user_delete(self, decoded_token: dict = Depends(JWTBearer())):
         user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         self.__user_service.delete_user(user_id)
 
@@ -54,12 +45,9 @@ class UserEndpointV1(Routable):
         path="/user/verify-email/{token}",
         description="Verify the email of a Fantasy account.",
         tags=["Users"],
-        status_code=202
+        status_code=202,
     )
-    def verify_email(
-            self,
-            token: str
-    ):
+    def verify_email(self, token: str):
         verification_message = self.__user_service.verify_user_email(token)
         return {"message": verification_message}
 
@@ -67,12 +55,9 @@ class UserEndpointV1(Routable):
         path="/user/request-verification-email",
         description="Request a verification email for a Fantasy account.",
         tags=["Users"],
-        status_code=201
+        status_code=201,
     )
-    def request_verification_email(
-            self,
-            request: EmailRequest
-    ):
+    def request_verification_email(self, request: EmailRequest):
         user_email = request.email
         self.__user_service.request_verification_email(user_email)
         return {"message": f"A new verification email has been sent to {user_email} if it exists."}

--- a/src/fantasy/exceptions/__init__.py
+++ b/src/fantasy/exceptions/__init__.py
@@ -1,7 +1,8 @@
 from .draft_order_exception import DraftOrderException  # noqa: F401
 from .fantasy_draft_exception import FantasyDraftException  # noqa: F401
-from .fantasy_league_invalid_required_state_exception import \
-    FantasyLeagueInvalidRequiredStateException  # noqa: F401
+from .fantasy_league_invalid_required_state_exception import (  # noqa: F401
+    FantasyLeagueInvalidRequiredStateException,
+)
 from .fantasy_league_invite_exception import FantasyLeagueInviteException  # noqa: F401
 from .fantasy_league_not_found_exception import FantasyLeagueNotFoundException  # noqa: F401
 from .fantasy_league_settings_exception import FantasyLeagueSettingsException  # noqa: F401

--- a/src/fantasy/exceptions/draft_order_exception.py
+++ b/src/fantasy/exceptions/draft_order_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class DraftOrderException(HTTPException):
     def __init__(self, detail) -> None:
-        super().__init__(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail=detail
-        )
+        super().__init__(status_code=HTTPStatus.BAD_REQUEST, detail=detail)

--- a/src/fantasy/exceptions/fantasy_draft_exception.py
+++ b/src/fantasy/exceptions/fantasy_draft_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class FantasyDraftException(HTTPException):
     def __init__(self, detail: str) -> None:
-        super().__init__(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail=detail
-        )
+        super().__init__(status_code=HTTPStatus.BAD_REQUEST, detail=detail)

--- a/src/fantasy/exceptions/fantasy_league_invalid_required_state_exception.py
+++ b/src/fantasy/exceptions/fantasy_league_invalid_required_state_exception.py
@@ -5,13 +5,15 @@ from ...common.schemas.fantasy_schemas import FantasyLeagueID, FantasyLeagueStat
 
 
 class FantasyLeagueInvalidRequiredStateException(HTTPException):
-    def __init__(self,
-                 fantasy_league_id: FantasyLeagueID,
-                 current_state: FantasyLeagueStatus,
-                 required_states: list[FantasyLeagueStatus]) -> None:
+    def __init__(
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        current_state: FantasyLeagueStatus,
+        required_states: list[FantasyLeagueStatus],
+    ) -> None:
         super().__init__(
             status_code=HTTPStatus.BAD_REQUEST,
             detail=f"Invalid fantasy league state: Fantasy league ({fantasy_league_id}) is"
             f"currently in state {current_state}, but is required to be in "
-            f"one of the required states: {required_states}"
+            f"one of the required states: {required_states}",
         )

--- a/src/fantasy/exceptions/fantasy_league_invite_exception.py
+++ b/src/fantasy/exceptions/fantasy_league_invite_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class FantasyLeagueInviteException(HTTPException):
     def __init__(self, detail: str) -> None:
-        super().__init__(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail=detail
-        )
+        super().__init__(status_code=HTTPStatus.BAD_REQUEST, detail=detail)

--- a/src/fantasy/exceptions/fantasy_league_not_found_exception.py
+++ b/src/fantasy/exceptions/fantasy_league_not_found_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class FantasyLeagueNotFoundException(HTTPException):
     def __init__(self) -> None:
-        super().__init__(
-            status_code=HTTPStatus.NOT_FOUND,
-            detail="Fantasy League not found"
-        )
+        super().__init__(status_code=HTTPStatus.NOT_FOUND, detail="Fantasy League not found")

--- a/src/fantasy/exceptions/fantasy_league_settings_exception.py
+++ b/src/fantasy/exceptions/fantasy_league_settings_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class FantasyLeagueSettingsException(HTTPException):
     def __init__(self, detail: str) -> None:
-        super().__init__(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail=detail
-        )
+        super().__init__(status_code=HTTPStatus.BAD_REQUEST, detail=detail)

--- a/src/fantasy/exceptions/fantasy_league_start_draft_exception.py
+++ b/src/fantasy/exceptions/fantasy_league_start_draft_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class FantasyLeagueStartDraftException(HTTPException):
     def __init__(self, detail: str) -> None:
-        super().__init__(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail=detail
-        )
+        super().__init__(status_code=HTTPStatus.BAD_REQUEST, detail=detail)

--- a/src/fantasy/exceptions/fantasy_membership_exception.py
+++ b/src/fantasy/exceptions/fantasy_membership_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class FantasyMembershipException(HTTPException):
     def __init__(self, detail: str) -> None:
-        super().__init__(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail=detail
-        )
+        super().__init__(status_code=HTTPStatus.BAD_REQUEST, detail=detail)

--- a/src/fantasy/exceptions/fantasy_unavailable_exception.py
+++ b/src/fantasy/exceptions/fantasy_unavailable_exception.py
@@ -7,7 +7,4 @@ from src.common.schemas.riot_data_schemas import RiotLeagueID
 class FantasyUnavailableException(HTTPException):
     def __init__(self, league_id: RiotLeagueID) -> None:
         error_msg = f"Riot league with ID {league_id} not available to be used in Fantasy Leagues"
-        super().__init__(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail=error_msg
-        )
+        super().__init__(status_code=HTTPStatus.BAD_REQUEST, detail=error_msg)

--- a/src/fantasy/exceptions/forbidden_exception.py
+++ b/src/fantasy/exceptions/forbidden_exception.py
@@ -4,6 +4,4 @@ from http import HTTPStatus
 
 class ForbiddenException(HTTPException):
     def __init__(self) -> None:
-        super().__init__(
-            status_code=HTTPStatus.FORBIDDEN
-        )
+        super().__init__(status_code=HTTPStatus.FORBIDDEN)

--- a/src/fantasy/exceptions/invalid_username_password_exception.py
+++ b/src/fantasy/exceptions/invalid_username_password_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class InvalidUsernameOrPasswordException(HTTPException):
     def __init__(self) -> None:
-        super().__init__(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail="Invalid username/password"
-        )
+        super().__init__(status_code=HTTPStatus.BAD_REQUEST, detail="Invalid username/password")

--- a/src/fantasy/exceptions/user_already_exists_exception.py
+++ b/src/fantasy/exceptions/user_already_exists_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class UserAlreadyExistsException(HTTPException):
     def __init__(self, detail: str) -> None:
-        super().__init__(
-            status_code=HTTPStatus.CONFLICT,
-            detail=detail
-        )
+        super().__init__(status_code=HTTPStatus.CONFLICT, detail=detail)

--- a/src/fantasy/exceptions/user_not_found_exception.py
+++ b/src/fantasy/exceptions/user_not_found_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class UserNotFoundException(HTTPException):
     def __init__(self) -> None:
-        super().__init__(
-            status_code=HTTPStatus.NOT_FOUND,
-            detail="User not found"
-        )
+        super().__init__(status_code=HTTPStatus.NOT_FOUND, detail="User not found")

--- a/src/fantasy/exceptions/user_verification_exception.py
+++ b/src/fantasy/exceptions/user_verification_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class UserVerificationException(HTTPException):
     def __init__(self, detail: str) -> None:
-        super().__init__(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail=detail
-        )
+        super().__init__(status_code=HTTPStatus.BAD_REQUEST, detail=detail)

--- a/src/fantasy/service/email_verification_service.py
+++ b/src/fantasy/service/email_verification_service.py
@@ -25,8 +25,8 @@ class EmailVerificationService:
             message.attach(text_part)
 
             with smtplib.SMTP_SSL(
-                    self.verification_config.smtp_host,
-                    self.verification_config.smtp_port) as server:
+                self.verification_config.smtp_host, self.verification_config.smtp_port
+            ) as server:
                 server.login(sender_email, password)
                 server.sendmail(sender_email, user_email, message.as_string())
         except Exception as e:

--- a/src/fantasy/service/fantasy_league_service.py
+++ b/src/fantasy/service/fantasy_league_service.py
@@ -12,7 +12,7 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueScoringSettings,
     FantasyLeagueDraftOrderResponse,
     UserAccountStatus,
-    UserID
+    UserID,
 )
 
 from src.fantasy.exceptions import (
@@ -20,7 +20,7 @@ from src.fantasy.exceptions import (
     FantasyLeagueSettingsException,
     FantasyLeagueStartDraftException,
     ForbiddenException,
-    UserNotFoundException
+    UserNotFoundException,
 )
 
 from src.fantasy.util import FantasyLeagueUtil
@@ -32,9 +32,8 @@ class FantasyLeagueService:
         self.fantasy_league_util = FantasyLeagueUtil(database_service)
 
     def create_fantasy_league(
-            self,
-            owner_id: UserID,
-            league_settings: FantasyLeagueSettings) -> FantasyLeague:
+        self, owner_id: UserID, league_settings: FantasyLeagueSettings
+    ) -> FantasyLeague:
         if len(league_settings.available_leagues) > 0:
             self.fantasy_league_util.validate_available_leagues(league_settings.available_leagues)
 
@@ -45,7 +44,7 @@ class FantasyLeagueService:
             status=FantasyLeagueStatus.PRE_DRAFT,
             name=league_settings.name,
             number_of_teams=league_settings.number_of_teams,
-            available_leagues=league_settings.available_leagues
+            available_leagues=league_settings.available_leagues,
         )
         self.db.create_fantasy_league(new_fantasy_league)
 
@@ -69,9 +68,8 @@ class FantasyLeagueService:
         return new_id
 
     def get_fantasy_league_settings(
-            self,
-            owner_id: UserID,
-            league_id: FantasyLeagueID) -> FantasyLeagueSettings:
+        self, owner_id: UserID, league_id: FantasyLeagueID
+    ) -> FantasyLeagueSettings:
         fantasy_league_model = self.fantasy_league_util.validate_league(league_id)
         if fantasy_league_model.owner_id != owner_id:
             raise ForbiddenException()
@@ -79,15 +77,16 @@ class FantasyLeagueService:
         league_settings = FantasyLeagueSettings(
             name=fantasy_league_model.name,
             number_of_teams=fantasy_league_model.number_of_teams,
-            available_leagues=fantasy_league_model.available_leagues
+            available_leagues=fantasy_league_model.available_leagues,
         )
         return league_settings
 
     def update_fantasy_league_settings(
-            self,
-            owner_id: UserID,
-            league_id: FantasyLeagueID,
-            updated_league_settings: FantasyLeagueSettings) -> FantasyLeagueSettings:
+        self,
+        owner_id: UserID,
+        league_id: FantasyLeagueID,
+        updated_league_settings: FantasyLeagueSettings,
+    ) -> FantasyLeagueSettings:
         fantasy_league_model = self.fantasy_league_util.validate_league(
             league_id, [FantasyLeagueStatus.PRE_DRAFT]
         )
@@ -116,26 +115,26 @@ class FantasyLeagueService:
         updated_fantasy_league_settings = FantasyLeagueSettings(
             name=updated_fantasy_league.name,
             number_of_teams=updated_fantasy_league.number_of_teams,
-            available_leagues=updated_league_settings.available_leagues
+            available_leagues=updated_league_settings.available_leagues,
         )
         return updated_fantasy_league_settings
 
     def get_scoring_settings(
-            self,
-            owner_id: UserID,
-            league_id: FantasyLeagueID) -> FantasyLeagueScoringSettings:
+        self, owner_id: UserID, league_id: FantasyLeagueID
+    ) -> FantasyLeagueScoringSettings:
         fantasy_league_model = self.fantasy_league_util.validate_league(league_id)
         if fantasy_league_model.owner_id != owner_id:
             raise ForbiddenException()
         scoring_settings = self.db.get_fantasy_league_scoring_settings_by_id(league_id)
-        assert (scoring_settings is not None)
+        assert scoring_settings is not None
         return scoring_settings
 
     def update_scoring_settings(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            user_id: UserID,
-            scoring_settings: FantasyLeagueScoringSettings) -> FantasyLeagueScoringSettings:
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        user_id: UserID,
+        scoring_settings: FantasyLeagueScoringSettings,
+    ) -> FantasyLeagueScoringSettings:
         fantasy_league = self.fantasy_league_util.validate_league(
             fantasy_league_id, [FantasyLeagueStatus.PRE_DRAFT]
         )
@@ -148,7 +147,7 @@ class FantasyLeagueService:
         return scoring_settings
 
     def get_users_pending_and_accepted_fantasy_leagues(
-            self, user_id: UserID
+        self, user_id: UserID
     ) -> UsersFantasyLeagues:
         pending_fantasy_leagues = self.db.get_users_fantasy_leagues_with_membership_status(
             user_id, FantasyLeagueMembershipStatus.PENDING
@@ -157,13 +156,12 @@ class FantasyLeagueService:
             user_id, FantasyLeagueMembershipStatus.ACCEPTED
         )
         users_fantasy_leagues = UsersFantasyLeagues(
-            pending=pending_fantasy_leagues,
-            accepted=accepted_fantasy_leagues
+            pending=pending_fantasy_leagues, accepted=accepted_fantasy_leagues
         )
         return users_fantasy_leagues
 
     def send_fantasy_league_invite(
-            self, owner_id: UserID, league_id: FantasyLeagueID, username: str
+        self, owner_id: UserID, league_id: FantasyLeagueID, username: str
     ) -> None:
         fantasy_league_model = self.fantasy_league_util.validate_league(
             league_id, [FantasyLeagueStatus.PRE_DRAFT]
@@ -197,13 +195,17 @@ class FantasyLeagueService:
             if membership.user_id == user_id:
                 user_membership = membership
 
-        if (user_membership is None
-                or user_membership.status == FantasyLeagueMembershipStatus.DECLINED
-                or user_membership.status == FantasyLeagueMembershipStatus.REVOKED):
+        if (
+            user_membership is None
+            or user_membership.status == FantasyLeagueMembershipStatus.DECLINED
+            or user_membership.status == FantasyLeagueMembershipStatus.REVOKED
+        ):
             raise FantasyLeagueInviteException(f"No pending invites to join league: {league_id}")
 
-        if (user_membership.status == FantasyLeagueMembershipStatus.PENDING
-                and fantasy_league_model.number_of_teams < accepted_member_count + 1):
+        if (
+            user_membership.status == FantasyLeagueMembershipStatus.PENDING
+            and fantasy_league_model.number_of_teams < accepted_member_count + 1
+        ):
             raise FantasyLeagueInviteException("Fantasy league is full")
 
         self.db.update_fantasy_league_membership_status(
@@ -229,10 +231,8 @@ class FantasyLeagueService:
             raise FantasyLeagueInviteException(f"You are not a member of the league: {league_id}")
 
     def revoke_from_fantasy_league(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            user_id: UserID,
-            user_to_remove_id: UserID) -> None:
+        self, fantasy_league_id: FantasyLeagueID, user_id: UserID, user_to_remove_id: UserID
+    ) -> None:
         fantasy_league = self.fantasy_league_util.validate_league(
             fantasy_league_id, [FantasyLeagueStatus.PRE_DRAFT]
         )
@@ -247,8 +247,10 @@ class FantasyLeagueService:
         user_to_remove_membership = self.db.get_user_membership_for_fantasy_league(
             user_to_remove_id, fantasy_league_id
         )
-        if user_to_remove_membership is None or \
-                user_to_remove_membership.status != FantasyLeagueMembershipStatus.ACCEPTED:
+        if (
+            user_to_remove_membership is None
+            or user_to_remove_membership.status != FantasyLeagueMembershipStatus.ACCEPTED
+        ):
             raise FantasyLeagueInviteException(
                 f"No accepted membership: User {user_to_remove_id} does not have an accepted "
                 f"membership to the fantasy league {fantasy_league_id}"
@@ -258,12 +260,12 @@ class FantasyLeagueService:
             user_to_remove_membership, FantasyLeagueMembershipStatus.REVOKED
         )
         self.fantasy_league_util.update_draft_order_on_player_leave(
-            user_to_remove_id, fantasy_league_id)
+            user_to_remove_id, fantasy_league_id
+        )
 
     def get_fantasy_league_draft_order(
-            self,
-            user_id: UserID,
-            league_id: FantasyLeagueID) -> list[FantasyLeagueDraftOrderResponse]:
+        self, user_id: UserID, league_id: FantasyLeagueID
+    ) -> list[FantasyLeagueDraftOrderResponse]:
         fantasy_league_model = self.fantasy_league_util.validate_league(league_id)
         if fantasy_league_model.owner_id != user_id:
             raise ForbiddenException()
@@ -281,10 +283,11 @@ class FantasyLeagueService:
         return draft_order_response
 
     def update_fantasy_league_draft_order(
-            self,
-            user_id: UserID,
-            league_id: FantasyLeagueID,
-            updated_draft_order: list[FantasyLeagueDraftOrderResponse]) -> None:
+        self,
+        user_id: UserID,
+        league_id: FantasyLeagueID,
+        updated_draft_order: list[FantasyLeagueDraftOrderResponse],
+    ) -> None:
         fantasy_league_model = self.fantasy_league_util.validate_league(
             league_id, [FantasyLeagueStatus.PRE_DRAFT]
         )
@@ -295,10 +298,13 @@ class FantasyLeagueService:
         self.fantasy_league_util.validate_draft_order(current_draft_order, updated_draft_order)
 
         for updated_position in updated_draft_order:
-            db_draft_position = next((
-                db_model
-                for db_model in current_draft_order
-                if db_model.user_id == updated_position.user_id), None
+            db_draft_position = next(
+                (
+                    db_model
+                    for db_model in current_draft_order
+                    if db_model.user_id == updated_position.user_id
+                ),
+                None,
             )
             if db_draft_position is None:
                 # This should never be hit if validation succeeds
@@ -339,13 +345,9 @@ class FantasyLeagueService:
         self.db.update_fantasy_league_current_draft_position(fantasy_league_id, 1)
 
     def create_fantasy_league_membership(
-            self,
-            league_id: FantasyLeagueID,
-            user_id: UserID,
-            status: FantasyLeagueMembershipStatus) -> None:
+        self, league_id: FantasyLeagueID, user_id: UserID, status: FantasyLeagueMembershipStatus
+    ) -> None:
         fantasy_league_membership = FantasyLeagueMembership(
-            league_id=league_id,
-            user_id=user_id,
-            status=status
+            league_id=league_id, user_id=user_id, status=status
         )
         self.db.create_fantasy_league_membership(fantasy_league_membership)

--- a/src/fantasy/service/fantasy_team_service.py
+++ b/src/fantasy/service/fantasy_team_service.py
@@ -6,10 +6,11 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueStatus,
     FantasyLeagueMembershipStatus,
     FantasyTeam,
-    UserID
+    UserID,
 )
-from src.common.exceptions.professional_player_not_found_exception import \
-    ProfessionalPlayerNotFoundException
+from src.common.exceptions.professional_player_not_found_exception import (
+    ProfessionalPlayerNotFoundException,
+)
 from src.fantasy.exceptions import FantasyMembershipException, FantasyDraftException
 from src.fantasy.util import FantasyTeamUtil, FantasyLeagueUtil
 
@@ -21,13 +22,11 @@ class FantasyTeamService:
         self.fantasy_team_util = FantasyTeamUtil(database_service)
 
     def get_all_fantasy_team_weeks(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            user_id: UserID
+        self, fantasy_league_id: FantasyLeagueID, user_id: UserID
     ) -> list[FantasyTeam]:
         self.fantasy_league_util.validate_league(
             fantasy_league_id,
-            [FantasyLeagueStatus.DRAFT, FantasyLeagueStatus.ACTIVE, FantasyLeagueStatus.COMPLETED]
+            [FantasyLeagueStatus.DRAFT, FantasyLeagueStatus.ACTIVE, FantasyLeagueStatus.COMPLETED],
         )
         self.validate_user_membership(user_id, fantasy_league_id)
 
@@ -37,10 +36,7 @@ class FantasyTeamService:
         return fantasy_team_weeks
 
     def pickup_player(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            user_id: UserID,
-            player_id: ProPlayerID
+        self, fantasy_league_id: FantasyLeagueID, user_id: UserID, player_id: ProPlayerID
     ) -> FantasyTeam:
         fantasy_league = self.fantasy_league_util.validate_league(
             fantasy_league_id, [FantasyLeagueStatus.DRAFT, FantasyLeagueStatus.ACTIVE]
@@ -49,8 +45,9 @@ class FantasyTeamService:
         self.fantasy_team_util.validate_player_from_available_league(fantasy_league, player_id)
         self.validate_user_membership(user_id, fantasy_league_id)
 
-        if (fantasy_league.status == FantasyLeagueStatus.DRAFT) \
-                and not self.fantasy_team_util.is_users_position_to_draft(fantasy_league, user_id):
+        if (
+            fantasy_league.status == FantasyLeagueStatus.DRAFT
+        ) and not self.fantasy_team_util.is_users_position_to_draft(fantasy_league, user_id):
             raise FantasyDraftException(
                 f"Invalid user draft position: The draft position for the user "
                 f"with ID {user_id} is not the current draft position for fantasy league "
@@ -62,9 +59,7 @@ class FantasyTeamService:
             raise FantasyDraftException(
                 f"Slot not available for role ({professional_player.role}) to draft new player"
             )
-        recent_fantasy_team.set_player_id_for_role(
-            professional_player.id, professional_player.role
-        )
+        recent_fantasy_team.set_player_id_for_role(professional_player.id, professional_player.role)
 
         if self.player_already_drafted(professional_player, fantasy_league):
             raise FantasyDraftException(
@@ -82,9 +77,7 @@ class FantasyTeamService:
         return recent_fantasy_team
 
     def drop_player(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            user_id: UserID, player_id: ProPlayerID
+        self, fantasy_league_id: FantasyLeagueID, user_id: UserID, player_id: ProPlayerID
     ) -> FantasyTeam:
         fantasy_league = self.fantasy_league_util.validate_league(
             fantasy_league_id, [FantasyLeagueStatus.ACTIVE]
@@ -93,8 +86,10 @@ class FantasyTeamService:
         professional_player = self.get_player_from_db(player_id)
 
         recent_fantasy_team = self.get_users_most_recent_fantasy_team(fantasy_league, user_id)
-        if recent_fantasy_team.get_player_id_for_role(professional_player.role) \
-                != professional_player.id:
+        if (
+            recent_fantasy_team.get_player_id_for_role(professional_player.role)
+            != professional_player.id
+        ):
             raise FantasyDraftException(
                 f"Player not drafted: User {user_id} does not have player "
                 f"{professional_player.id} currently drafted in fantasy league {fantasy_league_id}"
@@ -105,11 +100,11 @@ class FantasyTeamService:
         return recent_fantasy_team
 
     def swap_players(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            user_id: UserID,
-            player_to_drop_id: ProPlayerID,
-            player_to_pickup_id: ProPlayerID
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        user_id: UserID,
+        player_to_drop_id: ProPlayerID,
+        player_to_pickup_id: ProPlayerID,
     ) -> FantasyTeam:
         fantasy_league = self.fantasy_league_util.validate_league(
             fantasy_league_id, [FantasyLeagueStatus.ACTIVE]
@@ -118,7 +113,8 @@ class FantasyTeamService:
         pro_player_to_drop = self.get_player_from_db(player_to_drop_id)
         pro_player_to_pickup = self.get_player_from_db(player_to_pickup_id)
         self.fantasy_team_util.validate_player_from_available_league(
-            fantasy_league, player_to_pickup_id)
+            fantasy_league, player_to_pickup_id
+        )
 
         if pro_player_to_drop.role != pro_player_to_pickup.role:
             raise FantasyDraftException(
@@ -128,8 +124,10 @@ class FantasyTeamService:
             )
 
         recent_fantasy_team = self.get_users_most_recent_fantasy_team(fantasy_league, user_id)
-        if recent_fantasy_team.get_player_id_for_role(pro_player_to_drop.role) \
-                != pro_player_to_drop.id:
+        if (
+            recent_fantasy_team.get_player_id_for_role(pro_player_to_drop.role)
+            != pro_player_to_drop.id
+        ):
             raise FantasyDraftException(
                 f"Player not drafted: User {user_id} does not have player "
                 f"{pro_player_to_drop.id} currently drafted in fantasy league {fantasy_league_id}"
@@ -150,8 +148,10 @@ class FantasyTeamService:
 
     def validate_user_membership(self, user_id: UserID, fantasy_league_id: FantasyLeagueID) -> None:
         user_membership = self.db.get_user_membership_for_fantasy_league(user_id, fantasy_league_id)
-        if user_membership is None or \
-                user_membership.status != FantasyLeagueMembershipStatus.ACCEPTED:
+        if (
+            user_membership is None
+            or user_membership.status != FantasyLeagueMembershipStatus.ACCEPTED
+        ):
             raise FantasyMembershipException(
                 f"User ({user_id}) is not apart of the fantasy league ({fantasy_league_id})"
             )
@@ -163,28 +163,25 @@ class FantasyTeamService:
         return pro_player
 
     def get_users_most_recent_fantasy_team(
-            self,
-            fantasy_league: FantasyLeague,
-            user_id: UserID) -> FantasyTeam:
+        self, fantasy_league: FantasyLeague, user_id: UserID
+    ) -> FantasyTeam:
         fantasy_teams_by_week = self.db.get_all_fantasy_teams_for_user(fantasy_league.id, user_id)
         if len(fantasy_teams_by_week) != 0:
             fantasy_teams_by_week.sort(key=lambda x: x.week)
             recent_fantasy_team = FantasyTeam.model_validate(fantasy_teams_by_week[-1])
         else:
-            current_week = fantasy_league.current_week \
-                if fantasy_league.current_week is not None else 0
+            current_week = (
+                fantasy_league.current_week if fantasy_league.current_week is not None else 0
+            )
             recent_fantasy_team = FantasyTeam(
-                fantasy_league_id=fantasy_league.id,
-                user_id=user_id,
-                week=current_week
+                fantasy_league_id=fantasy_league.id, user_id=user_id, week=current_week
             )
         return recent_fantasy_team
 
     def player_already_drafted(
-            self,
-            professional_player: ProfessionalPlayer,
-            fantasy_league: FantasyLeague) -> bool:
-        assert (fantasy_league.current_week is not None)
+        self, professional_player: ProfessionalPlayer, fantasy_league: FantasyLeague
+    ) -> bool:
+        assert fantasy_league.current_week is not None
         all_fantasy_teams_for_curr_week = self.db.get_all_fantasy_teams_for_week(
             fantasy_league.id, fantasy_league.current_week
         )

--- a/src/fantasy/service/fantasy_user_service.py
+++ b/src/fantasy/service/fantasy_user_service.py
@@ -8,13 +8,13 @@ from src.common.schemas.fantasy_schemas import (
     User,
     UserLogin,
     UserID,
-    UserAccountStatus
+    UserAccountStatus,
 )
 from src.db.database_service import DatabaseService
 from src.fantasy.exceptions import (
     UserAlreadyExistsException,
     InvalidUsernameOrPasswordException,
-    UserVerificationException
+    UserVerificationException,
 )
 from .email_verification_service import EmailVerificationService
 
@@ -23,9 +23,9 @@ DEFAULT_PERMISSIONS = [Permissions.FANTASY_READ, Permissions.FANTASY_WRITE, Perm
 
 class UserService:
     def __init__(
-            self,
-            database_service: DatabaseService,
-            email_verification_service: EmailVerificationService = EmailVerificationService()
+        self,
+        database_service: DatabaseService,
+        email_verification_service: EmailVerificationService = EmailVerificationService(),
     ):
         self.db = database_service
         self.email_verification_service = email_verification_service
@@ -54,10 +54,10 @@ class UserService:
             raise UserAlreadyExistsException("Email already in use")
 
     def create_new_user(
-            self,
-            user_create: UserCreate,
-            permissions: list[Permissions],
-            verification_token: str | None = None
+        self,
+        user_create: UserCreate,
+        permissions: list[Permissions],
+        verification_token: str | None = None,
     ) -> User:
         new_id = self.generate_new_valid_id()
         hashed_password = self.hash_password(user_create.password)
@@ -69,7 +69,7 @@ class UserService:
             password=hashed_password,
             account_status=UserAccountStatus.PENDING_VERIFICATION,
             verified=False,
-            verification_token=verification_token
+            verification_token=verification_token,
         )
         user.set_permissions(permissions)
         return user
@@ -95,9 +95,7 @@ class UserService:
         if not user.verified:
             raise UserVerificationException("You must verify your email before logging in.")
 
-        passwords_match = bcrypt.checkpw(
-            user_credentials.password.encode(), user.password
-        )
+        passwords_match = bcrypt.checkpw(user_credentials.password.encode(), user.password)
         if not passwords_match:
             raise InvalidUsernameOrPasswordException()
 
@@ -127,8 +125,7 @@ class UserService:
     def send_verification_email_to_user(self, user_email: str) -> str:
         verification_token = self.generate_verification_token()
         email_sent_successfully = self.email_verification_service.send_verification_email(
-            user_email,
-            verification_token
+            user_email, verification_token
         )
         if not email_sent_successfully:
             raise UserVerificationException("Invalid email address provided.")

--- a/src/fantasy/util/fantasty_team_util.py
+++ b/src/fantasy/util/fantasty_team_util.py
@@ -11,9 +11,7 @@ class FantasyTeamUtil:
         self.db = database_service
 
     def validate_player_from_available_league(
-            self,
-            fantasy_league: FantasyLeague,
-            player_id: ProPlayerID
+        self, fantasy_league: FantasyLeague, player_id: ProPlayerID
     ) -> None:
         player_league_ids = self.db.get_league_ids_for_player(player_id)
         in_allowed_league = False
@@ -45,7 +43,7 @@ class FantasyTeamUtil:
         return users_draft_position == fantasy_league.current_draft_position
 
     def all_teams_fully_drafted(self, fantasy_league: FantasyLeague) -> bool:
-        assert (fantasy_league.current_week is not None)
+        assert fantasy_league.current_week is not None
         fantasy_league_teams = self.db.get_all_fantasy_teams_for_week(
             fantasy_league.id, fantasy_league.current_week
         )

--- a/src/fantasy/util/fantasy_league_util.py
+++ b/src/fantasy/util/fantasy_league_util.py
@@ -8,7 +8,7 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueDraftOrderResponse,
     FantasyLeagueID,
     FantasyLeagueStatus,
-    UserID
+    UserID,
 )
 from src.common.schemas.riot_data_schemas import RiotLeagueID
 
@@ -18,7 +18,7 @@ from src.fantasy.exceptions import (
     FantasyLeagueNotFoundException,
     FantasyLeagueInvalidRequiredStateException,
     FantasyUnavailableException,
-    DraftOrderException
+    DraftOrderException,
 )
 
 
@@ -27,9 +27,10 @@ class FantasyLeagueUtil:
         self.db = database_service
 
     def validate_league(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            required_states: list[FantasyLeagueStatus] | None = None) -> FantasyLeague:
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        required_states: list[FantasyLeagueStatus] | None = None,
+    ) -> FantasyLeague:
         fantasy_league = self.db.get_fantasy_league_by_id(fantasy_league_id)
         if fantasy_league is None:
             raise FantasyLeagueNotFoundException()
@@ -51,7 +52,7 @@ class FantasyLeagueUtil:
                 raise FantasyUnavailableException(league_id)
 
     def update_fantasy_leagues_current_draft_position(self, fantasy_league: FantasyLeague) -> None:
-        assert (fantasy_league.current_draft_position is not None)
+        assert fantasy_league.current_draft_position is not None
         if fantasy_league.current_draft_position + 1 <= fantasy_league.number_of_teams:
             new_draft_position = fantasy_league.current_draft_position + 1
         else:
@@ -72,16 +73,14 @@ class FantasyLeagueUtil:
             ).position
 
         new_draft_position = FantasyLeagueDraftOrder(
-            fantasy_league_id=league_id,
-            user_id=user_id,
-            position=max_position + 1
+            fantasy_league_id=league_id, user_id=user_id, position=max_position + 1
         )
         self.db.create_fantasy_league_draft_order(new_draft_position)
 
     @staticmethod
     def validate_draft_order(
-            current_draft_order: list[FantasyLeagueDraftOrder],
-            updated_draft_order: list[FantasyLeagueDraftOrderResponse]
+        current_draft_order: list[FantasyLeagueDraftOrder],
+        updated_draft_order: list[FantasyLeagueDraftOrderResponse],
     ) -> None:
         member_ids = [draft_position.user_id for draft_position in current_draft_order]
 
@@ -103,9 +102,7 @@ class FantasyLeagueUtil:
             )
 
     def update_draft_order_on_player_leave(
-            self,
-            user_id: UserID,
-            league_id: FantasyLeagueID
+        self, user_id: UserID, league_id: FantasyLeagueID
     ) -> None:
         current_draft_order = self.db.get_fantasy_league_draft_order(league_id)
 
@@ -127,18 +124,14 @@ class FantasyLeagueUtil:
                     draft_position, draft_position.position - 1
                 )
 
-    def get_leagues_current_week(
-            self,
-            riot_league_id: RiotLeagueID
-    ) -> int | None:
+    def get_leagues_current_week(self, riot_league_id: RiotLeagueID) -> int | None:
         non_week_blocks = [
             "playoffs",
             "groups",
             "finals",
             "swiss",
-            "play-ins"
-            "play in knockouts",
-            "play in groups"
+            "play-ins" "play in knockouts",
+            "play in groups",
         ]
 
         utc_now = datetime.now(pytz.utc)
@@ -183,6 +176,4 @@ def get_week_from_block_name(block_name: str) -> int:
 
 
 def parse_match_time(start_time: str) -> datetime:
-    return datetime.fromisoformat(
-        start_time.replace("Z", "")
-    ).replace(tzinfo=timezone.utc)
+    return datetime.fromisoformat(start_time.replace("Z", "")).replace(tzinfo=timezone.utc)

--- a/src/riot/app.py
+++ b/src/riot/app.py
@@ -12,7 +12,7 @@ from src.riot.endpoints import (
     MatchEndpoint,
     ProfessionalPlayerEndpoint,
     ProfessionalTeamEndpoint,
-    TournamentEndpoint
+    TournamentEndpoint,
 )
 from src.riot.service import (
     RiotGameService,
@@ -21,7 +21,7 @@ from src.riot.service import (
     RiotMatchService,
     RiotProfessionalPlayerService,
     RiotProfessionalTeamService,
-    RiotTournamentService
+    RiotTournamentService,
 )
 
 

--- a/src/riot/endpoints/game_endpoint_v1.py
+++ b/src/riot/endpoints/game_endpoint_v1.py
@@ -23,21 +23,14 @@ class GameEndpoint(Routable):
         tags=["Games"],
         dependencies=[Depends(JWTBearer([Permissions.RIOT_READ]))],
         response_model=Page[Game],
-        responses={
-            200: {
-                "model": Page[Game]
-            }
-        }
+        responses={200: {"model": Page[Game]}},
     )
     def get_riot_games(
-            self,
-            state: GameState = Depends(validate_status_parameter),
-            match_id: RiotMatchID = Query(None, description="Filter by game match id")
+        self,
+        state: GameState = Depends(validate_status_parameter),
+        match_id: RiotMatchID = Query(None, description="Filter by game match id"),
     ) -> Page[Game]:
-        search_parameters = GameSearchParameters(
-            state=state,
-            match_id=match_id
-        )
+        search_parameters = GameSearchParameters(state=state, match_id=match_id)
         games = self.__game_service.get_games(search_parameters)
         return paginate(games)
 
@@ -48,21 +41,12 @@ class GameEndpoint(Routable):
         dependencies=[Depends(JWTBearer([Permissions.RIOT_READ]))],
         response_model=Game,
         responses={
-            200: {
-                "model": Game
-            },
+            200: {"model": Game},
             404: {
                 "description": "Not Found",
-                "content": {
-                    "application/json": {
-                        "example": {"detail": "Game not found"}
-                    }
-                }
-            }
-        }
+                "content": {"application/json": {"example": {"detail": "Game not found"}}},
+            },
+        },
     )
-    def get_riot_game_by_id(
-            self,
-            game_id: RiotGameID
-    ) -> Game:
+    def get_riot_game_by_id(self, game_id: RiotGameID) -> Game:
         return self.__game_service.get_game_by_id(game_id)

--- a/src/riot/endpoints/game_stats_endpoint.py
+++ b/src/riot/endpoints/game_stats_endpoint.py
@@ -19,20 +19,13 @@ class GameStatsEndpoint(Routable):
         tags=["Game Stats"],
         dependencies=[Depends(JWTBearer([Permissions.RIOT_READ]))],
         response_model=Page[PlayerGameData],
-        responses={
-            200: {
-                "model": Page[PlayerGameData]
-            }
-        }
+        responses={200: {"model": Page[PlayerGameData]}},
     )
     def get_game_stats_for_game(
-            self,
-            game_id: RiotGameID = Query(None, description="Game id"),
-            player_id: ProPlayerID = Query(None, description="The id of the player to search for")
+        self,
+        game_id: RiotGameID = Query(None, description="Game id"),
+        player_id: ProPlayerID = Query(None, description="The id of the player to search for"),
     ) -> Page[PlayerGameData]:
-        search_parameters = PlayerGameStatsSearchParameters(
-            game_id=game_id,
-            player_id=player_id
-        )
+        search_parameters = PlayerGameStatsSearchParameters(game_id=game_id, player_id=player_id)
         player_game_stats = self.__game_stats_service.get_player_stats(search_parameters)
         return paginate(player_game_stats)

--- a/src/riot/endpoints/league_endpoint_v1.py
+++ b/src/riot/endpoints/league_endpoint_v1.py
@@ -19,23 +19,16 @@ class LeagueEndpoint(Routable):
         tags=["Leagues"],
         dependencies=[Depends(JWTBearer([Permissions.RIOT_READ]))],
         response_model=Page[League],
-        responses={
-            200: {
-                "model": Page[League]
-            }
-        }
+        responses={200: {"model": Page[League]}},
     )
     def get_riot_leagues(
-            self,
-            name: str = Query(None, description="Filter by league name"),
-            region: str = Query(None, description="Filter by league region"),
-            fantasy_available: bool = Query(
-                None, description="Filter by availability in Fantasy LoL")
+        self,
+        name: str = Query(None, description="Filter by league name"),
+        region: str = Query(None, description="Filter by league region"),
+        fantasy_available: bool = Query(None, description="Filter by availability in Fantasy LoL"),
     ) -> Page[League]:
         search_parameters = LeagueSearchParameters(
-            name=name,
-            region=region,
-            fantasy_available=fantasy_available
+            name=name, region=region, fantasy_available=fantasy_available
         )
         leagues = self.__league_service.get_leagues(search_parameters)
         return paginate(leagues)
@@ -47,23 +40,14 @@ class LeagueEndpoint(Routable):
         dependencies=[Depends(JWTBearer([Permissions.RIOT_READ]))],
         response_model=League,
         responses={
-            200: {
-                "model": League
-            },
+            200: {"model": League},
             404: {
                 "description": "Not Found",
-                "content": {
-                    "application/json": {
-                        "example": {"detail": "League not found"}
-                    }
-                }
-            }
-        }
+                "content": {"application/json": {"example": {"detail": "League not found"}}},
+            },
+        },
     )
-    def get_riot_league_by_id(
-            self,
-            league_id: RiotLeagueID
-    ) -> League:
+    def get_riot_league_by_id(self, league_id: RiotLeagueID) -> League:
         return self.__league_service.get_league_by_id(league_id)
 
     @put(
@@ -73,22 +57,14 @@ class LeagueEndpoint(Routable):
         dependencies=[Depends(JWTBearer([Permissions.RIOT_WRITE]))],
         response_model=League,
         responses={
-            200: {
-                "model": League
-            },
+            200: {"model": League},
             404: {
                 "description": "Not Found",
-                "content": {
-                    "application/json": {
-                        "example": {"detail": "League not found"}
-                    }
-                }
-            }
-        }
+                "content": {"application/json": {"example": {"detail": "League not found"}}},
+            },
+        },
     )
     def update_riot_league_fantasy_available(
-            self,
-            league_id: RiotLeagueID,
-            new_status: bool
+        self, league_id: RiotLeagueID, new_status: bool
     ) -> League:
         return self.__league_service.update_fantasy_available(league_id, new_status)

--- a/src/riot/endpoints/match_endpoint_v1.py
+++ b/src/riot/endpoints/match_endpoint_v1.py
@@ -19,20 +19,15 @@ class MatchEndpoint(Routable):
         tags=["Matches"],
         dependencies=[Depends(JWTBearer([Permissions.RIOT_READ]))],
         response_model=Page[Match],
-        responses={
-            200: {
-                "model": Page[Match]
-            }
-        }
+        responses={200: {"model": Page[Match]}},
     )
     def get_riot_matches(
-            self,
-            league_slug: str = Query(None, description="Filter by league name"),
-            tournament_id: RiotTournamentID = Query(None, description="Filter by tournament id")
+        self,
+        league_slug: str = Query(None, description="Filter by league name"),
+        tournament_id: RiotTournamentID = Query(None, description="Filter by tournament id"),
     ) -> Page[Match]:
         search_parameters = MatchSearchParameters(
-            league_slug=league_slug,
-            tournament_id=tournament_id
+            league_slug=league_slug, tournament_id=tournament_id
         )
         matches = self.__match_service.get_matches(search_parameters)
         return paginate(matches)
@@ -43,14 +38,7 @@ class MatchEndpoint(Routable):
         tags=["Matches"],
         dependencies=[Depends(JWTBearer([Permissions.RIOT_READ]))],
         response_model=Match,
-        responses={
-            200: {
-                "model": Match
-            }
-        }
+        responses={200: {"model": Match}},
     )
-    def get_riot_match_by_id(
-            self,
-            match_id: RiotMatchID
-    ) -> Match:
+    def get_riot_match_by_id(self, match_id: RiotMatchID) -> Match:
         return self.__match_service.get_match_by_id(match_id)

--- a/src/riot/endpoints/professional_player_endpoint_v1.py
+++ b/src/riot/endpoints/professional_player_endpoint_v1.py
@@ -7,14 +7,15 @@ from src.common.schemas.riot_data_schemas import (
     ProfessionalPlayer,
     PlayerRole,
     ProPlayerID,
-    ProTeamID
+    ProTeamID,
 )
 from src.common.schemas.search_parameters import PlayerSearchParameters
 from src.riot.service import RiotProfessionalPlayerService
 
 
 def validate_role_parameter(
-        role: PlayerRole = Query(None, description="Filter by players role")) -> PlayerRole:
+    role: PlayerRole = Query(None, description="Filter by players role"),
+) -> PlayerRole:
     return role
 
 
@@ -29,22 +30,16 @@ class ProfessionalPlayerEndpoint(Routable):
         tags=["Professional Players"],
         dependencies=[Depends(JWTBearer([Permissions.RIOT_READ]))],
         response_model=Page[ProfessionalPlayer],
-        responses={
-            200: {
-                "model": Page[ProfessionalPlayer]
-            }
-        }
+        responses={200: {"model": Page[ProfessionalPlayer]}},
     )
     def get_riot_professional_players(
-            self,
-            summoner_name: str = Query(None, description="Filter by players summoner name"),
-            role: PlayerRole = Depends(validate_role_parameter),
-            team_id: ProTeamID = Query(None, description="Filter by players team id")
+        self,
+        summoner_name: str = Query(None, description="Filter by players summoner name"),
+        role: PlayerRole = Depends(validate_role_parameter),
+        team_id: ProTeamID = Query(None, description="Filter by players team id"),
     ) -> Page[ProfessionalPlayer]:
         search_params = PlayerSearchParameters(
-            summoner_name=summoner_name,
-            role=role,
-            team_id=team_id
+            summoner_name=summoner_name, role=role, team_id=team_id
         )
         players = self.__player_service.get_players(search_params)
         return paginate(players)
@@ -56,21 +51,16 @@ class ProfessionalPlayerEndpoint(Routable):
         dependencies=[Depends(JWTBearer([Permissions.RIOT_READ]))],
         response_model=ProfessionalPlayer,
         responses={
-            200: {
-                "model": ProfessionalPlayer
-            },
+            200: {"model": ProfessionalPlayer},
             404: {
                 "description": "Not Found",
                 "content": {
-                    "application/json": {
-                        "example": {"detail": "Professional Player not found"}
-                    }
-                }
-            }
-        }
+                    "application/json": {"example": {"detail": "Professional Player not found"}}
+                },
+            },
+        },
     )
     def get_professional_team_by_id(
-            self,
-            professional_player_id: ProPlayerID
+        self, professional_player_id: ProPlayerID
     ) -> ProfessionalPlayer:
         return self.__player_service.get_player_by_id(professional_player_id)

--- a/src/riot/endpoints/professional_team_endpoint_v1.py
+++ b/src/riot/endpoints/professional_team_endpoint_v1.py
@@ -19,26 +19,18 @@ class ProfessionalTeamEndpoint(Routable):
         tags=["Professional Teams"],
         dependencies=[Depends(JWTBearer([Permissions.RIOT_READ]))],
         response_model=Page[ProfessionalTeam],
-        responses={
-            200: {
-                "model": Page[ProfessionalTeam]
-            }
-        }
+        responses={200: {"model": Page[ProfessionalTeam]}},
     )
     def get_riot_professional_teams(
-            self,
-            slug: str = Query(None, description="Filter by professional teams slug"),
-            name: str = Query(None, description="Filter by professional teams name"),
-            code: str = Query(None, description="Filter by professional teams code"),
-            status: str = Query(None, description="Filter by professional teams status"),
-            league: str = Query(None, description="Filter by professional teams home league")
+        self,
+        slug: str = Query(None, description="Filter by professional teams slug"),
+        name: str = Query(None, description="Filter by professional teams name"),
+        code: str = Query(None, description="Filter by professional teams code"),
+        status: str = Query(None, description="Filter by professional teams status"),
+        league: str = Query(None, description="Filter by professional teams home league"),
     ) -> Page[ProfessionalTeam]:
         search_parameters = TeamSearchParameters(
-            slug=slug,
-            name=name,
-            code=code,
-            status=status,
-            league=league
+            slug=slug, name=name, code=code, status=status, league=league
         )
         teams = self.__team_service.get_teams(search_parameters)
         return paginate(teams)
@@ -50,21 +42,14 @@ class ProfessionalTeamEndpoint(Routable):
         dependencies=[Depends(JWTBearer([Permissions.RIOT_READ]))],
         response_model=ProfessionalTeam,
         responses={
-            200: {
-                "model": ProfessionalTeam
-            },
+            200: {"model": ProfessionalTeam},
             404: {
                 "description": "Not Found",
                 "content": {
-                    "application/json": {
-                        "example": {"detail": "Professional Team not found"}
-                    }
-                }
-            }
-        }
+                    "application/json": {"example": {"detail": "Professional Team not found"}}
+                },
+            },
+        },
     )
-    def get_professional_team_by_id(
-            self,
-            professional_team_id: ProTeamID
-    ) -> ProfessionalTeam:
+    def get_professional_team_by_id(self, professional_team_id: ProTeamID) -> ProfessionalTeam:
         return self.__team_service.get_team_by_id(professional_team_id)

--- a/src/riot/endpoints/tournament_endpoint_v1.py
+++ b/src/riot/endpoints/tournament_endpoint_v1.py
@@ -8,8 +8,9 @@ from src.common.schemas.search_parameters import TournamentSearchParameters
 from src.riot.service import RiotTournamentService
 
 
-def validate_status_parameter(status: TournamentStatus = Query(
-        None, description="Status of tournament")):
+def validate_status_parameter(
+    status: TournamentStatus = Query(None, description="Status of tournament"),
+):
     return status
 
 
@@ -24,15 +25,10 @@ class TournamentEndpoint(Routable):
         tags=["Tournaments"],
         dependencies=[Depends(JWTBearer([Permissions.RIOT_READ]))],
         response_model=Page[Tournament],
-        responses={
-            200: {
-                "model": Page[Tournament]
-            }
-        }
+        responses={200: {"model": Page[Tournament]}},
     )
     def get_riot_tournaments(
-            self,
-            status: TournamentStatus = Depends(validate_status_parameter)
+        self, status: TournamentStatus = Depends(validate_status_parameter)
     ) -> Page[Tournament]:
         search_parameters = TournamentSearchParameters(status=status)
         tournaments = self.__tournament_service.get_tournaments(search_parameters)
@@ -45,21 +41,12 @@ class TournamentEndpoint(Routable):
         dependencies=[Depends(JWTBearer([Permissions.RIOT_READ]))],
         response_model=Tournament,
         responses={
-            200: {
-                "model": Tournament
-            },
+            200: {"model": Tournament},
             404: {
                 "description": "Not Found",
-                "content": {
-                    "application/json": {
-                        "example": {"detail": "Tournament not found"}
-                    }
-                }
-            }
-        }
+                "content": {"application/json": {"example": {"detail": "Tournament not found"}}},
+            },
+        },
     )
-    def get_riot_tournaments_by_id(
-            self,
-            tournament_id: RiotTournamentID
-    ) -> Tournament:
+    def get_riot_tournaments_by_id(self, tournament_id: RiotTournamentID) -> Tournament:
         return self.__tournament_service.get_tournament_by_id(tournament_id)

--- a/src/riot/exceptions/game_not_found_exception.py
+++ b/src/riot/exceptions/game_not_found_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class GameNotFoundException(HTTPException):
     def __init__(self) -> None:
-        super().__init__(
-            status_code=HTTPStatus.NOT_FOUND,
-            detail="Game not found"
-        )
+        super().__init__(status_code=HTTPStatus.NOT_FOUND, detail="Game not found")

--- a/src/riot/exceptions/match_not_found_exception.py
+++ b/src/riot/exceptions/match_not_found_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class MatchNotFoundException(HTTPException):
     def __init__(self) -> None:
-        super().__init__(
-            status_code=HTTPStatus.NOT_FOUND,
-            detail="Match not found"
-        )
+        super().__init__(status_code=HTTPStatus.NOT_FOUND, detail="Match not found")

--- a/src/riot/exceptions/professional_team_not_found_exception.py
+++ b/src/riot/exceptions/professional_team_not_found_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class ProfessionalTeamNotFoundException(HTTPException):
     def __init__(self) -> None:
-        super().__init__(
-            status_code=HTTPStatus.NOT_FOUND,
-            detail="Professional Team not found"
-        )
+        super().__init__(status_code=HTTPStatus.NOT_FOUND, detail="Professional Team not found")

--- a/src/riot/exceptions/tournament_not_found_exception.py
+++ b/src/riot/exceptions/tournament_not_found_exception.py
@@ -4,7 +4,4 @@ from http import HTTPStatus
 
 class TournamentNotFoundException(HTTPException):
     def __init__(self) -> None:
-        super().__init__(
-            status_code=HTTPStatus.NOT_FOUND,
-            detail="Tournament not found"
-        )
+        super().__init__(status_code=HTTPStatus.NOT_FOUND, detail="Tournament not found")

--- a/src/riot/service/riot_game_service.py
+++ b/src/riot/service/riot_game_service.py
@@ -6,7 +6,7 @@ from src.db.database_service import DatabaseService
 from src.db.models import GameModel
 from src.riot.exceptions import GameNotFoundException
 
-logger = logging.getLogger('riot')
+logger = logging.getLogger("riot")
 
 
 class RiotGameService:

--- a/src/riot/service/riot_game_stats_service.py
+++ b/src/riot/service/riot_game_stats_service.py
@@ -6,21 +6,23 @@ from src.common.schemas.riot_data_schemas import PlayerGameData
 from src.db.database_service import DatabaseService
 from src.db.views import PlayerGameView
 
-logger = logging.getLogger('riot')
+logger = logging.getLogger("riot")
 
 
 class RiotGameStatsService:
     def __init__(self, database_service: DatabaseService):
         self.db = database_service
 
-    def get_player_stats(self, search_parameters: PlayerGameStatsSearchParameters) \
-            -> list[PlayerGameData]:
+    def get_player_stats(
+        self, search_parameters: PlayerGameStatsSearchParameters
+    ) -> list[PlayerGameData]:
         filters = []
         if search_parameters.game_id is not None:
             filters.append(PlayerGameView.game_id == search_parameters.game_id)
         if search_parameters.player_id is not None:
             filters.append(PlayerGameView.player_id == search_parameters.player_id)
         player_game_stats = self.db.get_player_game_stats(filters)
-        sorted_player_game_stats = sorted(player_game_stats,
-                                          key=lambda x: (x.game_id, x.participant_id))
+        sorted_player_game_stats = sorted(
+            player_game_stats, key=lambda x: (x.game_id, x.participant_id)
+        )
         return sorted_player_game_stats

--- a/src/riot/service/riot_league_service.py
+++ b/src/riot/service/riot_league_service.py
@@ -6,7 +6,7 @@ from src.common.schemas.search_parameters import LeagueSearchParameters
 from src.db.database_service import DatabaseService
 from src.db.models import LeagueModel
 
-logger = logging.getLogger('riot')
+logger = logging.getLogger("riot")
 
 
 class RiotLeagueService:

--- a/src/riot/service/riot_match_service.py
+++ b/src/riot/service/riot_match_service.py
@@ -6,7 +6,7 @@ from src.db.database_service import DatabaseService
 from src.db.models import MatchModel
 from src.riot.exceptions import MatchNotFoundException
 
-logger = logging.getLogger('riot')
+logger = logging.getLogger("riot")
 
 
 class RiotMatchService:

--- a/src/riot/service/riot_professional_player_service.py
+++ b/src/riot/service/riot_professional_player_service.py
@@ -6,7 +6,7 @@ from src.db.database_service import DatabaseService
 from src.db.models import ProfessionalPlayerModel
 from src.common.exceptions import ProfessionalPlayerNotFoundException
 
-logger = logging.getLogger('riot')
+logger = logging.getLogger("riot")
 
 
 class RiotProfessionalPlayerService:

--- a/src/riot/service/riot_professional_team_service.py
+++ b/src/riot/service/riot_professional_team_service.py
@@ -8,7 +8,7 @@ from src.db.models import ProfessionalTeamModel
 
 from src.riot.exceptions import ProfessionalTeamNotFoundException
 
-logger = logging.getLogger('riot')
+logger = logging.getLogger("riot")
 
 
 class RiotProfessionalTeamService:

--- a/src/riot/service/riot_tournament_service.py
+++ b/src/riot/service/riot_tournament_service.py
@@ -7,7 +7,7 @@ from src.db.database_service import DatabaseService
 from src.db.models import TournamentModel
 from src.riot.exceptions import TournamentNotFoundException
 
-logger = logging.getLogger('riot')
+logger = logging.getLogger("riot")
 
 
 class RiotTournamentService:

--- a/src/riot_scraper/app.py
+++ b/src/riot_scraper/app.py
@@ -16,7 +16,7 @@ from src.riot_scraper.scrapers import (
     RiotLeagueScraper,
     RiotMatchScraper,
     RiotTeamScraper,
-    RiotTournamentScraper
+    RiotTournamentScraper,
 )
 from src.riot_scraper.job_scheduler import JobScheduler
 from src.riot_scraper.job_runner_endpoint import JobRunnerEndpoint
@@ -46,7 +46,7 @@ def configure_job_schedule(db_service: DatabaseService) -> JobScheduler:
         league_service=league_scraper,
         match_service=match_scraper,
         team_service=team_scraper,
-        tournament_service=tournament_scraper
+        tournament_service=tournament_scraper,
     )
     return job_scheduler
 
@@ -67,7 +67,7 @@ def configure_api_endpoints(job_runner_endpoint: JobRunnerEndpoint) -> FastAPI:
 
 
 def main():
-    configure_logger('scraper')
+    configure_logger("scraper")
 
     connection_provider = DatabaseConnectionProvider(app_config.DATABASE_URL)
     database_service = DatabaseService(connection_provider)

--- a/src/riot_scraper/job_runner.py
+++ b/src/riot_scraper/job_runner.py
@@ -4,7 +4,7 @@ from typing import Callable
 
 from src.common.exceptions import FantasyLolException
 
-logger = logging.getLogger('scraper')
+logger = logging.getLogger("scraper")
 
 
 class JobRunner:
@@ -22,8 +22,9 @@ class JobRunner:
             except FantasyLolException as e:
                 retry_count += 1
                 error = e
-                logger.warning(f"An error occurred during {job_name}."
-                               f" Retry attempt: {retry_count}")
+                logger.warning(
+                    f"An error occurred during {job_name}." f" Retry attempt: {retry_count}"
+                )
                 if retry_count <= max_retries:
                     time.sleep(5)
         if job_completed:

--- a/src/riot_scraper/job_runner_endpoint.py
+++ b/src/riot_scraper/job_runner_endpoint.py
@@ -17,14 +17,8 @@ class JobRunnerEndpoint(Routable):
         dependencies=[Depends(JWTBearer([Permissions.RIOT_ADMIN]))],
         status_code=202,
         responses={
-            202: {
-                "content": {
-                    "application/json": {
-                        "example": "Job triggered successfully"
-                    }
-                }
-            }
-        }
+            202: {"content": {"application/json": {"example": "Job triggered successfully"}}}
+        },
     )
     async def manual_fetch_leagues_from_riot_job_trigger(self) -> str:
         self.__job_scheduler.trigger_league_service_job()
@@ -37,14 +31,8 @@ class JobRunnerEndpoint(Routable):
         dependencies=[Depends(JWTBearer([Permissions.RIOT_ADMIN]))],
         status_code=202,
         responses={
-            202: {
-                "content": {
-                    "application/json": {
-                        "example": "Job triggered successfully"
-                    }
-                }
-            }
-        }
+            202: {"content": {"application/json": {"example": "Job triggered successfully"}}}
+        },
     )
     async def trigger_fetch_tournaments_from_riot_job(self) -> str:
         self.__job_scheduler.trigger_tournament_service_job()
@@ -57,14 +45,8 @@ class JobRunnerEndpoint(Routable):
         dependencies=[Depends(JWTBearer([Permissions.RIOT_ADMIN]))],
         status_code=202,
         responses={
-            202: {
-                "content": {
-                    "application/json": {
-                        "example": "Job triggered successfully"
-                    }
-                }
-            }
-        }
+            202: {"content": {"application/json": {"example": "Job triggered successfully"}}}
+        },
     )
     async def trigger_fetch_schedule_from_riot_job(self) -> str:
         self.__job_scheduler.trigger_match_service_job()
@@ -77,14 +59,8 @@ class JobRunnerEndpoint(Routable):
         dependencies=[Depends(JWTBearer([Permissions.RIOT_ADMIN]))],
         status_code=202,
         responses={
-            202: {
-                "content": {
-                    "application/json": {
-                        "example": "Job triggered successfully"
-                    }
-                }
-            }
-        }
+            202: {"content": {"application/json": {"example": "Job triggered successfully"}}}
+        },
     )
     async def trigger_fetch_games_from_match_ids_job(self) -> str:
         self.__job_scheduler.trigger_games_from_match_ids_job()
@@ -97,14 +73,8 @@ class JobRunnerEndpoint(Routable):
         dependencies=[Depends(JWTBearer([Permissions.RIOT_ADMIN]))],
         status_code=202,
         responses={
-            202: {
-                "content": {
-                    "application/json": {
-                        "example": "Job triggered successfully"
-                    }
-                }
-            }
-        }
+            202: {"content": {"application/json": {"example": "Job triggered successfully"}}}
+        },
     )
     async def trigger_update_game_states_job(self) -> str:
         self.__job_scheduler.trigger_update_game_states_job()
@@ -117,14 +87,8 @@ class JobRunnerEndpoint(Routable):
         dependencies=[Depends(JWTBearer([Permissions.RIOT_ADMIN]))],
         status_code=202,
         responses={
-            202: {
-                "content": {
-                    "application/json": {
-                        "example": "Job triggered successfully"
-                    }
-                }
-            }
-        }
+            202: {"content": {"application/json": {"example": "Job triggered successfully"}}}
+        },
     )
     async def trigger_fetch_teams_from_riot_job(self) -> str:
         self.__job_scheduler.trigger_team_service_job()

--- a/src/riot_scraper/job_scheduler.py
+++ b/src/riot_scraper/job_scheduler.py
@@ -10,50 +10,49 @@ from src.common import app_config
 from src.common.config import ScheduleConfig
 from src.riot.exceptions import JobConfigException
 
-logger = logging.getLogger('scraper')
+logger = logging.getLogger("scraper")
 
 
 class JobScheduler:
     def __init__(self, *args, **kwargs):
-
-        self.riot_game_service = kwargs.get('game_service')
-        self.riot_game_stats_service = kwargs.get('game_stats_service')
-        self.riot_league_service = kwargs.get('league_service')
-        self.riot_match_service = kwargs.get('match_service')
-        self.riot_team_service = kwargs.get('team_service')
-        self.riot_tournament_service = kwargs.get('tournament_service')
+        self.riot_game_service = kwargs.get("game_service")
+        self.riot_game_stats_service = kwargs.get("game_stats_service")
+        self.riot_league_service = kwargs.get("league_service")
+        self.riot_match_service = kwargs.get("match_service")
+        self.riot_team_service = kwargs.get("team_service")
+        self.riot_tournament_service = kwargs.get("tournament_service")
 
         self.scheduler = BackgroundScheduler()
         self.scheduler.start()
         atexit.register(self.shutdown_jobs)
 
     def trigger_league_service_job(self):
-        job = self.scheduler.get_job('league_service_job')
+        job = self.scheduler.get_job("league_service_job")
         if job:
             job.modify(next_run_time=datetime.now())
 
     def trigger_update_game_states_job(self):
-        job = self.scheduler.get_job('update_game_states_job')
+        job = self.scheduler.get_job("update_game_states_job")
         if job:
             job.modify(next_run_time=datetime.now())
 
     def trigger_games_from_match_ids_job(self):
-        job = self.scheduler.get_job('games_from_match_ids_job')
+        job = self.scheduler.get_job("games_from_match_ids_job")
         if job:
             job.modify(next_run_time=datetime.now())
 
     def trigger_team_service_job(self):
-        job = self.scheduler.get_job('team_service_job')
+        job = self.scheduler.get_job("team_service_job")
         if job:
             job.modify(next_run_time=datetime.now())
 
     def trigger_tournament_service_job(self):
-        job = self.scheduler.get_job('tournament_service_job')
+        job = self.scheduler.get_job("tournament_service_job")
         if job:
             job.modify(next_run_time=datetime.now())
 
     def trigger_match_service_job(self):
-        job = self.scheduler.get_job('match_service_job')
+        job = self.scheduler.get_job("match_service_job")
         if job:
             job.modify(next_run_time=datetime.now())
 
@@ -66,47 +65,48 @@ class JobScheduler:
         self.schedule_job(
             job_function=self.riot_league_service.fetch_leagues_from_riot_retry_job,
             job_config=app_config.LEAGUE_SERVICE_SCHEDULE,
-            job_id='league_service_job',
+            job_id="league_service_job",
         )
         self.schedule_job(
             job_function=self.riot_tournament_service.fetch_tournaments_retry_job,
             job_config=app_config.TOURNAMENT_SERVICE_SCHEDULE,
-            job_id='tournament_service_job'
+            job_id="tournament_service_job",
         )
         self.schedule_job(
             job_function=self.riot_team_service.fetch_professional_teams_from_riot_retry_job,
             job_config=app_config.TEAM_SERVICE_SCHEDULE,
-            job_id='team_service_job'
+            job_id="team_service_job",
         )
         self.schedule_job(
             job_function=self.riot_match_service.fetch_new_schedule_retry_job,
             job_config=app_config.MATCH_SERVICE_SCHEDULE,
-            job_id='match_service_job'
+            job_id="match_service_job",
         )
         self.schedule_job(
             job_function=self.riot_game_service.fetch_games_from_match_ids_retry_job,
             job_config=app_config.GAME_SERVICE_SCHEDULE,
-            job_id='games_from_match_ids_job'
+            job_id="games_from_match_ids_job",
         )
         self.schedule_job(
             job_function=self.riot_game_service.update_game_states_retry_job,
             job_config=app_config.GAME_SERVICE_SCHEDULE,
-            job_id='update_game_states_job'
+            job_id="update_game_states_job",
         )
         self.schedule_job(
             job_function=self.riot_game_stats_service.run_player_metadata_retry_job,
             job_config=app_config.GAME_STATS_SERVICE_SCHEDULE,
-            job_id='player_metadata_job'
+            job_id="player_metadata_job",
         )
         self.schedule_job(
             job_function=self.riot_game_stats_service.run_player_stats_retry_job,
             job_config=app_config.GAME_STATS_SERVICE_SCHEDULE,
-            job_id='player_stats_job'
+            job_id="player_stats_job",
         )
 
-    def schedule_job(self, job_function, job_config: ScheduleConfig,
-                     job_id: str, replace: bool = True):
-        if job_config.trigger == 'cron':
+    def schedule_job(
+        self, job_function, job_config: ScheduleConfig, job_id: str, replace: bool = True
+    ):
+        if job_config.trigger == "cron":
             job_trigger = CronTrigger(
                 day=job_config.day,
                 week=job_config.week,
@@ -114,25 +114,21 @@ class JobScheduler:
                 minute=job_config.minute,
                 second=job_config.second,
             )
-        elif job_config.trigger == 'interval':
+        elif job_config.trigger == "interval":
             job_trigger = IntervalTrigger(
                 weeks=job_config.weeks,
                 days=job_config.days,
                 hours=job_config.hours,
                 minutes=job_config.minutes,
-                seconds=job_config.seconds
+                seconds=job_config.seconds,
             )
         else:
             raise JobConfigException(
-                f"Invalid trigger ({job_config.trigger}) "
-                f"when scheduling job with id: {job_id}"
+                f"Invalid trigger ({job_config.trigger}) " f"when scheduling job with id: {job_id}"
             )
 
         self.scheduler.add_job(
-            job_function,
-            trigger=job_trigger,
-            id=job_id,
-            replace_existing=replace
+            job_function, trigger=job_trigger, id=job_id, replace_existing=replace
         )
 
     def shutdown_jobs(self):

--- a/src/riot_scraper/riot_api/api_requester.py
+++ b/src/riot_scraper/riot_api/api_requester.py
@@ -3,18 +3,13 @@ import logging
 import certifi
 from requests import Response
 
-logger = logging.getLogger('scraper')
+logger = logging.getLogger("scraper")
 
 
 class ApiRequester:
     def __init__(self):
         self.client = cloudscraper.create_scraper(
-            browser={
-                'browser': 'chrome',
-                'platform': 'windows',
-                'desktop': True
-            },
-            debug=False
+            browser={"browser": "chrome", "platform": "windows", "desktop": True}, debug=False
         )
 
     def make_request(self, url, headers=None) -> Response:

--- a/src/riot_scraper/riot_api/riot_api_client.py
+++ b/src/riot_scraper/riot_api/riot_api_client.py
@@ -15,7 +15,7 @@ from src.riot_scraper.riot_api.schemas.get_schedule import GetScheduleResponse
 from src.riot_scraper.riot_api.schemas.get_teams import GetTeamsResponse
 from src.riot_scraper.riot_api.schemas.get_tournament import GetTournamentsResponse
 
-logger = logging.getLogger('scraper')
+logger = logging.getLogger("scraper")
 
 
 class RiotApiClient:
@@ -26,7 +26,7 @@ class RiotApiClient:
         self.default_headers = {
             "Origin": "https://lolesports.com",
             "Referrer": "https://lolesports.com",
-            "x-api-key": app_config.RIOT_API_KEY
+            "x-api-key": app_config.RIOT_API_KEY,
         }
 
     def make_request(self, url, headers=None) -> Response:
@@ -38,9 +38,7 @@ class RiotApiClient:
         event_details_url = f"{self.esports_api_url}/getEventDetails?hl=en-GB&id={match_id}"
         response = self.make_request(event_details_url)
         validate_response(
-            [HTTPStatus.OK, HTTPStatus.NO_CONTENT],
-            response.status_code,
-            event_details_url
+            [HTTPStatus.OK, HTTPStatus.NO_CONTENT], response.status_code, event_details_url
         )
         if response.status_code == HTTPStatus.NO_CONTENT:
             return None
@@ -48,7 +46,7 @@ class RiotApiClient:
             return EventDetailsResponse.model_validate(response.json())
 
     def get_games(self, game_ids: list[RiotGameID]) -> GetGamesResponse:
-        game_ids_str = ','.join(map(str, game_ids))
+        game_ids_str = ",".join(map(str, game_ids))
         url = f"{self.esports_api_url}/getGames?hl=en-GB&id={game_ids_str}"
         response = self.make_request(url)
         validate_response([HTTPStatus.OK], response.status_code, url)
@@ -77,37 +75,25 @@ class RiotApiClient:
         return GetTeamsResponse.model_validate(response.json())
 
     def get_game_window(
-            self,
-            game_id: RiotGameID,
-            time_stamp: str | None = None
+        self, game_id: RiotGameID, time_stamp: str | None = None
     ) -> GetLiveWindowResponse | None:
         if time_stamp:
             url = f"{self.esports_feed_url}/window/{game_id}?hl=en-GB&startingTime={time_stamp}"
         else:
             url = f"{self.esports_feed_url}/window/{game_id}?hl=en-GB"
         response = self.make_request(url)
-        validate_response(
-            [HTTPStatus.OK, HTTPStatus.NO_CONTENT],
-            response.status_code,
-            url
-        )
+        validate_response([HTTPStatus.OK, HTTPStatus.NO_CONTENT], response.status_code, url)
         if response.status_code == HTTPStatus.NO_CONTENT:
             return None
 
         return GetLiveWindowResponse.model_validate(response.json())
 
     def get_game_details(
-            self,
-            game_id: RiotGameID,
-            time_stamp: str
+        self, game_id: RiotGameID, time_stamp: str
     ) -> GetLiveDetailsResponse | None:
         url = f"{self.esports_feed_url}/details/{game_id}?hl=en-GB&startingTime={time_stamp}"
         response = self.make_request(url)
-        validate_response(
-            [HTTPStatus.OK, HTTPStatus.NO_CONTENT],
-            response.status_code,
-            url
-        )
+        validate_response([HTTPStatus.OK, HTTPStatus.NO_CONTENT], response.status_code, url)
         if response.status_code == HTTPStatus.NO_CONTENT:
             return None
 

--- a/src/riot_scraper/riot_api/schemas/get_event_details.py
+++ b/src/riot_scraper/riot_api/schemas/get_event_details.py
@@ -5,7 +5,7 @@ from src.common.schemas.riot_data_schemas import (
     RiotTournamentID,
     RiotLeagueID,
     ProTeamID,
-    RiotMatchID
+    RiotMatchID,
 )
 
 

--- a/src/riot_scraper/riot_api/schemas/get_live_window.py
+++ b/src/riot_scraper/riot_api/schemas/get_live_window.py
@@ -5,7 +5,7 @@ from src.common.schemas.riot_data_schemas import (
     ProTeamID,
     RiotMatchID,
     RiotGameID,
-    LiveGameState
+    LiveGameState,
 )
 
 

--- a/src/riot_scraper/scrapers/game_data_scraper.py
+++ b/src/riot_scraper/scrapers/game_data_scraper.py
@@ -8,15 +8,15 @@ from src.riot_scraper.riot_api.riot_api_client import RiotApiClient
 from src.riot_scraper.job_runner import JobRunner
 from src.riot_scraper.timestamp_util import TimestampUtil
 
-logger = logging.getLogger('scraper')
+logger = logging.getLogger("scraper")
 
 
 class RiotGameDataScraper:
     def __init__(
-            self,
-            database_service: DatabaseService,
-            riot_api_requester: RiotApiClient,
-            job_runner: JobRunner
+        self,
+        database_service: DatabaseService,
+        riot_api_requester: RiotApiClient,
+        job_runner: JobRunner,
     ):
         self.db = database_service
         self.riot_api_requester = riot_api_requester
@@ -25,7 +25,7 @@ class RiotGameDataScraper:
     def scrape_game(self, game_id: RiotGameID):
         logger.debug(f"Starting for game id {game_id}")
         start_time = self.__get_game_start_time(game_id)
-        assert (start_time is not None)
+        assert start_time is not None
 
         end_time = None
         game_finished = False
@@ -36,7 +36,7 @@ class RiotGameDataScraper:
         current_time = TimestampUtil.round_to_10_seconds(start_time)
         while not game_finished:
             current_window = self.riot_api_requester.get_game_window(game_id, current_time)
-            assert (current_window is not None)
+            assert current_window is not None
 
             paused_frame = get_paused_frame(current_window.frames)
             if paused_frame and not paused_timestamp:
@@ -49,14 +49,13 @@ class RiotGameDataScraper:
                 unpause_timestamp = None
 
             game_finished = any(
-                frame.gameState == LiveGameState.FINISHED
-                for frame in current_window.frames
+                frame.gameState == LiveGameState.FINISHED for frame in current_window.frames
             )
             if game_finished:
                 end_time = current_window.frames[-1].rfc460Timestamp
             current_time = TimestampUtil.add_10_seconds(current_time)
 
-        assert (end_time is not None)
+        assert end_time is not None
         total_game_time = get_game_duration(start_time, end_time, pauses)
 
         minutes = total_game_time // 60
@@ -72,7 +71,7 @@ class RiotGameDataScraper:
             initial_start_window.frames[0].rfc460Timestamp
         )
         start_window = self.riot_api_requester.get_game_window(game_id, start_window_time)
-        assert (start_window is not None)
+        assert start_window is not None
 
         start_time = None
         for frame in start_window.frames:
@@ -89,7 +88,7 @@ def get_game_duration(start_time: str, end_time: str, pauses: list[tuple[str, st
     for pause_start, pause_end in pauses:
         pause_start_dt = TimestampUtil.parse_rfc3339(pause_start)
         pause_end_dt = TimestampUtil.parse_rfc3339(pause_end)
-        total_pause += (pause_end_dt - pause_start_dt)
+        total_pause += pause_end_dt - pause_start_dt
 
     effective_duration = end_dt - start_dt - total_pause
     total_seconds = int(effective_duration.total_seconds())

--- a/src/riot_scraper/scrapers/game_scraper.py
+++ b/src/riot_scraper/scrapers/game_scraper.py
@@ -5,15 +5,15 @@ from src.db.database_service import DatabaseService
 from src.riot_scraper.riot_api.riot_api_client import RiotApiClient
 from src.riot_scraper.job_runner import JobRunner
 
-logger = logging.getLogger('riot')
+logger = logging.getLogger("riot")
 
 
 class RiotGameScraper:
     def __init__(
-            self,
-            database_service: DatabaseService,
-            api_requester: RiotApiClient,
-            job_runner: JobRunner,
+        self,
+        database_service: DatabaseService,
+        api_requester: RiotApiClient,
+        job_runner: JobRunner,
     ):
         self.db = database_service
         self.riot_api_requester = api_requester
@@ -23,13 +23,13 @@ class RiotGameScraper:
         self.job_runner.run_retry_job(
             job_function=self.fetch_games_from_match_ids_job,
             job_name="fetch games from match ids job",
-            max_retries=3
+            max_retries=3,
         )
 
     def fetch_games_from_match_ids_job(self, batch_size: int = 25):
         match_ids = self.db.get_match_ids_without_games()
         for i in range(0, len(match_ids), batch_size):
-            batch = match_ids[i:i + batch_size]
+            batch = match_ids[i : i + batch_size]
             self.process_batch_match_ids(batch)
 
     def process_batch_match_ids(self, match_ids: list[RiotMatchID]):
@@ -52,7 +52,7 @@ class RiotGameScraper:
                     state=GameState(game.state),
                     red_team=ProTeamID(red_team_id),
                     blue_team=ProTeamID(blue_team_id),
-                    match_id=match_id
+                    match_id=match_id,
                 )
                 all_fetched_games.append(new_game)
         self.db.bulk_save_games(all_fetched_games)
@@ -61,14 +61,16 @@ class RiotGameScraper:
         self.job_runner.run_retry_job(
             job_function=self.update_game_states_job,
             job_name="update game states job",
-            max_retries=3
+            max_retries=3,
         )
 
     def update_game_states_job(self):
         game_ids = self.db.get_games_to_check_state()
 
         batch_size = 10
-        game_id_batches = [game_ids[i:i + batch_size] for i in range(0, len(game_ids), batch_size)]
+        game_id_batches = [
+            game_ids[i : i + batch_size] for i in range(0, len(game_ids), batch_size)
+        ]
 
         for batch in game_id_batches:
             get_games_response = self.riot_api_requester.get_games(batch)

--- a/src/riot_scraper/scrapers/game_stats_scraper.py
+++ b/src/riot_scraper/scrapers/game_stats_scraper.py
@@ -1,22 +1,28 @@
 import logging
 
-from src.common.schemas.riot_data_schemas import RiotGameID, PlayerGameMetadata, ProPlayerID, \
-    TeamGameStats, ProTeamID, PlayerGameStats
+from src.common.schemas.riot_data_schemas import (
+    RiotGameID,
+    PlayerGameMetadata,
+    ProPlayerID,
+    TeamGameStats,
+    ProTeamID,
+    PlayerGameStats,
+)
 from src.db.database_service import DatabaseService
 from src.riot_scraper.riot_api.schemas.get_live_window import TeamMetaData, TeamWindowFrame
 from src.riot_scraper.riot_api.riot_api_client import RiotApiClient
 from src.riot_scraper.job_runner import JobRunner
 from src.riot_scraper.timestamp_util import TimestampUtil
 
-logger = logging.getLogger('scraper')
+logger = logging.getLogger("scraper")
 
 
 class RiotGameStatsScraper:
     def __init__(
-            self,
-            database_service: DatabaseService,
-            riot_api_requester: RiotApiClient,
-            job_runner: JobRunner
+        self,
+        database_service: DatabaseService,
+        riot_api_requester: RiotApiClient,
+        job_runner: JobRunner,
     ):
         self.db = database_service
         self.riot_api_requester = riot_api_requester
@@ -24,9 +30,7 @@ class RiotGameStatsScraper:
 
     def run_player_metadata_retry_job(self):
         self.job_runner.run_retry_job(
-            job_function=self.run_player_metadata_job,
-            job_name="player metadata job",
-            max_retries=3
+            job_function=self.run_player_metadata_job, job_name="player metadata job", max_retries=3
         )
 
     def run_player_metadata_job(self) -> None:
@@ -46,12 +50,10 @@ class RiotGameStatsScraper:
                 return
 
             blue_team_player_metadata = parse_team_metadata(
-                window_response.gameMetadata.blueTeamMetadata,
-                game_id
+                window_response.gameMetadata.blueTeamMetadata, game_id
             )
             red_team_player_metadata = parse_team_metadata(
-                window_response.gameMetadata.redTeamMetadata,
-                game_id
+                window_response.gameMetadata.redTeamMetadata, game_id
             )
             for player_metadata in blue_team_player_metadata + red_team_player_metadata:
                 self.db.put_player_metadata(player_metadata)
@@ -61,9 +63,7 @@ class RiotGameStatsScraper:
 
     def run_player_stats_retry_job(self):
         self.job_runner.run_retry_job(
-            job_function=self.run_player_stats_job,
-            job_name="player stats job",
-            max_retries=3
+            job_function=self.run_player_stats_job, job_name="player stats job", max_retries=3
         )
 
     def run_player_stats_job(self):
@@ -123,7 +123,7 @@ class RiotGameStatsScraper:
                 kill_participation=round(participant.killParticipation * 100),
                 champion_damage_share=round(participant.championDamageShare * 100),
                 wards_placed=participant.wardsPlaced,
-                wards_destroyed=participant.wardsDestroyed
+                wards_destroyed=participant.wardsDestroyed,
             )
             player_stats.append(new_player_stats)
 
@@ -143,40 +143,40 @@ class RiotGameStatsScraper:
         blue_team_stats = get_team_stats_from_frame(
             game_id,
             window_response.gameMetadata.blueTeamMetadata.esportsTeamId,
-            last_frame.blueTeam
+            last_frame.blueTeam,
         )
         red_team_stats = get_team_stats_from_frame(
             game_id,
             window_response.gameMetadata.blueTeamMetadata.esportsTeamId,
-            last_frame.blueTeam
+            last_frame.blueTeam,
         )
 
         return [blue_team_stats, red_team_stats]
 
 
 def parse_team_metadata(
-        team_metadata: TeamMetaData,
-        game_id: RiotGameID
+    team_metadata: TeamMetaData, game_id: RiotGameID
 ) -> list[PlayerGameMetadata]:
     player_metadata_for_team = []
     for participant in team_metadata.participantMetadata:
-        player_id = participant.esportsPlayerId if participant.esportsPlayerId \
+        player_id = (
+            participant.esportsPlayerId
+            if participant.esportsPlayerId
             else ProPlayerID(str(participant.participantId))
+        )
         new_player_metadata = PlayerGameMetadata(
             game_id=game_id,
             participant_id=participant.participantId,
             champion_id=participant.championId,
             role=participant.role,
-            player_id=player_id  # Weird edge case where it doesn't exist for some games
+            player_id=player_id,  # Weird edge case where it doesn't exist for some games
         )
         player_metadata_for_team.append(new_player_metadata)
     return player_metadata_for_team
 
 
 def get_team_stats_from_frame(
-        game_id: RiotGameID,
-        team_id: ProTeamID,
-        team_frame: TeamWindowFrame
+    game_id: RiotGameID, team_id: ProTeamID, team_frame: TeamWindowFrame
 ) -> TeamGameStats:
     return TeamGameStats(
         game_id=game_id,
@@ -185,5 +185,5 @@ def get_team_stats_from_frame(
         inhibitors=team_frame.inhibitors,
         towers=team_frame.towers,
         barons=team_frame.barons,
-        total_kills=team_frame.totalKills
+        total_kills=team_frame.totalKills,
     )

--- a/src/riot_scraper/scrapers/league_scraper.py
+++ b/src/riot_scraper/scrapers/league_scraper.py
@@ -5,15 +5,15 @@ from src.db.database_service import DatabaseService
 from src.riot_scraper.riot_api.riot_api_client import RiotApiClient
 from src.riot_scraper.job_runner import JobRunner
 
-logger = logging.getLogger('scraper')
+logger = logging.getLogger("scraper")
 
 
 class RiotLeagueScraper:
     def __init__(
-            self,
-            database_service: DatabaseService,
-            riot_api_requester: RiotApiClient,
-            job_runner: JobRunner
+        self,
+        database_service: DatabaseService,
+        riot_api_requester: RiotApiClient,
+        job_runner: JobRunner,
     ):
         self.db = database_service
         self.riot_api_requester = riot_api_requester
@@ -23,7 +23,7 @@ class RiotLeagueScraper:
         self.job_runner.run_retry_job(
             job_function=self.fetch_leagues_from_riot_job,
             job_name="Fetch leagues from riot job",
-            max_retries=3
+            max_retries=3,
         )
 
     def fetch_leagues_from_riot_job(self):
@@ -36,6 +36,6 @@ class RiotLeagueScraper:
                 name=league.slug,
                 region=league.region,
                 image=league.image,
-                priority=league.displayPriority.position
+                priority=league.displayPriority.position,
             )
             self.db.put_league(new_league)

--- a/src/riot_scraper/scrapers/match_scraper.py
+++ b/src/riot_scraper/scrapers/match_scraper.py
@@ -7,15 +7,15 @@ from src.riot_scraper.riot_api.schemas.get_schedule import Schedule
 from src.riot_scraper.riot_api.riot_api_client import RiotApiClient
 from src.riot_scraper.job_runner import JobRunner
 
-logger = logging.getLogger('scraper')
+logger = logging.getLogger("scraper")
 
 
 class RiotMatchScraper:
     def __init__(
-            self,
-            database_service: DatabaseService,
-            riot_api_requester: RiotApiClient,
-            job_runner=JobRunner
+        self,
+        database_service: DatabaseService,
+        riot_api_requester: RiotApiClient,
+        job_runner=JobRunner,
     ):
         self.db = database_service
         self.riot_api_requester = riot_api_requester
@@ -25,7 +25,7 @@ class RiotMatchScraper:
         self.job_runner.run_retry_job(
             job_function=self.fetch_new_schedule_job,
             job_name="fetch schedule from riot job",
-            max_retries=3
+            max_retries=3,
         )
 
     def fetch_matches_with_missing_data(self) -> None:
@@ -37,7 +37,7 @@ class RiotMatchScraper:
 
         earliest_start = datetime.fromisoformat(earliest_match.start_time.replace("Z", "+00:00"))
         riot_schedule = self.db.get_schedule("riot_schedule")
-        assert (riot_schedule is not None)
+        assert riot_schedule is not None
         current_page_token = riot_schedule.older_token_key
 
         while True:
@@ -73,9 +73,7 @@ class RiotMatchScraper:
             if len(matches) == 0:
                 logger.info(f"No matches found for page token {current_page_token}")
             else:
-                logger.info(
-                    f"{len(matches)} matches found for page token {current_page_token}"
-                )
+                logger.info(f"{len(matches)} matches found for page token {current_page_token}")
 
             for match in matches:
                 self.db.put_match(match)
@@ -99,8 +97,7 @@ class RiotMatchScraper:
         # After which fetch new schedule should only be used
 
         # Save the starting schedule into the database
-        logger.warning("Fetching entire schedule. "
-                       "This should only occur on new deployments")
+        logger.warning("Fetching entire schedule. " "This should only occur on new deployments")
         get_schedule_response = self.riot_api_requester.get_schedule()
         schedule = get_schedule_response.data.schedule
         matches = self.__get_matches_from_schedule(schedule)
@@ -116,16 +113,14 @@ class RiotMatchScraper:
             riot_curr_token = schedule.pages.older
 
         riot_schedule = StoredSchedule(
-            schedule_name="riot_schedule",
-            older_token_key=None,
-            newer_token_key=riot_curr_token
+            schedule_name="riot_schedule", older_token_key=None, newer_token_key=riot_curr_token
         )
 
         # Used as a save point if we encounter an error during back prop
         entire_schedule = StoredSchedule(
             schedule_name="entire_schedule",
             older_token_key=schedule.pages.older,
-            newer_token_key=None
+            newer_token_key=None,
         )
         self.db.update_schedule(riot_schedule)
         self.db.update_schedule(entire_schedule)
@@ -136,7 +131,7 @@ class RiotMatchScraper:
     def backprop_older_schedules(self) -> None:
         logger.info("Back propagating older schedule")
         entire_schedule = self.db.get_schedule("entire_schedule")
-        assert (entire_schedule is not None)
+        assert entire_schedule is not None
         current_page_token = entire_schedule.older_token_key
 
         no_more_schedules = False
@@ -177,14 +172,14 @@ class RiotMatchScraper:
                 if match.teams[1].result:
                     team_2_wins = match.teams[1].result.gameWins
             if event.state == MatchState.COMPLETED:
-                assert (match.teams[0].result is not None)
+                assert match.teams[0].result is not None
                 if match.teams[0].result.outcome == "win":
                     winning_team = match.teams[0].name
                 else:
                     winning_team = match.teams[1].name
 
             get_event_details_response = self.riot_api_requester.get_event_details(match.id)
-            assert (get_event_details_response is not None)
+            assert get_event_details_response is not None
 
             new_match = Match(
                 id=match.id,
@@ -199,7 +194,7 @@ class RiotMatchScraper:
                 state=event.state,
                 team_1_wins=team_1_wins,
                 team_2_wins=team_2_wins,
-                winning_team=winning_team
+                winning_team=winning_team,
             )
             matches_from_schedule.append(new_match)
 
@@ -209,7 +204,8 @@ class RiotMatchScraper:
 def get_earliest_past_match(tbd_matches: list[Match]) -> Match | None:
     now_utc = datetime.now(timezone.utc)
     past_tbd_matches = [
-        match for match in tbd_matches
+        match
+        for match in tbd_matches
         if datetime.fromisoformat(match.start_time.replace("Z", "+00:00")) < now_utc
     ]
 
@@ -217,6 +213,5 @@ def get_earliest_past_match(tbd_matches: list[Match]) -> Match | None:
         return None
 
     return min(
-        past_tbd_matches,
-        key=lambda m: datetime.fromisoformat(m.start_time.replace("Z", "+00:00"))
+        past_tbd_matches, key=lambda m: datetime.fromisoformat(m.start_time.replace("Z", "+00:00"))
     )

--- a/src/riot_scraper/scrapers/team_scraper.py
+++ b/src/riot_scraper/scrapers/team_scraper.py
@@ -5,15 +5,15 @@ from src.db.database_service import DatabaseService
 from src.riot_scraper.riot_api.riot_api_client import RiotApiClient
 from src.riot_scraper.job_runner import JobRunner
 
-logger = logging.getLogger('scraper')
+logger = logging.getLogger("scraper")
 
 
 class RiotTeamScraper:
     def __init__(
-            self,
-            database_service: DatabaseService,
-            riot_api_requester: RiotApiClient,
-            job_runner: JobRunner
+        self,
+        database_service: DatabaseService,
+        riot_api_requester: RiotApiClient,
+        job_runner: JobRunner,
     ):
         self.db = database_service
         self.riot_api_requester = riot_api_requester
@@ -23,7 +23,7 @@ class RiotTeamScraper:
         self.job_runner.run_retry_job(
             job_function=self.fetch_professional_teams_from_riot_job,
             job_name="fetch teams from riot job",
-            max_retries=3
+            max_retries=3,
         )
 
     def fetch_professional_teams_from_riot_job(self) -> None:
@@ -39,7 +39,7 @@ class RiotTeamScraper:
                 alternative_image=team.alternativeImage,
                 background_image=team.backgroundImage,
                 status=team.status,
-                home_league=team.homeLeague.name if team.homeLeague else None
+                home_league=team.homeLeague.name if team.homeLeague else None,
             )
             self.db.put_team(new_team)
 
@@ -49,6 +49,6 @@ class RiotTeamScraper:
                     summoner_name=player.summonerName,
                     image=player.image,
                     role=player.role,
-                    team_id=team.id
+                    team_id=team.id,
                 )
                 self.db.put_player(new_player)

--- a/src/riot_scraper/scrapers/tournament_scraper.py
+++ b/src/riot_scraper/scrapers/tournament_scraper.py
@@ -5,15 +5,15 @@ from src.db.database_service import DatabaseService
 from src.riot_scraper.riot_api.riot_api_client import RiotApiClient
 from src.riot_scraper.job_runner import JobRunner
 
-logger = logging.getLogger('scraper')
+logger = logging.getLogger("scraper")
 
 
 class RiotTournamentScraper:
     def __init__(
-            self,
-            database_service: DatabaseService,
-            riot_api_requester: RiotApiClient,
-            job_runner: JobRunner
+        self,
+        database_service: DatabaseService,
+        riot_api_requester: RiotApiClient,
+        job_runner: JobRunner,
     ):
         self.db = database_service
         self.riot_api_requester = riot_api_requester
@@ -21,9 +21,7 @@ class RiotTournamentScraper:
 
     def fetch_tournaments_retry_job(self) -> None:
         self.job_runner.run_retry_job(
-            job_function=self.fetch_tournaments_job,
-            job_name="fetch tournaments job",
-            max_retries=3
+            job_function=self.fetch_tournaments_job, job_name="fetch tournaments job", max_retries=3
         )
 
     def fetch_tournaments_job(self) -> None:
@@ -37,6 +35,6 @@ class RiotTournamentScraper:
                         slug=tournament.slug,
                         start_date=tournament.startDate,
                         end_date=tournament.endDate,
-                        league_id=league.id
+                        league_id=league.id,
                     )
                     self.db.put_tournament(new_tournament)

--- a/tests/db/fantasy/test_draft_order_dao.py
+++ b/tests/db/fantasy/test_draft_order_dao.py
@@ -12,9 +12,7 @@ class TestCrudFantasyLeagueDraftOrder(TestBase):
         fantasy_league = fantasy_fixtures.fantasy_league_fixture
         user = fantasy_fixtures.user_fixture
         draft_order = FantasyLeagueDraftOrder(
-            fantasy_league_id=fantasy_league.id,
-            user_id=user.id,
-            position=1
+            fantasy_league_id=fantasy_league.id, user_id=user.id, position=1
         )
 
         # Act and Assert
@@ -26,25 +24,19 @@ class TestCrudFantasyLeagueDraftOrder(TestBase):
         self.assertEqual(draft_order, draft_order_after_create[0])
         with self.assertRaises(IntegrityError) as context:
             self.db.create_fantasy_league_draft_order(draft_order)
-        self.assertIn(
-            'duplicate key value violates unique constraint',
-            str(context.exception)
-        )
+        self.assertIn("duplicate key value violates unique constraint", str(context.exception))
 
     def test_delete_fantasy_league_draft_order(self):
         # Arrange
         fantasy_league = fantasy_fixtures.fantasy_league_fixture
         user = fantasy_fixtures.user_fixture
         draft_order = FantasyLeagueDraftOrder(
-            fantasy_league_id=fantasy_league.id,
-            user_id=user.id,
-            position=1
+            fantasy_league_id=fantasy_league.id, user_id=user.id, position=1
         )
         self.db.create_fantasy_league_draft_order(draft_order)
 
         # Act and Assert
-        draft_order_before_delete = self.db.\
-            get_fantasy_league_draft_order(fantasy_league.id)
+        draft_order_before_delete = self.db.get_fantasy_league_draft_order(fantasy_league.id)
         self.assertEqual(1, len(draft_order_before_delete))
         self.db.delete_fantasy_league_draft_order(draft_order)
         draft_order_after_delete = self.db.get_fantasy_league_draft_order(fantasy_league.id)
@@ -57,9 +49,7 @@ class TestCrudFantasyLeagueDraftOrder(TestBase):
         fantasy_league = fantasy_fixtures.fantasy_league_fixture
         user = fantasy_fixtures.user_fixture
         draft_order = FantasyLeagueDraftOrder(
-            fantasy_league_id=fantasy_league.id,
-            user_id=user.id,
-            position=1
+            fantasy_league_id=fantasy_league.id, user_id=user.id, position=1
         )
         self.db.create_fantasy_league_draft_order(draft_order)
         new_position = 2
@@ -68,8 +58,7 @@ class TestCrudFantasyLeagueDraftOrder(TestBase):
 
         # Act and Assert
         self.assertNotEqual(draft_order.position, new_position)
-        draft_order_before_update = self.db.\
-            get_fantasy_league_draft_order(fantasy_league.id)
+        draft_order_before_update = self.db.get_fantasy_league_draft_order(fantasy_league.id)
         self.assertEqual(1, len(draft_order_before_update))
         self.assertEqual(draft_order, draft_order_before_update[0])
         self.db.update_fantasy_league_draft_order_position(draft_order, new_position)

--- a/tests/db/fantasy/test_fantasy_league.py
+++ b/tests/db/fantasy/test_fantasy_league.py
@@ -8,18 +8,15 @@ from src.common.schemas.riot_data_schemas import RiotLeagueID
 
 
 class TestCrudFantasyLeague(TestBase):
-
     def test_create_fantasy_league(self):
         # Arrange
         fantasy_league = fantasy_fixtures.fantasy_league_fixture
 
         # Act and Assert
-        fantasy_league_before_create = self.db.\
-            get_fantasy_league_by_id(fantasy_league.id)
+        fantasy_league_before_create = self.db.get_fantasy_league_by_id(fantasy_league.id)
         self.assertIsNone(fantasy_league_before_create)
         self.db.create_fantasy_league(fantasy_league)
-        fantasy_league_after_create = self.db.\
-            get_fantasy_league_by_id(fantasy_league.id)
+        fantasy_league_after_create = self.db.get_fantasy_league_by_id(fantasy_league.id)
         self.assertEqual(fantasy_league, fantasy_league_after_create)
 
     def test_create_fantasy_league_with_an_existing_id(self):
@@ -30,7 +27,7 @@ class TestCrudFantasyLeague(TestBase):
         # Act and Assert
         with self.assertRaises(IntegrityError) as context:
             self.db.create_fantasy_league(fantasy_league)
-        self.assertIn('duplicate key value violates unique constraint', str(context.exception))
+        self.assertIn("duplicate key value violates unique constraint", str(context.exception))
 
     def test_get_fantasy_league_by_id(self):
         # Arrange
@@ -38,10 +35,7 @@ class TestCrudFantasyLeague(TestBase):
         self.db.create_fantasy_league(fantasy_league)
 
         # Act and Assert
-        self.assertEqual(
-            fantasy_league,
-            self.db.get_fantasy_league_by_id(fantasy_league.id)
-        )
+        self.assertEqual(fantasy_league, self.db.get_fantasy_league_by_id(fantasy_league.id))
         self.assertIsNone(self.db.get_fantasy_league_by_id(FantasyLeagueID("123")))
 
     def test_put_fantasy_league_scoring_settings(self):
@@ -51,17 +45,20 @@ class TestCrudFantasyLeague(TestBase):
         updated_scoring_settings.kills = scoring_settings.kills + 1
 
         # Act and Assert
-        scoring_settings_before_create = self.db.\
-            get_fantasy_league_scoring_settings_by_id(scoring_settings.fantasy_league_id)
+        scoring_settings_before_create = self.db.get_fantasy_league_scoring_settings_by_id(
+            scoring_settings.fantasy_league_id
+        )
         self.assertIsNone(scoring_settings_before_create)
         self.db.put_fantasy_league_scoring_settings(scoring_settings)
-        scoring_settings_after_create = self.db.\
-            get_fantasy_league_scoring_settings_by_id(scoring_settings.fantasy_league_id)
+        scoring_settings_after_create = self.db.get_fantasy_league_scoring_settings_by_id(
+            scoring_settings.fantasy_league_id
+        )
         self.assertEqual(scoring_settings, scoring_settings_after_create)
 
         self.db.put_fantasy_league_scoring_settings(updated_scoring_settings)
-        scoring_settings_after_update = self.db.\
-            get_fantasy_league_scoring_settings_by_id(scoring_settings.fantasy_league_id)
+        scoring_settings_after_update = self.db.get_fantasy_league_scoring_settings_by_id(
+            scoring_settings.fantasy_league_id
+        )
         self.assertEqual(updated_scoring_settings, scoring_settings_after_update)
 
     def test_get_fantasy_league_scoring_settings_by_id(self):
@@ -72,13 +69,9 @@ class TestCrudFantasyLeague(TestBase):
         # Act and Assert
         self.assertEqual(
             scoring_settings,
-            self.db.get_fantasy_league_scoring_settings_by_id(
-                scoring_settings.fantasy_league_id
-            )
+            self.db.get_fantasy_league_scoring_settings_by_id(scoring_settings.fantasy_league_id),
         )
-        self.assertIsNone(
-            self.db.get_fantasy_league_scoring_settings_by_id(FantasyLeagueID("123"))
-        )
+        self.assertIsNone(self.db.get_fantasy_league_scoring_settings_by_id(FantasyLeagueID("123")))
 
     def test_update_fantasy_league_settings_name(self):
         # Arrange
@@ -112,12 +105,10 @@ class TestCrudFantasyLeague(TestBase):
 
         # Assert
         self.assertEqual(
-            updated_fantasy_league_settings.number_of_teams,
-            updated_fantasy_league.number_of_teams
+            updated_fantasy_league_settings.number_of_teams, updated_fantasy_league.number_of_teams
         )
         self.assertNotEqual(
-            updated_fantasy_league_settings.number_of_teams,
-            fantasy_league.number_of_teams
+            updated_fantasy_league_settings.number_of_teams, fantasy_league.number_of_teams
         )
         self.assertEqual(updated_fantasy_league.name, fantasy_league.name)
         self.assertEqual(updated_fantasy_league.available_leagues, fantasy_league.available_leagues)
@@ -137,11 +128,10 @@ class TestCrudFantasyLeague(TestBase):
         # Assert
         self.assertEqual(
             updated_fantasy_league_settings.available_leagues,
-            updated_fantasy_league.available_leagues
+            updated_fantasy_league.available_leagues,
         )
         self.assertNotEqual(
-            updated_fantasy_league_settings.available_leagues,
-            fantasy_league.available_leagues
+            updated_fantasy_league_settings.available_leagues, fantasy_league.available_leagues
         )
         self.assertEqual(updated_fantasy_league.name, fantasy_league.name)
         self.assertEqual(updated_fantasy_league.number_of_teams, fantasy_league.number_of_teams)
@@ -152,9 +142,7 @@ class TestCrudFantasyLeague(TestBase):
 
         # Act and Assert
         with self.assertRaises(AssertionError):
-            self.db.update_fantasy_league_settings(
-                FantasyLeagueID("123"), fantasy_league_settings
-            )
+            self.db.update_fantasy_league_settings(FantasyLeagueID("123"), fantasy_league_settings)
 
     def test_update_fantasy_league_status(self):
         # Arrange
@@ -166,9 +154,7 @@ class TestCrudFantasyLeague(TestBase):
 
         # Act and Assert
         self.assertNotEqual(fantasy_league.status, new_status)
-        updated_fantasy_league = self.db.update_fantasy_league_status(
-            fantasy_league.id, new_status
-        )
+        updated_fantasy_league = self.db.update_fantasy_league_status(fantasy_league.id, new_status)
         self.assertEqual(expected_updated_fantasy_league, updated_fantasy_league)
         with self.assertRaises(AssertionError):
             self.db.update_fantasy_league_status(FantasyLeagueID("123"), new_status)

--- a/tests/db/fantasy/test_membership.py
+++ b/tests/db/fantasy/test_membership.py
@@ -7,7 +7,7 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueID,
     FantasyLeagueMembership,
     FantasyLeagueMembershipStatus,
-    UserID
+    UserID,
 )
 
 
@@ -19,7 +19,7 @@ class TestCrudFantasyLeagueMembership(TestBase):
         membership = FantasyLeagueMembership(
             league_id=fantasy_league.id,
             user_id=user.id,
-            status=FantasyLeagueMembershipStatus.ACCEPTED
+            status=FantasyLeagueMembershipStatus.ACCEPTED,
         )
 
         # Act and Assert
@@ -34,10 +34,7 @@ class TestCrudFantasyLeagueMembership(TestBase):
         self.assertEqual(membership, membership_after_create)
         with self.assertRaises(IntegrityError) as context:
             self.db.create_fantasy_league_membership(membership)
-        self.assertIn(
-            'duplicate key value violates unique constraint',
-            str(context.exception)
-        )
+        self.assertIn("duplicate key value violates unique constraint", str(context.exception))
 
     def test_get_pending_and_accepted_members_for_league(self):
         # Arrange
@@ -49,22 +46,22 @@ class TestCrudFantasyLeagueMembership(TestBase):
         user_membership_accepted = FantasyLeagueMembership(
             league_id=fantasy_league.id,
             user_id=user.id,
-            status=FantasyLeagueMembershipStatus.ACCEPTED
+            status=FantasyLeagueMembershipStatus.ACCEPTED,
         )
         user_2_membership_pending = FantasyLeagueMembership(
             league_id=fantasy_league.id,
             user_id=user_2.id,
-            status=FantasyLeagueMembershipStatus.PENDING
+            status=FantasyLeagueMembershipStatus.PENDING,
         )
         user_3_membership_revoked = FantasyLeagueMembership(
             league_id=fantasy_league.id,
             user_id=user_3.id,
-            status=FantasyLeagueMembershipStatus.REVOKED
+            status=FantasyLeagueMembershipStatus.REVOKED,
         )
         user_4_membership_declined = FantasyLeagueMembership(
             league_id=fantasy_league.id,
             user_id=user_4.id,
-            status=FantasyLeagueMembershipStatus.DECLINED
+            status=FantasyLeagueMembershipStatus.DECLINED,
         )
         self.db.create_fantasy_league_membership(user_membership_accepted)
         self.db.create_fantasy_league_membership(user_2_membership_pending)
@@ -91,7 +88,7 @@ class TestCrudFantasyLeagueMembership(TestBase):
         membership = FantasyLeagueMembership(
             league_id=fantasy_league.id,
             user_id=user.id,
-            status=FantasyLeagueMembershipStatus.PENDING
+            status=FantasyLeagueMembershipStatus.PENDING,
         )
         new_status = FantasyLeagueMembershipStatus.ACCEPTED
         expected_updated_membership = membership.model_copy(deep=True)
@@ -112,14 +109,13 @@ class TestCrudFantasyLeagueMembership(TestBase):
         membership = FantasyLeagueMembership(
             league_id=fantasy_league.id,
             user_id=user.id,
-            status=FantasyLeagueMembershipStatus.PENDING
+            status=FantasyLeagueMembershipStatus.PENDING,
         )
         self.db.create_fantasy_league_membership(membership)
 
         # Act and Assert
         self.assertEqual(
-            membership,
-            self.db.get_user_membership_for_fantasy_league(user.id, fantasy_league.id)
+            membership, self.db.get_user_membership_for_fantasy_league(user.id, fantasy_league.id)
         )
         self.assertIsNone(
             self.db.get_user_membership_for_fantasy_league(UserID("123"), fantasy_league.id)
@@ -138,12 +134,12 @@ class TestCrudFantasyLeagueMembership(TestBase):
         membership_1 = FantasyLeagueMembership(
             league_id=fantasy_league_1.id,
             user_id=user.id,
-            status=FantasyLeagueMembershipStatus.PENDING
+            status=FantasyLeagueMembershipStatus.PENDING,
         )
         membership_2 = FantasyLeagueMembership(
             league_id=fantasy_league_2.id,
             user_id=user.id,
-            status=FantasyLeagueMembershipStatus.ACCEPTED
+            status=FantasyLeagueMembershipStatus.ACCEPTED,
         )
         self.db.create_fantasy_league_membership(membership_1)
         self.db.create_fantasy_league_membership(membership_2)

--- a/tests/db/fantasy/test_user.py
+++ b/tests/db/fantasy/test_user.py
@@ -28,7 +28,7 @@ class TestCrudUser(TestBase):
         # Act and Assert
         with self.assertRaises(IntegrityError) as context:
             self.db.create_user(user_2)
-        self.assertIn('duplicate key value violates unique constraint', str(context.exception))
+        self.assertIn("duplicate key value violates unique constraint", str(context.exception))
 
     def test_create_user_with_existing_username_error(self):
         # Arrange
@@ -40,7 +40,7 @@ class TestCrudUser(TestBase):
         # Act and Assert
         with self.assertRaises(IntegrityError) as context:
             self.db.create_user(user_2)
-        self.assertIn('duplicate key value violates unique constraint', str(context.exception))
+        self.assertIn("duplicate key value violates unique constraint", str(context.exception))
 
     def test_get_user_by_id(self):
         # Arrange

--- a/tests/db/riot/test_riot_game.py
+++ b/tests/db/riot/test_riot_game.py
@@ -36,7 +36,7 @@ class TestCrudRiotGame(TestBase):
         games_to_save = [
             riot_fixtures.game_1_fixture_completed,
             riot_fixtures.game_2_fixture_inprogress,
-            riot_fixtures.game_3_fixture_unstarted
+            riot_fixtures.game_3_fixture_unstarted,
         ]
 
         # Act

--- a/tests/db/riot/test_riot_player_metadata.py
+++ b/tests/db/riot/test_riot_player_metadata.py
@@ -7,7 +7,7 @@ from src.common.schemas.riot_data_schemas import (
     PlayerRole,
     ProPlayerID,
     RiotGameID,
-    PlayerGameMetadata
+    PlayerGameMetadata,
 )
 
 
@@ -55,16 +55,10 @@ class TestCrudRiotPlayerMetadata(TestBase):
         # Act and Assert
         self.assertEqual(
             player_metadata,
-            self.db.get_player_metadata(
-                player_metadata.player_id, player_metadata.game_id
-            )
+            self.db.get_player_metadata(player_metadata.player_id, player_metadata.game_id),
         )
-        self.assertIsNone(
-            self.db.get_player_metadata(ProPlayerID("123"), player_metadata.game_id)
-        )
-        self.assertIsNone(
-            self.db.get_player_metadata(player_metadata.player_id, RiotGameID("123"))
-        )
+        self.assertIsNone(self.db.get_player_metadata(ProPlayerID("123"), player_metadata.game_id))
+        self.assertIsNone(self.db.get_player_metadata(player_metadata.player_id, RiotGameID("123")))
 
     def test_get_games_without_player_metadata_completed_game_without_10_rows(self):
         game = riot_fixtures.game_1_fixture_completed
@@ -124,6 +118,6 @@ class TestCrudRiotPlayerMetadata(TestBase):
             player_id=ProPlayerID(str(random.randint(1, 9999999))),
             participant_id=participant_id,
             champion_id=f"championId{participant_id}",
-            role=role
+            role=role,
         )
         self.db.put_player_metadata(player_metadata)

--- a/tests/db/riot/test_riot_player_stats.py
+++ b/tests/db/riot/test_riot_player_stats.py
@@ -49,11 +49,9 @@ class TestCrudRiotPlayerStats(TestBase):
         # Act and Assert
         self.assertEqual(
             player_stats,
-            self.db.get_player_stats(player_stats.game_id, player_stats.participant_id)
+            self.db.get_player_stats(player_stats.game_id, player_stats.participant_id),
         )
-        self.assertIsNone(
-            self.db.get_player_stats(RiotGameID("123"), player_stats.participant_id)
-        )
+        self.assertIsNone(self.db.get_player_stats(RiotGameID("123"), player_stats.participant_id))
         self.assertIsNone(self.db.get_player_stats(player_stats.game_id, 123))
 
     def test_get_game_ids_to_fetch_player_stats_for_completed_game_without_10_rows(self):
@@ -229,6 +227,6 @@ class TestCrudRiotPlayerStats(TestBase):
             kill_participation=int(0.5),
             champion_damage_share=int(0.2),
             wards_placed=10,
-            wards_destroyed=10
+            wards_destroyed=10,
         )
         self.db.put_player_stats(player_game_stats)

--- a/tests/fantasy/integration/service/test_fantasy_league_service.py
+++ b/tests/fantasy/integration/service/test_fantasy_league_service.py
@@ -16,7 +16,7 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueDraftOrderResponse,
     UsersFantasyLeagues,
     UserAccountStatus,
-    UserID
+    UserID,
 )
 from src.common.exceptions import LeagueNotFoundException
 from src.fantasy.exceptions import (
@@ -28,7 +28,7 @@ from src.fantasy.exceptions import (
     FantasyUnavailableException,
     FantasyLeagueInvalidRequiredStateException,
     ForbiddenException,
-    UserNotFoundException
+    UserNotFoundException,
 )
 from src.fantasy.service import FantasyLeagueService
 
@@ -60,7 +60,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.assertEqual(1, len(draft_order_from_db))
         self.assertEqual(
             FantasyLeagueDraftOrder.model_validate(expected_draft_order),
-            FantasyLeagueDraftOrder.model_validate(draft_order_from_db[0])
+            FantasyLeagueDraftOrder.model_validate(draft_order_from_db[0]),
         )
 
     def test_default_fantasy_league_scoring_settings_created_on_fantasy_league_creation(self):
@@ -84,7 +84,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.assertIsNotNone(scoring_settings_from_db)
         self.assertEqual(
             FantasyLeagueScoringSettings.model_validate(expected_default_settings),
-            FantasyLeagueScoringSettings.model_validate(scoring_settings_from_db)
+            FantasyLeagueScoringSettings.model_validate(scoring_settings_from_db),
         )
 
     def test_fantasy_league_membership_created_on_fantasy_league_creation(self):
@@ -103,8 +103,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.assertEqual(1, len(fantasy_league_memberships))
         self.assertEqual(user.id, fantasy_league_memberships[0].user_id)
         self.assertEqual(
-            FantasyLeagueMembershipStatus.ACCEPTED,
-            fantasy_league_memberships[0].status
+            FantasyLeagueMembershipStatus.ACCEPTED, fantasy_league_memberships[0].status
         )
 
     def test_create_fantasy_league_with_available_leagues_successful(self):
@@ -177,7 +176,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         # Assert
         self.assertEqual(
             expected_fantasy_league_settings,
-            FantasyLeagueSettings.model_validate(returned_fantasy_league_settings)
+            FantasyLeagueSettings.model_validate(returned_fantasy_league_settings),
         )
 
     def test_get_fantasy_league_settings_non_existing_fantasy_league_exception(self):
@@ -218,13 +217,12 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         returned_settings = self.fantasy_league_service.update_fantasy_league_settings(
             fantasy_fixtures.user_fixture.id,
             fantasy_fixtures.fantasy_league_fixture.id,
-            updated_fantasy_league_settings
+            updated_fantasy_league_settings,
         )
 
         # Assert
         self.assertEqual(
-            updated_fantasy_league_settings,
-            FantasyLeagueSettings.model_validate(returned_settings)
+            updated_fantasy_league_settings, FantasyLeagueSettings.model_validate(returned_settings)
         )
 
     def test_update_fantasy_league_settings_available_leagues_successful(self):
@@ -240,7 +238,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         returned_settings = self.fantasy_league_service.update_fantasy_league_settings(
             fantasy_fixtures.user_fixture.id,
             fantasy_fixtures.fantasy_league_fixture.id,
-            updated_fantasy_league_settings
+            updated_fantasy_league_settings,
         )
 
         # Assert
@@ -260,7 +258,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             self.fantasy_league_service.update_fantasy_league_settings(
                 fantasy_fixtures.user_fixture.id,
                 fantasy_fixtures.fantasy_league_fixture.id,
-                updated_fantasy_league_settings
+                updated_fantasy_league_settings,
             )
 
     def test_update_fantasy_league_settings_available_fantasy_unavailable_exception(self):
@@ -277,7 +275,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             self.fantasy_league_service.update_fantasy_league_settings(
                 fantasy_fixtures.user_fixture.id,
                 fantasy_fixtures.fantasy_league_fixture.id,
-                updated_fantasy_league_settings
+                updated_fantasy_league_settings,
             )
 
     def test_update_fantasy_league_settings_non_existing_fantasy_league_exception(self):
@@ -292,7 +290,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             self.fantasy_league_service.update_fantasy_league_settings(
                 fantasy_fixtures.user_fixture.id,
                 FantasyLeagueID("badFantasyLeagueId"),
-                updated_fantasy_league_settings
+                updated_fantasy_league_settings,
             )
 
     def test_update_fantasy_league_settings_non_owner_of_fantasy_league_exception(self):
@@ -308,7 +306,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             self.fantasy_league_service.update_fantasy_league_settings(
                 fantasy_fixtures.user_2_fixture.id,
                 fantasy_fixtures.fantasy_league_fixture.id,
-                updated_fantasy_league_settings
+                updated_fantasy_league_settings,
             )
 
     def test_update_fantasy_league_settings_status_not_pre_draft_exception(self):
@@ -323,7 +321,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             self.fantasy_league_service.update_fantasy_league_settings(
                 fantasy_fixtures.user_fixture.id,
                 fantasy_fixtures.fantasy_league_active_fixture.id,
-                updated_fantasy_league_settings
+                updated_fantasy_league_settings,
             )
 
     def test_update_fantasy_league_settings_num_teams_less_than_active_member_count(self):
@@ -341,9 +339,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         # Act and Assert
         with self.assertRaises(FantasyLeagueSettingsException):
             self.fantasy_league_service.update_fantasy_league_settings(
-                fantasy_fixtures.user_fixture.id,
-                fantasy_league.id,
-                updated_fantasy_league_settings
+                fantasy_fixtures.user_fixture.id, fantasy_league.id, updated_fantasy_league_settings
             )
 
     # --------------------------------------------------
@@ -388,7 +384,8 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         # Act and Act
         with self.assertRaises(FantasyLeagueNotFoundException):
             self.fantasy_league_service.get_scoring_settings(
-                user.id, FantasyLeagueID("badLeagueId"))
+                user.id, FantasyLeagueID("badLeagueId")
+            )
 
     # --------------------------------------------------
     # ----- Update Fantasy League Scoring Settings -----
@@ -417,7 +414,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         db_scoring_settings = self.db.get_fantasy_league_scoring_settings_by_id(fantasy_league.id)
         self.assertEqual(
             expected_updated_scoring_settings,
-            FantasyLeagueScoringSettings.model_validate(db_scoring_settings)
+            FantasyLeagueScoringSettings.model_validate(db_scoring_settings),
         )
 
     def test_update_scoring_settings_non_existing_fantasy_league_exception(self):
@@ -515,7 +512,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         )
         self.assertEqual(
             fantasy_league_2_scoring_settings,
-            FantasyLeagueScoringSettings.model_validate(league_2_scoring_settings_from_db)
+            FantasyLeagueScoringSettings.model_validate(league_2_scoring_settings_from_db),
         )
 
     # --------------------------------------------------
@@ -533,41 +530,44 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
 
         # Create user_2's memberships
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_fixture.id,
             fantasy_fixtures.user_2_fixture.id,
-            FantasyLeagueMembershipStatus.PENDING
+            FantasyLeagueMembershipStatus.PENDING,
         )
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_2_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
 
         # Act
-        users_fantasy_leagues = self.fantasy_league_service. \
-            get_users_pending_and_accepted_fantasy_leagues(fantasy_fixtures.user_2_fixture.id)
+        users_fantasy_leagues = (
+            self.fantasy_league_service.get_users_pending_and_accepted_fantasy_leagues(
+                fantasy_fixtures.user_2_fixture.id
+            )
+        )
 
         # Assert
         self.assertIsInstance(users_fantasy_leagues, UsersFantasyLeagues)
         self.assertEqual(1, len(users_fantasy_leagues.pending))
         self.assertEqual(
             fantasy_fixtures.fantasy_league_fixture,
-            FantasyLeague.model_validate(users_fantasy_leagues.pending[0])
+            FantasyLeague.model_validate(users_fantasy_leagues.pending[0]),
         )
         self.assertEqual(1, len(users_fantasy_leagues.accepted))
         self.assertEqual(
             fantasy_fixtures.fantasy_league_active_fixture,
-            FantasyLeague.model_validate(users_fantasy_leagues.accepted[0])
+            FantasyLeague.model_validate(users_fantasy_leagues.accepted[0]),
         )
 
     def test_get_users_pending_and_accepted_fantasy_leagues_no_pending_or_accepted(self):
@@ -581,17 +581,20 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
 
         # Act
-        users_fantasy_leagues = self.fantasy_league_service. \
-            get_users_pending_and_accepted_fantasy_leagues(fantasy_fixtures.user_2_fixture.id)
+        users_fantasy_leagues = (
+            self.fantasy_league_service.get_users_pending_and_accepted_fantasy_leagues(
+                fantasy_fixtures.user_2_fixture.id
+            )
+        )
 
         # Assert
         self.assertIsInstance(users_fantasy_leagues, UsersFantasyLeagues)
@@ -755,11 +758,11 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.assertEqual(2, len(draft_order_from_db))
         self.assertEqual(
             FantasyLeagueDraftOrder.model_validate(expected_user_1_draft_order),
-            FantasyLeagueDraftOrder.model_validate(draft_order_from_db[0])
+            FantasyLeagueDraftOrder.model_validate(draft_order_from_db[0]),
         )
         self.assertEqual(
             FantasyLeagueDraftOrder.model_validate(expected_user_2_draft_order),
-            FantasyLeagueDraftOrder.model_validate(draft_order_from_db[1])
+            FantasyLeagueDraftOrder.model_validate(draft_order_from_db[1]),
         )
 
     def test_join_fantasy_league_no_membership_for_league(self):
@@ -895,10 +898,12 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             fantasy_league.id, user_2.id, FantasyLeagueMembershipStatus.ACCEPTED
         )
         user_1_draft_order = self.create_draft_order_for_fantasy_league(
-            fantasy_league.id, user_1.id, 1)
+            fantasy_league.id, user_1.id, 1
+        )
         self.create_draft_order_for_fantasy_league(fantasy_league.id, user_2.id, 2)
         user_3_draft_order = self.create_draft_order_for_fantasy_league(
-            fantasy_league.id, user_3.id, 3)
+            fantasy_league.id, user_3.id, 3
+        )
 
         # Act
         self.fantasy_league_service.leave_fantasy_league(user_2.id, fantasy_league.id)
@@ -909,13 +914,13 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.assertEqual(2, len(draft_order_from_db))
         self.assertEqual(
             FantasyLeagueDraftOrder.model_validate(user_1_draft_order),
-            FantasyLeagueDraftOrder.model_validate(draft_order_from_db[0])
+            FantasyLeagueDraftOrder.model_validate(draft_order_from_db[0]),
         )
         expected_updated_user_3_draft_order = user_3_draft_order
         expected_updated_user_3_draft_order.position = 2
         self.assertEqual(
             FantasyLeagueDraftOrder.model_validate(expected_updated_user_3_draft_order),
-            FantasyLeagueDraftOrder.model_validate(draft_order_from_db[1])
+            FantasyLeagueDraftOrder.model_validate(draft_order_from_db[1]),
         )
 
     def test_leave_fantasy_league_when_owner_exception(self):
@@ -979,13 +984,14 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         users = [
             fantasy_fixtures.user_fixture,
             fantasy_fixtures.user_2_fixture,
-            fantasy_fixtures.user_3_fixture
+            fantasy_fixtures.user_3_fixture,
         ]
         draft_order_position = 1
         for user in users:
             self.db.create_user(user)
             self.create_draft_order_for_fantasy_league(
-                fantasy_league.id, user.id, draft_order_position)
+                fantasy_league.id, user.id, draft_order_position
+            )
             self.create_fantasy_league_membership_for_league(
                 fantasy_league.id, user.id, FantasyLeagueMembershipStatus.ACCEPTED
             )
@@ -1021,13 +1027,14 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         users = [
             fantasy_fixtures.user_fixture,
             fantasy_fixtures.user_2_fixture,
-            fantasy_fixtures.user_3_fixture
+            fantasy_fixtures.user_3_fixture,
         ]
         draft_order_position = 1
         for user in users:
             self.db.create_user(user)
             self.create_draft_order_for_fantasy_league(
-                fantasy_league.id, user.id, draft_order_position)
+                fantasy_league.id, user.id, draft_order_position
+            )
             self.create_fantasy_league_membership_for_league(
                 fantasy_league.id, user.id, FantasyLeagueMembershipStatus.ACCEPTED
             )
@@ -1052,7 +1059,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             self.fantasy_league_service.revoke_from_fantasy_league(
                 active_fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
-                fantasy_fixtures.user_2_fixture.id
+                fantasy_fixtures.user_2_fixture.id,
             )
 
     def test_revoke_from_fantasy_league_not_owner_exception(self):
@@ -1078,13 +1085,14 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
 
         # Act and Assert
         with self.assertRaises(FantasyLeagueInviteException) as context:
             self.fantasy_league_service.revoke_from_fantasy_league(
-                fantasy_league.id, user.id, user.id)
+                fantasy_league.id, user.id, user.id
+            )
         self.assertIn("Invalid revoke request", str(context.exception))
 
     def test_revoke_from_fantasy_league_no_membership_exception(self):
@@ -1097,12 +1105,12 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_3_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
 
         # Act and assert
@@ -1110,7 +1118,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             self.fantasy_league_service.revoke_from_fantasy_league(
                 fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
-                fantasy_fixtures.user_2_fixture.id
+                fantasy_fixtures.user_2_fixture.id,
             )
         self.assertIn("No accepted membership", str(context.exception))
 
@@ -1124,17 +1132,17 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_2_fixture.id,
-            FantasyLeagueMembershipStatus.PENDING
+            FantasyLeagueMembershipStatus.PENDING,
         )
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_3_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
 
         # Act and assert
@@ -1142,7 +1150,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             self.fantasy_league_service.revoke_from_fantasy_league(
                 fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
-                fantasy_fixtures.user_2_fixture.id
+                fantasy_fixtures.user_2_fixture.id,
             )
         self.assertIn("No accepted membership", str(context.exception))
 
@@ -1157,7 +1165,8 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.db.create_fantasy_league(fantasy_league)
         self.db.create_user(user_1)
         user_1_draft_order = self.create_draft_order_for_fantasy_league(
-            fantasy_league.id, user_1.id, 1)
+            fantasy_league.id, user_1.id, 1
+        )
         user_1_draft_order_response = FantasyLeagueDraftOrderResponse(
             user_id=user_1.id, username=user_1.username, position=user_1_draft_order.position
         )
@@ -1205,33 +1214,29 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         fantasy_league = fantasy_fixtures.fantasy_league_fixture
         self.db.create_fantasy_league(fantasy_league)
         self.create_draft_order_for_fantasy_league(
-            fantasy_league.id,
-            fantasy_fixtures.user_fixture.id,
-            1
+            fantasy_league.id, fantasy_fixtures.user_fixture.id, 1
         )
         self.create_draft_order_for_fantasy_league(
-            fantasy_league.id,
-            fantasy_fixtures.user_2_fixture.id,
-            2
+            fantasy_league.id, fantasy_fixtures.user_2_fixture.id, 2
         )
         expected_updated_draft_order = [
             FantasyLeagueDraftOrderResponse(
                 user_id=fantasy_fixtures.user_fixture.id,
                 username=fantasy_fixtures.user_fixture.username,
-                position=2
+                position=2,
             ),
             FantasyLeagueDraftOrderResponse(
                 user_id=fantasy_fixtures.user_2_fixture.id,
                 username=fantasy_fixtures.user_2_fixture.username,
-                position=1
-            )
+                position=1,
+            ),
         ]
 
         # Act
         self.fantasy_league_service.update_fantasy_league_draft_order(
             fantasy_fixtures.user_fixture.id,
             fantasy_fixtures.fantasy_league_fixture.id,
-            expected_updated_draft_order
+            expected_updated_draft_order,
         )
 
         # Assert
@@ -1247,20 +1252,16 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         fantasy_league = fantasy_fixtures.fantasy_league_fixture
         self.db.create_fantasy_league(fantasy_league)
         self.create_draft_order_for_fantasy_league(
-            fantasy_league.id,
-            fantasy_fixtures.user_fixture.id,
-            1
+            fantasy_league.id, fantasy_fixtures.user_fixture.id, 1
         )
         self.create_draft_order_for_fantasy_league(
-            fantasy_league.id,
-            fantasy_fixtures.user_2_fixture.id,
-            2
+            fantasy_league.id, fantasy_fixtures.user_2_fixture.id, 2
         )
         expected_updated_draft_order = [
             FantasyLeagueDraftOrderResponse(
                 user_id=fantasy_fixtures.user_fixture.id,
                 username=fantasy_fixtures.user_fixture.username,
-                position=1
+                position=1,
             )
         ]
 
@@ -1269,7 +1270,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             self.fantasy_league_service.update_fantasy_league_draft_order(
                 fantasy_fixtures.user_fixture.id,
                 fantasy_fixtures.fantasy_league_fixture.id,
-                expected_updated_draft_order
+                expected_updated_draft_order,
             )
 
     def test_update_fantasy_league_draft_order_bad_user_id(self):
@@ -1277,26 +1278,22 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         fantasy_league = fantasy_fixtures.fantasy_league_fixture
         self.db.create_fantasy_league(fantasy_league)
         self.create_draft_order_for_fantasy_league(
-            fantasy_league.id,
-            fantasy_fixtures.user_fixture.id,
-            1
+            fantasy_league.id, fantasy_fixtures.user_fixture.id, 1
         )
         self.create_draft_order_for_fantasy_league(
-            fantasy_league.id,
-            fantasy_fixtures.user_2_fixture.id,
-            2
+            fantasy_league.id, fantasy_fixtures.user_2_fixture.id, 2
         )
         expected_updated_draft_order = [
             FantasyLeagueDraftOrderResponse(
                 user_id=fantasy_fixtures.user_fixture.id,
                 username=fantasy_fixtures.user_fixture.username,
-                position=2
+                position=2,
             ),
             FantasyLeagueDraftOrderResponse(
                 user_id=fantasy_fixtures.user_3_fixture.id,
                 username=fantasy_fixtures.user_3_fixture.username,
-                position=1
-            )
+                position=1,
+            ),
         ]
 
         # Act and Assert
@@ -1304,7 +1301,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             self.fantasy_league_service.update_fantasy_league_draft_order(
                 fantasy_fixtures.user_fixture.id,
                 fantasy_fixtures.fantasy_league_fixture.id,
-                expected_updated_draft_order
+                expected_updated_draft_order,
             )
 
     def test_update_fantasy_league_draft_order_bad_position_order(self):
@@ -1312,26 +1309,22 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         fantasy_league = fantasy_fixtures.fantasy_league_fixture
         self.db.create_fantasy_league(fantasy_league)
         self.create_draft_order_for_fantasy_league(
-            fantasy_league.id,
-            fantasy_fixtures.user_fixture.id,
-            1
+            fantasy_league.id, fantasy_fixtures.user_fixture.id, 1
         )
         self.create_draft_order_for_fantasy_league(
-            fantasy_league.id,
-            fantasy_fixtures.user_2_fixture.id,
-            2
+            fantasy_league.id, fantasy_fixtures.user_2_fixture.id, 2
         )
         expected_updated_draft_order = [
             FantasyLeagueDraftOrderResponse(
                 user_id=fantasy_fixtures.user_fixture.id,
                 username=fantasy_fixtures.user_fixture.username,
-                position=3
+                position=3,
             ),
             FantasyLeagueDraftOrderResponse(
                 user_id=fantasy_fixtures.user_2_fixture.id,
                 username=fantasy_fixtures.user_2_fixture.username,
-                position=1
-            )
+                position=1,
+            ),
         ]
 
         # Act and Assert
@@ -1339,7 +1332,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             self.fantasy_league_service.update_fantasy_league_draft_order(
                 fantasy_fixtures.user_fixture.id,
                 fantasy_fixtures.fantasy_league_fixture.id,
-                expected_updated_draft_order
+                expected_updated_draft_order,
             )
 
     def test_update_fantasy_league_draft_order_no_existing_fantasy_league(self):
@@ -1350,7 +1343,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             FantasyLeagueDraftOrderResponse(
                 user_id=fantasy_fixtures.user_fixture.id,
                 username=fantasy_fixtures.user_fixture.username,
-                position=1
+                position=1,
             )
         ]
 
@@ -1359,7 +1352,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             self.fantasy_league_service.update_fantasy_league_draft_order(
                 fantasy_fixtures.user_fixture.id,
                 fantasy_fixtures.fantasy_league_fixture.id,
-                expected_updated_draft_order
+                expected_updated_draft_order,
             )
 
     def test_update_fantasy_league_draft_order_not_owner_of_league(self):
@@ -1369,7 +1362,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             FantasyLeagueDraftOrderResponse(
                 user_id=fantasy_fixtures.user_fixture.id,
                 username=fantasy_fixtures.user_fixture.username,
-                position=1
+                position=1,
             )
         ]
 
@@ -1378,7 +1371,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             self.fantasy_league_service.update_fantasy_league_draft_order(
                 fantasy_fixtures.user_2_fixture.id,
                 fantasy_fixtures.fantasy_league_fixture.id,
-                expected_updated_draft_order
+                expected_updated_draft_order,
             )
 
     def test_update_fantasy_league_draft_order_not_in_pre_draft_exception(self):
@@ -1388,7 +1381,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             FantasyLeagueDraftOrderResponse(
                 user_id=fantasy_fixtures.user_fixture.id,
                 username=fantasy_fixtures.user_fixture.username,
-                position=1
+                position=1,
             )
         ]
 
@@ -1397,7 +1390,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
             self.fantasy_league_service.update_fantasy_league_draft_order(
                 fantasy_fixtures.user_fixture.id,
                 fantasy_fixtures.fantasy_league_active_fixture.id,
-                updated_draft_order
+                updated_draft_order,
             )
 
     # --------------------------------------------------
@@ -1477,7 +1470,9 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.assertIn("Invalid member count", str(context.exception))
         self.assertIn(
             f"Expected {fantasy_league.number_of_teams} but has "
-            f"{fantasy_league.number_of_teams - 1}", str(context.exception))
+            f"{fantasy_league.number_of_teams - 1}",
+            str(context.exception),
+        )
         db_fantasy_league = self.db.get_fantasy_league_by_id(fantasy_league.id)
         self.assertEqual(FantasyLeagueStatus.PRE_DRAFT, db_fantasy_league.status)
         self.assertEqual(None, db_fantasy_league.current_draft_position)
@@ -1501,7 +1496,9 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.assertIn("Invalid member count", str(context.exception))
         self.assertIn(
             f"Expected {fantasy_league.number_of_teams} but has "
-            f"{fantasy_league.number_of_teams + 1}", str(context.exception))
+            f"{fantasy_league.number_of_teams + 1}",
+            str(context.exception),
+        )
         db_fantasy_league = self.db.get_fantasy_league_by_id(fantasy_league.id)
         self.assertEqual(FantasyLeagueStatus.PRE_DRAFT, db_fantasy_league.status)
         self.assertEqual(None, db_fantasy_league.current_draft_position)
@@ -1528,23 +1525,15 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.assertEqual(None, db_fantasy_league.current_draft_position)
 
     def create_fantasy_league_membership_for_league(
-            self,
-            league_id: FantasyLeagueID,
-            user_id: UserID,
-            status: FantasyLeagueMembershipStatus
+        self, league_id: FantasyLeagueID, user_id: UserID, status: FantasyLeagueMembershipStatus
     ):
         fantasy_league_membership = FantasyLeagueMembership(
-            league_id=league_id,
-            user_id=user_id,
-            status=status
+            league_id=league_id, user_id=user_id, status=status
         )
         self.db.create_fantasy_league_membership(fantasy_league_membership)
 
     def create_draft_order_for_fantasy_league(
-            self,
-            league_id: FantasyLeagueID,
-            user_id: UserID,
-            position: int
+        self, league_id: FantasyLeagueID, user_id: UserID, position: int
     ):
         new_draft_position = FantasyLeagueDraftOrder(
             fantasy_league_id=league_id, user_id=user_id, position=position

--- a/tests/fantasy/integration/service/test_fantasy_team_service.py
+++ b/tests/fantasy/integration/service/test_fantasy_team_service.py
@@ -10,19 +10,19 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueMembershipStatus,
     FantasyLeagueStatus,
     FantasyLeagueDraftOrder,
-    UserID
+    UserID,
 )
 from src.common.schemas.riot_data_schemas import (
     PlayerRole,
     ProfessionalPlayer,
     ProPlayerID,
-    ProTeamID
+    ProTeamID,
 )
 from src.fantasy.exceptions import (
     FantasyDraftException,
     FantasyLeagueNotFoundException,
     FantasyLeagueInvalidRequiredStateException,
-    FantasyMembershipException
+    FantasyMembershipException,
 )
 from src.fantasy.service import FantasyTeamService
 from src.common.exceptions import ProfessionalPlayerNotFoundException
@@ -32,7 +32,7 @@ pro_player_fixture = ProfessionalPlayer(
     team_id=ProTeamID(str(uuid.uuid4())),
     summoner_name="summonerName1",
     image="imageUrl",
-    role=PlayerRole.JUNGLE
+    role=PlayerRole.JUNGLE,
 )
 
 pro_player_2_fixture = ProfessionalPlayer(
@@ -40,7 +40,7 @@ pro_player_2_fixture = ProfessionalPlayer(
     team_id=ProTeamID(str(uuid.uuid4())),
     summoner_name="summonerName2",
     image="imageUrl2",
-    role=PlayerRole.JUNGLE
+    role=PlayerRole.JUNGLE,
 )
 
 
@@ -60,12 +60,12 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_2_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         user_1_fantasy_team_week_1 = deepcopy(fantasy_fixtures.fantasy_team_week_1)
         user_1_fantasy_team_week_1.jungle_player_id = pro_player_fixture.id
@@ -85,8 +85,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
 
         # Act
         returned_fantasy_team_weeks = self.fantasy_team_service.get_all_fantasy_team_weeks(
-            fantasy_fixtures.fantasy_league_active_fixture.id,
-            fantasy_fixtures.user_fixture.id
+            fantasy_fixtures.fantasy_league_active_fixture.id, fantasy_fixtures.user_fixture.id
         )
 
         # Assert
@@ -112,8 +111,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         # Act and Assert
         with self.assertRaises(FantasyLeagueInvalidRequiredStateException):
             self.fantasy_team_service.get_all_fantasy_team_weeks(
-                fantasy_fixtures.fantasy_league_fixture.id,
-                fantasy_fixtures.user_fixture.id
+                fantasy_fixtures.fantasy_league_fixture.id, fantasy_fixtures.user_fixture.id
             )
 
     def test_get_all_fantasy_team_weeks_user_not_an_active_member(self):
@@ -123,14 +121,13 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.PENDING
+            FantasyLeagueMembershipStatus.PENDING,
         )
 
         # Act and Assert
         with self.assertRaises(FantasyMembershipException):
             self.fantasy_team_service.get_all_fantasy_team_weeks(
-                fantasy_fixtures.fantasy_league_active_fixture.id,
-                fantasy_fixtures.user_fixture.id
+                fantasy_fixtures.fantasy_league_active_fixture.id, fantasy_fixtures.user_fixture.id
             )
 
     def test_get_all_fantasy_team_weeks_user_has_no_membership(self):
@@ -141,8 +138,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         # Act and Assert
         with self.assertRaises(FantasyMembershipException):
             self.fantasy_team_service.get_all_fantasy_team_weeks(
-                fantasy_fixtures.fantasy_league_active_fixture.id,
-                fantasy_fixtures.user_fixture.id
+                fantasy_fixtures.fantasy_league_active_fixture.id, fantasy_fixtures.user_fixture.id
             )
 
     # --------------------------------------
@@ -406,7 +402,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         self.db.put_fantasy_team(fantasy_fixtures.fantasy_team_week_1)
 
@@ -415,7 +411,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             self.fantasy_team_service.pickup_player(
                 fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
-                riot_fixtures.player_1_fixture.id
+                riot_fixtures.player_1_fixture.id,
             )
         self.assertIn("Player not in available league", str(context.exception))
 
@@ -429,7 +425,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         self.db.put_fantasy_team(fantasy_fixtures.fantasy_team_week_1)
 
@@ -438,7 +434,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             self.fantasy_team_service.pickup_player(
                 fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
-                riot_fixtures.player_1_fixture.id
+                riot_fixtures.player_1_fixture.id,
             )
         self.assertIn("Player not in available league", str(context.exception))
 
@@ -452,7 +448,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         user_1_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
         user_1_fantasy_team.top_player_id = "somePlayerId"
@@ -463,7 +459,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             self.fantasy_team_service.pickup_player(
                 fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
-                riot_fixtures.player_1_fixture.id
+                riot_fixtures.player_1_fixture.id,
             )
         self.assertIn("Slot not available for role", str(context.exception))
 
@@ -478,12 +474,12 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_2_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         self.db.put_fantasy_team(fantasy_fixtures.fantasy_team_week_1)
         user_2_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
@@ -496,7 +492,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             self.fantasy_team_service.pickup_player(
                 fantasy_fixtures.fantasy_league_active_fixture.id,
                 fantasy_fixtures.user_fixture.id,
-                riot_fixtures.player_1_fixture.id
+                riot_fixtures.player_1_fixture.id,
             )
         self.assertIn("Player already drafted", str(context.exception))
 
@@ -510,7 +506,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             self.fantasy_team_service.pickup_player(
                 FantasyLeagueID("badFantasyLeagueId"),
                 fantasy_fixtures.user_fixture.id,
-                pro_player_fixture.id
+                pro_player_fixture.id,
             )
 
     def test_pickup_player_fantasy_league_not_draft_or_active_state(self):
@@ -518,7 +514,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         bad_states = [
             FantasyLeagueStatus.PRE_DRAFT,
             FantasyLeagueStatus.COMPLETED,
-            FantasyLeagueStatus.DELETED
+            FantasyLeagueStatus.DELETED,
         ]
         self.db.create_user(fantasy_fixtures.user_fixture)
         self.db.put_player(pro_player_fixture)
@@ -531,9 +527,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             self.db.create_fantasy_league(bad_fantasy_league)
             with self.assertRaises(FantasyLeagueInvalidRequiredStateException):
                 self.fantasy_team_service.pickup_player(
-                    bad_fantasy_league.id,
-                    fantasy_fixtures.user_fixture.id,
-                    pro_player_fixture.id
+                    bad_fantasy_league.id, fantasy_fixtures.user_fixture.id, pro_player_fixture.id
                 )
 
     def test_pickup_player_user_not_an_active_member_exception(self):
@@ -546,7 +540,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.PENDING
+            FantasyLeagueMembershipStatus.PENDING,
         )
 
         # Act and Assert
@@ -554,7 +548,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             self.fantasy_team_service.pickup_player(
                 fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
-                riot_fixtures.player_1_fixture.id
+                riot_fixtures.player_1_fixture.id,
             )
 
     def test_pickup_player_professional_player_not_found_exception(self):
@@ -567,7 +561,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
 
         # Act and Assert
@@ -575,7 +569,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             self.fantasy_team_service.pickup_player(
                 fantasy_fixtures.fantasy_league_active_fixture.id,
                 fantasy_fixtures.user_fixture.id,
-                ProPlayerID("badProPlayerId")
+                ProPlayerID("badProPlayerId"),
             )
 
     # -------------------------------------
@@ -590,12 +584,12 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_2_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         user_1_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
         user_1_fantasy_team.jungle_player_id = pro_player_fixture.id
@@ -614,7 +608,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         returned_fantasy_team = self.fantasy_team_service.drop_player(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            pro_player_fixture.id
+            pro_player_fixture.id,
         )
 
         # Assert
@@ -638,7 +632,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         user_1_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
         user_1_fantasy_team.jungle_player_id = "someOtherPlayerId"
@@ -650,7 +644,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             self.fantasy_team_service.drop_player(
                 fantasy_fixtures.fantasy_league_active_fixture.id,
                 fantasy_fixtures.user_fixture.id,
-                pro_player_fixture.id
+                pro_player_fixture.id,
             )
         self.assertIn("Player not drafted", str(context.exception))
 
@@ -664,7 +658,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             self.fantasy_team_service.drop_player(
                 FantasyLeagueID("badFantasyLeagueId"),
                 fantasy_fixtures.user_fixture.id,
-                pro_player_fixture.id
+                pro_player_fixture.id,
             )
 
     def test_drop_player_fantasy_league_not_active_state(self):
@@ -673,7 +667,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             FantasyLeagueStatus.PRE_DRAFT,
             FantasyLeagueStatus.DRAFT,
             FantasyLeagueStatus.COMPLETED,
-            FantasyLeagueStatus.DELETED
+            FantasyLeagueStatus.DELETED,
         ]
         self.db.create_user(fantasy_fixtures.user_fixture)
         self.db.put_player(pro_player_fixture)
@@ -686,9 +680,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             self.db.create_fantasy_league(bad_fantasy_league)
             with self.assertRaises(FantasyLeagueInvalidRequiredStateException):
                 self.fantasy_team_service.drop_player(
-                    bad_fantasy_league.id,
-                    fantasy_fixtures.user_fixture.id,
-                    pro_player_fixture.id
+                    bad_fantasy_league.id, fantasy_fixtures.user_fixture.id, pro_player_fixture.id
                 )
 
     def test_drop_player_user_not_an_active_member_exception(self):
@@ -699,7 +691,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.PENDING
+            FantasyLeagueMembershipStatus.PENDING,
         )
 
         # Act and Assert
@@ -707,7 +699,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             self.fantasy_team_service.drop_player(
                 fantasy_fixtures.fantasy_league_active_fixture.id,
                 fantasy_fixtures.user_fixture.id,
-                pro_player_fixture.id
+                pro_player_fixture.id,
             )
 
     def test_drop_player_professional_player_not_found_exception(self):
@@ -717,7 +709,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
 
         # Act and Assert
@@ -725,7 +717,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             self.fantasy_team_service.drop_player(
                 fantasy_fixtures.fantasy_league_active_fixture.id,
                 fantasy_fixtures.user_fixture.id,
-                ProPlayerID("badProPlayerId")
+                ProPlayerID("badProPlayerId"),
             )
 
     # -------------------------------------
@@ -743,12 +735,12 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_2_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         jungle_player_1 = riot_fixtures.player_2_fixture
         jungle_player_2 = riot_fixtures.player_7_fixture
@@ -769,7 +761,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
             jungle_player_1.id,
-            jungle_player_2.id
+            jungle_player_2.id,
         )
 
         # Assert
@@ -797,7 +789,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         player_1 = riot_fixtures.player_1_fixture
         player_2 = riot_fixtures.player_2_fixture
@@ -808,10 +800,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         # Act and Assert
         with self.assertRaises(FantasyDraftException) as context:
             self.fantasy_team_service.swap_players(
-                fantasy_league.id,
-                fantasy_fixtures.user_fixture.id,
-                player_2.id,
-                player_1.id
+                fantasy_league.id, fantasy_fixtures.user_fixture.id, player_2.id, player_1.id
             )
         self.assertIn("Mismatching roles", str(context.exception))
         self.assertNotEqual(player_1.role, player_2.role)
@@ -826,7 +815,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         jungle_player_1 = riot_fixtures.player_2_fixture
         jungle_player_2 = riot_fixtures.player_7_fixture
@@ -840,7 +829,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
                 fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
                 jungle_player_1.id,
-                jungle_player_2.id
+                jungle_player_2.id,
             )
         self.assertIn("Player not drafted", str(context.exception))
         self.assertEqual(jungle_player_1.role, jungle_player_2.role)
@@ -876,7 +865,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
                 fantasy_league.id,
                 user_1.id,
                 riot_fixtures.player_2_fixture.id,
-                riot_fixtures.player_7_fixture.id
+                riot_fixtures.player_7_fixture.id,
             )
         self.assertIn("Player already drafted", str(context.exception))
         db_user_1_fantasy_teams = self.db.get_all_fantasy_teams_for_user(
@@ -902,7 +891,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_league.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
         user_1_fantasy_team = deepcopy(fantasy_fixtures.fantasy_team_week_1)
         user_1_fantasy_team.jungle_player_id = riot_fixtures.player_2_fixture.id
@@ -914,7 +903,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
                 fantasy_league.id,
                 fantasy_fixtures.user_fixture.id,
                 riot_fixtures.player_2_fixture.id,
-                riot_fixtures.player_7_fixture.id
+                riot_fixtures.player_7_fixture.id,
             )
         self.assertIn("Player not in available league", str(context.exception))
 
@@ -930,7 +919,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
                 FantasyLeagueID("badFantasyLeagueId"),
                 fantasy_fixtures.user_fixture.id,
                 pro_player_fixture.id,
-                pro_player_2_fixture.id
+                pro_player_2_fixture.id,
             )
 
     def test_swap_players_fantasy_league_not_active_state(self):
@@ -939,7 +928,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
             FantasyLeagueStatus.PRE_DRAFT,
             FantasyLeagueStatus.DRAFT,
             FantasyLeagueStatus.COMPLETED,
-            FantasyLeagueStatus.DELETED
+            FantasyLeagueStatus.DELETED,
         ]
         self.db.create_user(fantasy_fixtures.user_fixture)
         self.db.put_player(pro_player_fixture)
@@ -956,7 +945,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
                     bad_fantasy_league.id,
                     fantasy_fixtures.user_fixture.id,
                     pro_player_fixture.id,
-                    pro_player_2_fixture.id
+                    pro_player_2_fixture.id,
                 )
 
     def test_swap_players_user_not_an_active_member_exception(self):
@@ -968,7 +957,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.PENDING
+            FantasyLeagueMembershipStatus.PENDING,
         )
 
         # Act and Assert
@@ -977,7 +966,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
                 fantasy_fixtures.fantasy_league_active_fixture.id,
                 fantasy_fixtures.user_fixture.id,
                 pro_player_fixture.id,
-                pro_player_2_fixture.id
+                pro_player_2_fixture.id,
             )
 
     def test_swap_players_professional_player_to_drop_not_found_exception(self):
@@ -988,7 +977,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
 
         # Act and Assert
@@ -997,7 +986,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
                 fantasy_fixtures.fantasy_league_active_fixture.id,
                 fantasy_fixtures.user_fixture.id,
                 ProPlayerID("badProPlayerId"),
-                pro_player_2_fixture.id
+                pro_player_2_fixture.id,
             )
 
     def test_swap_players_professional_player_to_pickup_not_found_exception(self):
@@ -1008,7 +997,7 @@ class FantasyTeamServiceIntegrationTest(TestBase):
         self.create_fantasy_league_membership_for_league(
             fantasy_fixtures.fantasy_league_active_fixture.id,
             fantasy_fixtures.user_fixture.id,
-            FantasyLeagueMembershipStatus.ACCEPTED
+            FantasyLeagueMembershipStatus.ACCEPTED,
         )
 
         # Act and Assert
@@ -1017,32 +1006,22 @@ class FantasyTeamServiceIntegrationTest(TestBase):
                 fantasy_fixtures.fantasy_league_active_fixture.id,
                 fantasy_fixtures.user_fixture.id,
                 pro_player_fixture.id,
-                ProPlayerID("badProPlayerId")
+                ProPlayerID("badProPlayerId"),
             )
 
     def create_fantasy_league_membership_for_league(
-            self,
-            league_id: FantasyLeagueID,
-            user_id: UserID,
-            status: FantasyLeagueMembershipStatus
+        self, league_id: FantasyLeagueID, user_id: UserID, status: FantasyLeagueMembershipStatus
     ):
         fantasy_league_membership = FantasyLeagueMembership(
-            league_id=league_id,
-            user_id=user_id,
-            status=status
+            league_id=league_id, user_id=user_id, status=status
         )
         self.db.create_fantasy_league_membership(fantasy_league_membership)
 
     def create_fantasy_league_draft_position(
-            self,
-            fantasy_league_id: FantasyLeagueID,
-            user_id: UserID,
-            position: int
+        self, fantasy_league_id: FantasyLeagueID, user_id: UserID, position: int
     ):
         fantasy_league_draft_order = FantasyLeagueDraftOrder(
-            fantasy_league_id=fantasy_league_id,
-            user_id=user_id,
-            position=position
+            fantasy_league_id=fantasy_league_id, user_id=user_id, position=position
         )
         self.db.create_fantasy_league_draft_order(fantasy_league_draft_order)
 

--- a/tests/fantasy/integration/service/test_fantasy_user_service.py
+++ b/tests/fantasy/integration/service/test_fantasy_user_service.py
@@ -9,7 +9,7 @@ from src.common.schemas.fantasy_schemas import User, UserAccountStatus
 from src.fantasy.exceptions import (
     UserAlreadyExistsException,
     InvalidUsernameOrPasswordException,
-    UserVerificationException
+    UserVerificationException,
 )
 from src.fantasy.service import UserService
 
@@ -40,9 +40,9 @@ class UserServiceIntegrationTest(TestBase):
         self.assertTrue(uuid.UUID(user_from_db.id, version=4))
         self.assertEqual(user_from_db.username, user_create_fixture.username)
         self.assertEqual(user_from_db.email, user_create_fixture.email)
-        self.assertTrue(bcrypt.checkpw(
-            str.encode(user_create_fixture.password), user_from_db.password
-        ))
+        self.assertTrue(
+            bcrypt.checkpw(str.encode(user_create_fixture.password), user_from_db.password)
+        )
         self.assertFalse(user_from_db.verified)
         self.assertIsNotNone(user_from_db.verification_token)
 
@@ -57,7 +57,7 @@ class UserServiceIntegrationTest(TestBase):
         with self.assertRaises(UserAlreadyExistsException) as context:
             self.user_service.user_signup(modified_user_create)
 
-        self.assertIn('Username already in use', str(context.exception))
+        self.assertIn("Username already in use", str(context.exception))
 
     def test_user_signup_email_already_in_use_exception(self):
         # Arrange
@@ -70,7 +70,7 @@ class UserServiceIntegrationTest(TestBase):
         with self.assertRaises(UserAlreadyExistsException) as context:
             self.user_service.user_signup(modified_user_create)
 
-        self.assertIn('Email already in use', str(context.exception))
+        self.assertIn("Email already in use", str(context.exception))
 
     def test_user_login_successful(self):
         # Arrange

--- a/tests/fantasy/unit/service/test_fantasy_league_service.py
+++ b/tests/fantasy/unit/service/test_fantasy_league_service.py
@@ -10,12 +10,12 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueID,
     FantasyLeagueSettings,
     FantasyLeagueStatus,
-    UserID
+    UserID,
 )
 from src.fantasy.exceptions import FantasyLeagueNotFoundException, ForbiddenException
 from src.fantasy.service import FantasyLeagueService
 
-FANTASY_LEAGUE_SERV_PATH = 'src.fantasy.service.fantasy_league_service.FantasyLeagueService'
+FANTASY_LEAGUE_SERV_PATH = "src.fantasy.service.fantasy_league_service.FantasyLeagueService"
 
 
 class TestFantasyLeagueService(TestBase):
@@ -26,7 +26,7 @@ class TestFantasyLeagueService(TestBase):
     def tearDown(self):
         self.mock_db_service.reset_mock()
 
-    @patch(f'{FANTASY_LEAGUE_SERV_PATH}.generate_new_valid_id')
+    @patch(f"{FANTASY_LEAGUE_SERV_PATH}.generate_new_valid_id")
     def test_create_fantasy_league(self, mock_generate_new_valid_id: MagicMock):
         # Arrange
         fantasy_league_id = FantasyLeagueID(str(uuid.uuid4()))
@@ -36,7 +36,7 @@ class TestFantasyLeagueService(TestBase):
             id=fantasy_league_id,
             owner_id=owner_id,
             status=FantasyLeagueStatus.PRE_DRAFT,
-            name=fantasy_league_settings.name
+            name=fantasy_league_settings.name,
         )
         self.mock_db_service.get_fantasy_league_by_id.return_value = expected_fantasy_league
         mock_generate_new_valid_id.return_value = fantasy_league_id
@@ -51,7 +51,7 @@ class TestFantasyLeagueService(TestBase):
         mock_generate_new_valid_id.assert_called_once()
         self.mock_db_service.create_fantasy_league.assert_called_once_with(expected_fantasy_league)
 
-    @patch('uuid.uuid4', side_effect=['id1', 'id2'])
+    @patch("uuid.uuid4", side_effect=["id1", "id2"])
     def test_generate_new_valid_id(self, mock_uuid4: MagicMock):
         # Arrange
         mock_get_fantasy_league_by_id = MagicMock(side_effect=[MagicMock(), None])
@@ -61,12 +61,12 @@ class TestFantasyLeagueService(TestBase):
         generated_id = self.fantasy_league_service.generate_new_valid_id()
 
         # Assert
-        self.assertEqual(generated_id, 'id2')
+        self.assertEqual(generated_id, "id2")
         mock_uuid4.assert_called()
         self.assertEqual(mock_uuid4.call_count, 2)
-        mock_get_fantasy_league_by_id.assert_any_call('id1')
-        mock_get_fantasy_league_by_id.assert_any_call('id2')
-        mock_get_fantasy_league_by_id.assert_called_with('id2')
+        mock_get_fantasy_league_by_id.assert_any_call("id1")
+        mock_get_fantasy_league_by_id.assert_any_call("id2")
+        mock_get_fantasy_league_by_id.assert_called_with("id2")
 
     def test_get_fantasy_league_settings_successful(self):
         # Arrange
@@ -119,8 +119,7 @@ class TestFantasyLeagueService(TestBase):
         league_id = fantasy_league.id
 
         expected_updated_league_settings = FantasyLeagueSettings(
-            name="Update fantasy league",
-            number_of_teams=10
+            name="Update fantasy league", number_of_teams=10
         )
         expected_updated_league = copy.deepcopy(fantasy_league)
         expected_updated_league.name = expected_updated_league_settings.name
@@ -148,8 +147,7 @@ class TestFantasyLeagueService(TestBase):
         league_id = fantasy_league.id
 
         updated_league_settings = FantasyLeagueSettings(
-            name="Update fantasy league",
-            number_of_teams=10
+            name="Update fantasy league", number_of_teams=10
         )
         self.mock_db_service.get_fantasy_league_by_id.return_value = None
 
@@ -168,8 +166,7 @@ class TestFantasyLeagueService(TestBase):
         league_id = fantasy_league.id
 
         updated_league_settings = FantasyLeagueSettings(
-            name="Update fantasy league",
-            number_of_teams=10
+            name="Update fantasy league", number_of_teams=10
         )
 
         self.mock_db_service.get_fantasy_league_by_id.return_value = fantasy_league

--- a/tests/fantasy/unit/service/test_fantasy_team_service.py
+++ b/tests/fantasy/unit/service/test_fantasy_team_service.py
@@ -8,7 +8,7 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueMembership,
     FantasyLeagueMembershipStatus,
     FantasyTeam,
-    UserID
+    UserID,
 )
 from src.common.schemas.riot_data_schemas import ProPlayerID
 
@@ -43,7 +43,7 @@ class TestFantasyTeamService(TestBase):
         user_membership = FantasyLeagueMembership(
             league_id=fantasy_league_id,
             user_id=user_id,
-            status=FantasyLeagueMembershipStatus.PENDING
+            status=FantasyLeagueMembershipStatus.PENDING,
         )
         self.mock_db_service.get_user_membership_for_fantasy_league.return_value = user_membership
 
@@ -84,7 +84,7 @@ class TestFantasyTeamService(TestBase):
             jungle_player_id=ProPlayerID("some_jungle_id"),
             mid_player_id=ProPlayerID("some_mid_id"),
             adc_player_id=ProPlayerID("some_adc_id"),
-            support_player_id=ProPlayerID("some_support_id")
+            support_player_id=ProPlayerID("some_support_id"),
         )
         user_2_fantasy_team = FantasyTeam(
             fantasy_league_id=fantasy_league.id,
@@ -94,10 +94,11 @@ class TestFantasyTeamService(TestBase):
             jungle_player_id=ProPlayerID("some_jungle2_id"),
             mid_player_id=ProPlayerID("some_mid2_id"),
             adc_player_id=ProPlayerID("some_adc2_id"),
-            support_player_id=ProPlayerID("some_support2_id")
+            support_player_id=ProPlayerID("some_support2_id"),
         )
         self.mock_db_service.get_all_fantasy_teams_for_week.return_value = [
-            user_1_fantasy_team, user_2_fantasy_team
+            user_1_fantasy_team,
+            user_2_fantasy_team,
         ]
 
         # Act
@@ -119,7 +120,7 @@ class TestFantasyTeamService(TestBase):
             jungle_player_id=ProPlayerID("some_jungle_id"),
             mid_player_id=ProPlayerID("some_mid_id"),
             adc_player_id=ProPlayerID("some_adc_id"),
-            support_player_id=ProPlayerID("some_support_id")
+            support_player_id=ProPlayerID("some_support_id"),
         )
         user_2_fantasy_team = FantasyTeam(
             fantasy_league_id=fantasy_league.id,
@@ -129,10 +130,11 @@ class TestFantasyTeamService(TestBase):
             jungle_player_id=ProPlayerID(pro_player.id),
             mid_player_id=ProPlayerID("some_mid2_id"),
             adc_player_id=ProPlayerID("some_adc2_id"),
-            support_player_id=ProPlayerID("some_support2_id")
+            support_player_id=ProPlayerID("some_support2_id"),
         )
         self.mock_db_service.get_all_fantasy_teams_for_week.return_value = [
-            user_1_fantasy_team, user_2_fantasy_team
+            user_1_fantasy_team,
+            user_2_fantasy_team,
         ]
 
         # Act
@@ -154,7 +156,7 @@ class TestFantasyTeamService(TestBase):
             jungle_player_id=ProPlayerID("some_jungle_id"),
             mid_player_id=ProPlayerID("some_mid_id"),
             adc_player_id=ProPlayerID("some_adc_id"),
-            support_player_id=ProPlayerID("some_support_id")
+            support_player_id=ProPlayerID("some_support_id"),
         )
         user_week_2_fantasy_team = FantasyTeam(
             fantasy_league_id=fantasy_league.id,
@@ -164,10 +166,11 @@ class TestFantasyTeamService(TestBase):
             jungle_player_id=None,
             mid_player_id=ProPlayerID("some_mid2_id"),
             adc_player_id=ProPlayerID("some_adc2_id"),
-            support_player_id=ProPlayerID("some_support2_id")
+            support_player_id=ProPlayerID("some_support2_id"),
         )
         self.mock_db_service.get_all_fantasy_teams_for_user.return_value = [
-            user_week_1_fantasy_team, user_week_2_fantasy_team
+            user_week_1_fantasy_team,
+            user_week_2_fantasy_team,
         ]
 
         # Act
@@ -187,7 +190,7 @@ class TestFantasyTeamService(TestBase):
         expected_fantasy_team = FantasyTeam(
             fantasy_league_id=fantasy_league.id,
             user_id=UserID(user_id),
-            week=fantasy_league.current_week
+            week=fantasy_league.current_week,
         )
 
         # Act

--- a/tests/fantasy/unit/service/test_fantasy_user_service.py
+++ b/tests/fantasy/unit/service/test_fantasy_user_service.py
@@ -8,8 +8,8 @@ from src.fantasy.exceptions import UserAlreadyExistsException, InvalidUsernameOr
 from src.fantasy.service import UserService
 from src.auth import token_response
 
-BASE_USER_SERVICE_PATH = 'src.fantasy.service.fantasy_user_service.UserService'
-SIGN_JWT_PATH = 'src.fantasy.service.fantasy_user_service.sign_jwt'
+BASE_USER_SERVICE_PATH = "src.fantasy.service.fantasy_user_service.UserService"
+SIGN_JWT_PATH = "src.fantasy.service.fantasy_user_service.sign_jwt"
 
 
 class UserServiceTest(TestBase):
@@ -21,14 +21,15 @@ class UserServiceTest(TestBase):
     def tearDown(self):
         self.mock_db_service.reset_mock()
 
-    @patch(f'{BASE_USER_SERVICE_PATH}.generate_verification_token')
-    @patch(f'{BASE_USER_SERVICE_PATH}.validate_username_and_email')
-    @patch(f'{BASE_USER_SERVICE_PATH}.create_new_user')
+    @patch(f"{BASE_USER_SERVICE_PATH}.generate_verification_token")
+    @patch(f"{BASE_USER_SERVICE_PATH}.validate_username_and_email")
+    @patch(f"{BASE_USER_SERVICE_PATH}.create_new_user")
     def test_user_signup(
-            self,
-            mock_create_new_user: MagicMock,
-            mock_validate_username_and_email: MagicMock,
-            mock_generate_verification_token: MagicMock):
+        self,
+        mock_create_new_user: MagicMock,
+        mock_validate_username_and_email: MagicMock,
+        mock_generate_verification_token: MagicMock,
+    ):
         # Arrange
         verification_token = "123"
         create_user_fixture = fantasy_fixtures.user_create_fixture
@@ -47,9 +48,7 @@ class UserServiceTest(TestBase):
             create_user_fixture.username, create_user_fixture.email
         )
         mock_create_new_user.assert_called_once_with(
-            create_user_fixture,
-            expected_user.get_permissions(),
-            verification_token
+            create_user_fixture, expected_user.get_permissions(), verification_token
         )
         self.mock_db_service.create_user.assert_called_once_with(expected_user)
 
@@ -74,7 +73,7 @@ class UserServiceTest(TestBase):
         # Arrange
         user = fantasy_fixtures.user_fixture
         signup_username = user.username
-        signup_email = 'newEmail@example.com'
+        signup_email = "newEmail@example.com"
 
         self.mock_db_service.get_user_by_username.return_value = user
         self.mock_db_service.get_user_by_email.return_value = None
@@ -84,14 +83,14 @@ class UserServiceTest(TestBase):
             self.user_service.validate_username_and_email(
                 username=signup_username, email=signup_email
             )
-        self.assertIn('Username already in use', str(context.exception))
+        self.assertIn("Username already in use", str(context.exception))
         self.mock_db_service.get_user_by_username.assert_called_once_with(signup_username)
         self.mock_db_service.get_user_by_email.assert_not_called()
 
     def test_validate_username_and_email_exception_email_in_use(self):
         # Arrange
         user = fantasy_fixtures.user_fixture
-        signup_username = 'newUser'
+        signup_username = "newUser"
         signup_email = user.email
 
         self.mock_db_service.get_user_by_username.return_value = None
@@ -102,14 +101,15 @@ class UserServiceTest(TestBase):
             self.user_service.validate_username_and_email(
                 username=signup_username, email=signup_email
             )
-        self.assertIn('Email already in use', str(context.exception))
+        self.assertIn("Email already in use", str(context.exception))
         self.mock_db_service.get_user_by_username.assert_called_once_with(signup_username)
         self.mock_db_service.get_user_by_email.assert_called_once_with(signup_email)
 
-    @patch(f'{BASE_USER_SERVICE_PATH}.generate_new_valid_id')
-    @patch(f'{BASE_USER_SERVICE_PATH}.hash_password')
+    @patch(f"{BASE_USER_SERVICE_PATH}.generate_new_valid_id")
+    @patch(f"{BASE_USER_SERVICE_PATH}.hash_password")
     def test_create_new_user(
-            self, mock_hash_password: MagicMock, mock_generate_new_valid_id: MagicMock):
+        self, mock_hash_password: MagicMock, mock_generate_new_valid_id: MagicMock
+    ):
         # Arrange
         verification_token = "123"
         user_create_fixture = fantasy_fixtures.user_create_fixture
@@ -121,9 +121,7 @@ class UserServiceTest(TestBase):
 
         # Act
         new_user = self.user_service.create_new_user(
-            user_create_fixture,
-            user_fixture.get_permissions(),
-            verification_token
+            user_create_fixture, user_fixture.get_permissions(), verification_token
         )
 
         # Assert
@@ -131,7 +129,7 @@ class UserServiceTest(TestBase):
         mock_hash_password.assert_called_once_with(user_create_fixture.password)
         mock_generate_new_valid_id.assert_called_once()
 
-    @patch('uuid.uuid4', side_effect=['id1', 'id2', 'id3', 'id4'])
+    @patch("uuid.uuid4", side_effect=["id1", "id2", "id3", "id4"])
     def test_generate_new_valid_id(self, mock_uuid4: MagicMock):
         # Arrange
         self.mock_db_service.get_user_by_id.side_effect = [MagicMock(), None, None, None]
@@ -140,15 +138,15 @@ class UserServiceTest(TestBase):
         generated_id = self.user_service.generate_new_valid_id()
 
         # Assert
-        self.assertEqual(generated_id, 'id2')
+        self.assertEqual(generated_id, "id2")
         mock_uuid4.assert_called()
         self.assertEqual(mock_uuid4.call_count, 2)
-        self.mock_db_service.get_user_by_id.assert_any_call('id1')
-        self.mock_db_service.get_user_by_id.assert_any_call('id2')
-        self.mock_db_service.get_user_by_id.assert_called_with('id2')
+        self.mock_db_service.get_user_by_id.assert_any_call("id1")
+        self.mock_db_service.get_user_by_id.assert_any_call("id2")
+        self.mock_db_service.get_user_by_id.assert_called_with("id2")
 
-    @patch('bcrypt.gensalt', return_value=b'$2b$12$abcdefghijklmnopqrstuv')
-    @patch('bcrypt.hashpw', return_value=b'hashed_password')
+    @patch("bcrypt.gensalt", return_value=b"$2b$12$abcdefghijklmnopqrstuv")
+    @patch("bcrypt.hashpw", return_value=b"hashed_password")
     def test_hash_password(self, mock_hashpw: MagicMock, mock_gensalt: MagicMock):
         # Arrange
         password = "secure_password"
@@ -157,10 +155,10 @@ class UserServiceTest(TestBase):
         hashed_password = self.user_service.hash_password(password)
 
         # Assert
-        self.assertEqual(hashed_password, b'hashed_password')
+        self.assertEqual(hashed_password, b"hashed_password")
         mock_gensalt.assert_called_once()
         mock_hashpw.assert_called_once_with(
-            password.encode('utf-8'), b'$2b$12$abcdefghijklmnopqrstuv'
+            password.encode("utf-8"), b"$2b$12$abcdefghijklmnopqrstuv"
         )
 
     @patch(SIGN_JWT_PATH)

--- a/tests/fantasy/unit/util/test_fantasy_league_util.py
+++ b/tests/fantasy/unit/util/test_fantasy_league_util.py
@@ -11,7 +11,7 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueDraftOrderResponse,
     FantasyLeagueStatus,
     FantasyLeagueID,
-    UserID
+    UserID,
 )
 from src.common.schemas.riot_data_schemas import RiotLeagueID, Match, RiotMatchID, RiotTournamentID
 from src.common.exceptions import LeagueNotFoundException
@@ -20,7 +20,7 @@ from src.fantasy.exceptions import (
     DraftOrderException,
     FantasyLeagueNotFoundException,
     FantasyLeagueInvalidRequiredStateException,
-    FantasyUnavailableException
+    FantasyUnavailableException,
 )
 from src.fantasy.util import FantasyLeagueUtil
 
@@ -49,7 +49,8 @@ class TestFantasyLeagueUtil(TestBase):
         self.assertIsInstance(returned_fantasy_league, FantasyLeague)
         self.assertIn(expected_fantasy_league.status, required_states)
         self.mock_db_service.get_fantasy_league_by_id.assert_called_once_with(
-            expected_fantasy_league.id)
+            expected_fantasy_league.id
+        )
 
     def test_validate_league_league_not_found_exception(self):
         # Arrange
@@ -79,7 +80,8 @@ class TestFantasyLeagueUtil(TestBase):
 
         # Act
         returned_fantasy_league = self.fantasy_league_util.validate_league(
-            expected_fantasy_league.id)
+            expected_fantasy_league.id
+        )
 
         # Assert
         self.assertEqual(expected_fantasy_league, returned_fantasy_league)
@@ -171,7 +173,9 @@ class TestFantasyLeagueUtil(TestBase):
             fantasy_league.id, expected_new_draft_position
         )
 
-    def test_create_draft_order_entry_first_draft_order_for_fantasy_league(self,):
+    def test_create_draft_order_entry_first_draft_order_for_fantasy_league(
+        self,
+    ):
         # Arrange
         user = fantasy_fixtures.user_fixture
         fantasy_league = fantasy_fixtures.fantasy_league_fixture
@@ -187,12 +191,15 @@ class TestFantasyLeagueUtil(TestBase):
         # Assert
         self.mock_db_service.get_fantasy_league_by_id.assert_called_once_with(fantasy_league.id)
         self.mock_db_service.get_fantasy_league_draft_order.assert_called_once_with(
-            fantasy_league.id)
+            fantasy_league.id
+        )
         self.mock_db_service.create_fantasy_league_draft_order.assert_called_once_with(
             expected_draft_order_entry
         )
 
-    def test_create_draft_order_entry_with_an_existing_draft_entry(self,):
+    def test_create_draft_order_entry_with_an_existing_draft_entry(
+        self,
+    ):
         # Arrange
         user = fantasy_fixtures.user_fixture
         fantasy_league = fantasy_fixtures.fantasy_league_fixture
@@ -212,9 +219,11 @@ class TestFantasyLeagueUtil(TestBase):
         # Assert
         self.mock_db_service.get_fantasy_league_by_id.assert_called_once_with(fantasy_league.id)
         self.mock_db_service.get_fantasy_league_draft_order.assert_called_once_with(
-            fantasy_league.id)
+            fantasy_league.id
+        )
         self.mock_db_service.create_fantasy_league_draft_order.assert_called_once_with(
-            expected_draft_order_entry)
+            expected_draft_order_entry
+        )
 
     def test_create_draft_order_entry_fantasy_league_not_found_exception(self):
         # Arrange
@@ -240,7 +249,7 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrder(
                 fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
-            )
+            ),
         ]
         updated_draft_order = [
             FantasyLeagueDraftOrderResponse(
@@ -272,7 +281,7 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrder(
                 fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
-            )
+            ),
         ]
         updated_draft_order = [
             FantasyLeagueDraftOrderResponse(
@@ -304,12 +313,10 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrder(
                 fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
-            )
+            ),
         ]
         updated_draft_order = [
-            FantasyLeagueDraftOrderResponse(
-                user_id=user_1.id, username=user_1.username, position=1
-            )
+            FantasyLeagueDraftOrderResponse(user_id=user_1.id, username=user_1.username, position=1)
         ]
 
         # Act and Assert
@@ -330,7 +337,7 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrder(
                 fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
-            )
+            ),
         ]
         updated_draft_order = [
             FantasyLeagueDraftOrderResponse(
@@ -341,7 +348,7 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrderResponse(
                 user_id=user_3.id, username=user_3.username, position=3
-            )
+            ),
         ]
 
         # Act and Assert
@@ -362,7 +369,7 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrder(
                 fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
-            )
+            ),
         ]
         updated_draft_order = [
             FantasyLeagueDraftOrderResponse(
@@ -370,7 +377,7 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrderResponse(
                 user_id=user_3.id, username=user_3.username, position=2
-            )
+            ),
         ]
 
         # Act and Assert
@@ -389,7 +396,7 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrder(
                 fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
-            )
+            ),
         ]
         updated_draft_order = [
             FantasyLeagueDraftOrderResponse(
@@ -397,15 +404,14 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrderResponse(
                 user_id=user_2.id, username=user_2.username, position=1
-            )
+            ),
         ]
 
         # Act and Assert
         with self.assertRaises(DraftOrderException) as context:
             self.fantasy_league_util.validate_draft_order(current_draft_order, updated_draft_order)
         self.assertIn(
-            "The positions given in the updated draft order are not valid",
-            str(context.exception)
+            "The positions given in the updated draft order are not valid", str(context.exception)
         )
 
     def test_validate_draft_order_invalid_positions_negatives_of_positions_exception(self):
@@ -419,7 +425,7 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrder(
                 fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
-            )
+            ),
         ]
         updated_draft_order = [
             FantasyLeagueDraftOrderResponse(
@@ -427,15 +433,14 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrderResponse(
                 user_id=user_2.id, username=user_2.username, position=-2
-            )
+            ),
         ]
 
         # Act and Assert
         with self.assertRaises(DraftOrderException) as context:
             self.fantasy_league_util.validate_draft_order(current_draft_order, updated_draft_order)
         self.assertIn(
-            "The positions given in the updated draft order are not valid",
-            str(context.exception)
+            "The positions given in the updated draft order are not valid", str(context.exception)
         )
 
     def test_validate_draft_order_invalid_positions_gap_between_positions_exception(self):
@@ -449,7 +454,7 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrder(
                 fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
-            )
+            ),
         ]
         updated_draft_order = [
             FantasyLeagueDraftOrderResponse(
@@ -457,15 +462,14 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrderResponse(
                 user_id=user_2.id, username=user_2.username, position=3
-            )
+            ),
         ]
 
         # Act and Assert
         with self.assertRaises(DraftOrderException) as context:
             self.fantasy_league_util.validate_draft_order(current_draft_order, updated_draft_order)
         self.assertIn(
-            "The positions given in the updated draft order are not valid",
-            str(context.exception)
+            "The positions given in the updated draft order are not valid", str(context.exception)
         )
 
     def test_update_draft_order_on_player_leave_middle_position_successful(self):
@@ -485,7 +489,7 @@ class TestFantasyLeagueUtil(TestBase):
             expected_position_to_delete,
             FantasyLeagueDraftOrder(
                 fantasy_league_id=fantasy_league.id, user_id=user_3.id, position=3
-            )
+            ),
         ]
         self.mock_db_service.get_fantasy_league_draft_order.return_value = current_draft_order
 
@@ -497,9 +501,11 @@ class TestFantasyLeagueUtil(TestBase):
         except DraftOrderException:
             self.fail("Update draft order on player leave failed with an unexpected exception")
         self.mock_db_service.get_fantasy_league_draft_order.assert_called_once_with(
-            fantasy_league.id)
+            fantasy_league.id
+        )
         self.mock_db_service.delete_fantasy_league_draft_order.assert_called_once_with(
-            expected_position_to_delete)
+            expected_position_to_delete
+        )
         self.mock_db_service.update_fantasy_league_draft_order_position.assert_called_once_with(
             current_draft_order[2], 2
         )
@@ -521,7 +527,7 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrder(
                 fantasy_league_id=fantasy_league.id, user_id=user_3.id, position=3
-            )
+            ),
         ]
         self.mock_db_service.get_fantasy_league_draft_order.return_value = current_draft_order
 
@@ -533,17 +539,21 @@ class TestFantasyLeagueUtil(TestBase):
         except DraftOrderException:
             self.fail("Update draft order on player leave failed with an unexpected exception")
         self.mock_db_service.get_fantasy_league_draft_order.assert_called_once_with(
-            fantasy_league.id)
+            fantasy_league.id
+        )
         self.mock_db_service.delete_fantasy_league_draft_order.assert_called_once_with(
-            expected_position_to_delete)
+            expected_position_to_delete
+        )
         expected_calls = [
             call.update_fantasy_league_draft_order_position(current_draft_order[1], 1),
-            call.update_fantasy_league_draft_order_position(current_draft_order[2], 2)
+            call.update_fantasy_league_draft_order_position(current_draft_order[2], 2),
         ]
         self.mock_db_service.update_fantasy_league_draft_order_position.assert_has_calls(
-            expected_calls)
+            expected_calls
+        )
         self.assertEqual(
-            self.mock_db_service.update_fantasy_league_draft_order_position.call_count, 2)
+            self.mock_db_service.update_fantasy_league_draft_order_position.call_count, 2
+        )
 
     def test_update_draft_order_on_player_leave_last_position_successful(self):
         # Arrange
@@ -562,7 +572,7 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrder(
                 fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
-            )
+            ),
         ]
         self.mock_db_service.get_fantasy_league_draft_order.return_value = current_draft_order
 
@@ -574,9 +584,11 @@ class TestFantasyLeagueUtil(TestBase):
         except DraftOrderException:
             self.fail("Update draft order on player leave failed with an unexpected exception")
         self.mock_db_service.get_fantasy_league_draft_order.assert_called_once_with(
-            fantasy_league.id)
+            fantasy_league.id
+        )
         self.mock_db_service.delete_fantasy_league_draft_order.assert_called_once_with(
-            expected_position_to_delete)
+            expected_position_to_delete
+        )
         self.mock_db_service.update_fantasy_league_draft_order_position.assert_not_called()
 
     def test_update_draft_order_on_player_leave_user_has_no_draft_position_exception(self):
@@ -591,17 +603,19 @@ class TestFantasyLeagueUtil(TestBase):
             ),
             FantasyLeagueDraftOrder(
                 fantasy_league_id=fantasy_league.id, user_id=user_2.id, position=2
-            )
+            ),
         ]
         self.mock_db_service.get_fantasy_league_draft_order.return_value = current_draft_order
 
         # Act and Assert
         with self.assertRaises(DraftOrderException) as context:
             self.fantasy_league_util.update_draft_order_on_player_leave(
-                user_3.id, fantasy_league.id)
+                user_3.id, fantasy_league.id
+            )
         self.assertIn("Missing user on draft removal", str(context.exception))
         self.mock_db_service.get_fantasy_league_draft_order.assert_called_once_with(
-            fantasy_league.id)
+            fantasy_league.id
+        )
         self.mock_db_service.delete_fantasy_league_draft_order.assert_not_called()
         self.mock_db_service.update_fantasy_league_draft_order_position.assert_not_called()
 
@@ -617,9 +631,9 @@ class TestFantasyLeagueUtil(TestBase):
 
         # Assert
         self.assertEqual(curr_week, expected_current_week)
-        self.mock_db_service\
-            .get_matches_for_league_with_active_tournament\
-            .assert_called_once_with(league_id)
+        self.mock_db_service.get_matches_for_league_with_active_tournament.assert_called_once_with(
+            league_id
+        )
 
     def test_get_leagues_current_week_returns_correct_week(self):
         # Arrange
@@ -628,18 +642,18 @@ class TestFantasyLeagueUtil(TestBase):
         for week_num in range(1, num_weeks + 1):
             matches = generate_matches(num_weeks, 3, week_num)
             self.mock_db_service.reset_mock()
-            self.mock_db_service\
-                .get_matches_for_league_with_active_tournament\
-                .return_value = matches
+            self.mock_db_service.get_matches_for_league_with_active_tournament.return_value = (
+                matches
+            )
 
             # Act
             curr_week = self.fantasy_league_util.get_leagues_current_week(league_id)
 
             # Assert
             self.assertEqual(curr_week, week_num)
-            self.mock_db_service\
-                .get_matches_for_league_with_active_tournament\
-                .assert_called_once_with(league_id)
+            self.mock_db_service.get_matches_for_league_with_active_tournament.assert_called_once_with(
+                league_id
+            )
 
     def test_get_leagues_current_week_returns_last_valid_week_if_in_past(self):
         # Arrange
@@ -653,9 +667,9 @@ class TestFantasyLeagueUtil(TestBase):
 
         # Assert
         self.assertEqual(curr_week, num_weeks)
-        self.mock_db_service\
-            .get_matches_for_league_with_active_tournament\
-            .assert_called_once_with(league_id)
+        self.mock_db_service.get_matches_for_league_with_active_tournament.assert_called_once_with(
+            league_id
+        )
 
     def test_get_leagues_current_week_groups_returns_none(self):
         # Arrange
@@ -668,9 +682,9 @@ class TestFantasyLeagueUtil(TestBase):
 
         # Assert
         self.assertIsNone(curr_week)
-        self.mock_db_service\
-            .get_matches_for_league_with_active_tournament\
-            .assert_called_once_with(league_id)
+        self.mock_db_service.get_matches_for_league_with_active_tournament.assert_called_once_with(
+            league_id
+        )
 
     def test_get_leagues_current_week_no_matches_returns_none(self):
         # Arrange
@@ -682,16 +696,14 @@ class TestFantasyLeagueUtil(TestBase):
 
         # Assert
         self.assertIsNone(curr_week)
-        self.mock_db_service\
-            .get_matches_for_league_with_active_tournament\
-            .assert_called_once_with(league_id)
+        self.mock_db_service.get_matches_for_league_with_active_tournament.assert_called_once_with(
+            league_id
+        )
 
 
 def generate_matches(
-        num_weeks: int,
-        matches_per_week: int,
-        current_week: int = 1,
-        use_weeks: bool = True) -> list[Match]:
+    num_weeks: int, matches_per_week: int, current_week: int = 1, use_weeks: bool = True
+) -> list[Match]:
     matches = []
     base_time = datetime.now(UTC) - timedelta(weeks=current_week - 1)
     tournament_id = RiotTournamentID(riot_fixtures.generate_random_id())
@@ -701,45 +713,51 @@ def generate_matches(
         block_name = f"week {week}" if use_weeks else "Groups"
         for match_num in range(matches_per_week):
             match_time = base_time + timedelta(weeks=week - 1, days=match_num)
-            matches.append(Match(
-                id=RiotMatchID(riot_fixtures.generate_random_id()),
-                start_time=match_time.isoformat() + "Z",
-                block_name=block_name,
-                league_slug="test",
-                strategy_type="bestOf",
-                strategy_count=1,
-                tournament_id=tournament_id,
-                team_1_name=f"Team {week}-{match_num + 1}A",
-                team_2_name=f"Team {week}-{match_num + 1}B",
-            ))
+            matches.append(
+                Match(
+                    id=RiotMatchID(riot_fixtures.generate_random_id()),
+                    start_time=match_time.isoformat() + "Z",
+                    block_name=block_name,
+                    league_slug="test",
+                    strategy_type="bestOf",
+                    strategy_count=1,
+                    tournament_id=tournament_id,
+                    team_1_name=f"Team {week}-{match_num + 1}A",
+                    team_2_name=f"Team {week}-{match_num + 1}B",
+                )
+            )
 
     # Generate playoffs
     for match_num in range(matches_per_week):
         match_time = base_time + timedelta(weeks=num_weeks, days=match_num)
-        matches.append(Match(
+        matches.append(
+            Match(
+                id=RiotMatchID(riot_fixtures.generate_random_id()),
+                start_time=match_time.isoformat() + "Z",
+                block_name="playoffs",
+                league_slug="test",
+                strategy_type="bestOf",
+                strategy_count=1,
+                tournament_id=tournament_id,
+                team_1_name=f"Playoff Team {match_num + 1}A",
+                team_2_name=f"Playoff Team {match_num + 1}B",
+            )
+        )
+
+    # Generate finals
+    finals_time = base_time + timedelta(weeks=num_weeks, days=matches_per_week)
+    matches.append(
+        Match(
             id=RiotMatchID(riot_fixtures.generate_random_id()),
-            start_time=match_time.isoformat() + "Z",
-            block_name="playoffs",
+            start_time=finals_time.isoformat() + "Z",
+            block_name="finals",
             league_slug="test",
             strategy_type="bestOf",
             strategy_count=1,
             tournament_id=tournament_id,
-            team_1_name=f"Playoff Team {match_num + 1}A",
-            team_2_name=f"Playoff Team {match_num + 1}B"
-        ))
-
-    # Generate finals
-    finals_time = base_time + timedelta(weeks=num_weeks, days=matches_per_week)
-    matches.append(Match(
-        id=RiotMatchID(riot_fixtures.generate_random_id()),
-        start_time=finals_time.isoformat() + "Z",
-        block_name="finals",
-        league_slug="test",
-        strategy_type="bestOf",
-        strategy_count=1,
-        tournament_id=tournament_id,
-        team_1_name="Finalist A",
-        team_2_name="Finalist B"
-    ))
+            team_1_name="Finalist A",
+            team_2_name="Finalist B",
+        )
+    )
 
     return matches

--- a/tests/fantasy/unit/util/test_fantasy_team_util.py
+++ b/tests/fantasy/unit/util/test_fantasy_team_util.py
@@ -8,7 +8,7 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueID,
     FantasyLeagueDraftOrder,
     FantasyTeam,
-    UserID
+    UserID,
 )
 from src.common.schemas.riot_data_schemas import RiotLeagueID, ProPlayerID
 
@@ -84,13 +84,15 @@ class TestFantasyTeamUtil(TestBase):
 
         # Act
         is_turn_to_draft = self.fantasy_team_util.is_users_position_to_draft(
-            fantasy_league, user.id)
+            fantasy_league, user.id
+        )
 
         # Assert
         self.assertTrue(is_turn_to_draft)
         self.assertEqual(fantasy_league.current_draft_position, user_draft_position.position)
         self.mock_db_service.get_fantasy_league_draft_order.assert_called_once_with(
-            fantasy_league.id)
+            fantasy_league.id
+        )
 
     def test_is_users_position_to_draft_false(self):
         # Arrange
@@ -108,13 +110,15 @@ class TestFantasyTeamUtil(TestBase):
 
         # Act
         is_turn_to_draft = self.fantasy_team_util.is_users_position_to_draft(
-            fantasy_league, user.id)
+            fantasy_league, user.id
+        )
 
         # Assert
         self.assertFalse(is_turn_to_draft)
         self.assertNotEqual(fantasy_league.current_draft_position, user_draft_position.position)
         self.mock_db_service.get_fantasy_league_draft_order.assert_called_once_with(
-            fantasy_league.id)
+            fantasy_league.id
+        )
 
     def test_is_users_position_to_draft_no_user_draft_position_found_exception(self):
         # Arrange
@@ -133,10 +137,12 @@ class TestFantasyTeamUtil(TestBase):
         # Act and Assert
         with self.assertRaises(FantasyDraftException) as context:
             self.fantasy_team_util.is_users_position_to_draft(
-                fantasy_league, UserID("notFoundUserId"))
+                fantasy_league, UserID("notFoundUserId")
+            )
         self.assertIn("Could not find draft position", str(context.exception))
         self.mock_db_service.get_fantasy_league_draft_order.assert_called_once_with(
-            fantasy_league.id)
+            fantasy_league.id
+        )
 
     def test_all_teams_fully_drafted_true(self):
         # Arrange
@@ -246,7 +252,7 @@ class TestFantasyTeamUtil(TestBase):
             fantasy_league.id,
             UserID("123"),
             fantasy_league.current_week,
-            set_jungle_player_id=False
+            set_jungle_player_id=False,
         )
         fantasy_teams.append(missing_jungle_player_team)
         self.mock_db_service.get_all_fantasy_teams_for_week.return_value = fantasy_teams
@@ -330,7 +336,7 @@ class TestFantasyTeamUtil(TestBase):
             fantasy_league.id,
             UserID("123"),
             fantasy_league.current_week,
-            set_support_player_id=False
+            set_support_player_id=False,
         )
         fantasy_teams.append(missing_support_player_team)
         self.mock_db_service.get_all_fantasy_teams_for_week.return_value = fantasy_teams
@@ -348,14 +354,15 @@ class TestFantasyTeamUtil(TestBase):
 
 
 def create_fantasy_team(
-        fantasy_league_id: FantasyLeagueID,
-        user_id: UserID,
-        week: int,
-        set_top_player_id: bool = True,
-        set_jungle_player_id: bool = True,
-        set_mid_player_id: bool = True,
-        set_adc_player_id: bool = True,
-        set_support_player_id: bool = True) -> FantasyTeam:
+    fantasy_league_id: FantasyLeagueID,
+    user_id: UserID,
+    week: int,
+    set_top_player_id: bool = True,
+    set_jungle_player_id: bool = True,
+    set_mid_player_id: bool = True,
+    set_adc_player_id: bool = True,
+    set_support_player_id: bool = True,
+) -> FantasyTeam:
     return FantasyTeam(
         fantasy_league_id=fantasy_league_id,
         user_id=user_id,

--- a/tests/riot/integration/service/test_league_service.py
+++ b/tests/riot/integration/service/test_league_service.py
@@ -35,7 +35,10 @@ class LeagueServiceTest(TestBase):
 
         # Assert
         self.assertIsInstance(leagues_from_db, list)
-        self.assertEqual(0, len(leagues_from_db), )
+        self.assertEqual(
+            0,
+            len(leagues_from_db),
+        )
 
     def test_get_leagues_by_region_existing_league(self):
         # Arrange
@@ -142,8 +145,7 @@ class LeagueServiceTest(TestBase):
         # Assert
         self.assertEqual(expected_updated_league, updated_league)
         self.assertNotEqual(
-            expected_updated_league.fantasy_available,
-            fantasy_league.fantasy_available
+            expected_updated_league.fantasy_available, fantasy_league.fantasy_available
         )
 
     def test_update_fantasy_available_to_false(self):
@@ -161,8 +163,7 @@ class LeagueServiceTest(TestBase):
         # Assert
         self.assertEqual(expected_updated_league, updated_league)
         self.assertNotEqual(
-            expected_updated_league.fantasy_available,
-            fantasy_league.fantasy_available
+            expected_updated_league.fantasy_available, fantasy_league.fantasy_available
         )
 
     def test_update_fantasy_available_non_existing_league_exception(self):

--- a/tests/riot/unit/riot_endpoints/test_game_endpoint_v1.py
+++ b/tests/riot/unit/riot_endpoints/test_game_endpoint_v1.py
@@ -23,7 +23,7 @@ class GameEndpointV1Test(TestBase):
         self.app = FastAPI()
         self.app.include_router(endpoint.router, prefix="/api/v1")
         for route in self.app.routes:
-            for dep in getattr(route, 'dependencies', []):
+            for dep in getattr(route, "dependencies", []):
                 if isinstance(dep.dependency, JWTBearer):
                     self.app.dependency_overrides[dep.dependency] = lambda: {}
         disable_installed_extensions_check()
@@ -38,7 +38,7 @@ class GameEndpointV1Test(TestBase):
         response = self.client.get(f"{GAME_BASE_URL}?state={GameState.COMPLETED.value}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -50,7 +50,7 @@ class GameEndpointV1Test(TestBase):
         response = self.client.get(f"{GAME_BASE_URL}?state={GameState.INPROGRESS.value}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -62,7 +62,7 @@ class GameEndpointV1Test(TestBase):
         response = self.client.get(f"{GAME_BASE_URL}?state={GameState.UNSTARTED.value}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -74,7 +74,7 @@ class GameEndpointV1Test(TestBase):
         response = self.client.get(f"{GAME_BASE_URL}?state={GameState.UNNEEDED.value}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -90,7 +90,7 @@ class GameEndpointV1Test(TestBase):
         response = self.client.get(f"{GAME_BASE_URL}?match_id={game_fixture.match_id}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 

--- a/tests/riot/unit/riot_endpoints/test_game_stats_endpoint_v1.py
+++ b/tests/riot/unit/riot_endpoints/test_game_stats_endpoint_v1.py
@@ -21,7 +21,7 @@ class GameStatsEndpointV1Test(TestBase):
         self.app = FastAPI()
         self.app.include_router(endpoint.router, prefix="/api/v1")
         for route in self.app.routes:
-            for dep in getattr(route, 'dependencies', []):
+            for dep in getattr(route, "dependencies", []):
                 if isinstance(dep.dependency, JWTBearer):
                     self.app.dependency_overrides[dep.dependency] = lambda: {}
         disable_installed_extensions_check()
@@ -36,7 +36,7 @@ class GameStatsEndpointV1Test(TestBase):
         response = self.client.get(f"{GAME_STATS_BASE_URL}/player")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -46,7 +46,7 @@ class GameStatsEndpointV1Test(TestBase):
         response = self.client.get(f"{GAME_STATS_BASE_URL}/player")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(0, len(items))
 
     def test_get_player_stats_filter_by_game_id_existing_data(self):
@@ -54,12 +54,10 @@ class GameStatsEndpointV1Test(TestBase):
         expected = fixture.model_dump()
         self.mock_service.get_player_stats.return_value = [fixture]
 
-        response = self.client.get(
-            f"{GAME_STATS_BASE_URL}/player?game_id={fixture.game_id}"
-        )
+        response = self.client.get(f"{GAME_STATS_BASE_URL}/player?game_id={fixture.game_id}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -67,12 +65,10 @@ class GameStatsEndpointV1Test(TestBase):
         fixture = fixtures.player_1_game_data_fixture
         self.mock_service.get_player_stats.return_value = []
 
-        response = self.client.get(
-            f"{GAME_STATS_BASE_URL}/player?game_id={fixture.game_id}"
-        )
+        response = self.client.get(f"{GAME_STATS_BASE_URL}/player?game_id={fixture.game_id}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(0, len(items))
 
     def test_get_player_stats_filter_by_player_id_existing_data(self):
@@ -80,12 +76,10 @@ class GameStatsEndpointV1Test(TestBase):
         expected = fixture.model_dump()
         self.mock_service.get_player_stats.return_value = [fixture]
 
-        response = self.client.get(
-            f"{GAME_STATS_BASE_URL}/player?player_id={fixture.player_id}"
-        )
+        response = self.client.get(f"{GAME_STATS_BASE_URL}/player?player_id={fixture.player_id}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -93,10 +87,8 @@ class GameStatsEndpointV1Test(TestBase):
         fixture = fixtures.player_1_game_data_fixture
         self.mock_service.get_player_stats.return_value = []
 
-        response = self.client.get(
-            f"{GAME_STATS_BASE_URL}/player?player_id={fixture.player_id}"
-        )
+        response = self.client.get(f"{GAME_STATS_BASE_URL}/player?player_id={fixture.player_id}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(0, len(items))

--- a/tests/riot/unit/riot_endpoints/test_league_endpoint_v1.py
+++ b/tests/riot/unit/riot_endpoints/test_league_endpoint_v1.py
@@ -24,7 +24,7 @@ class LeagueEndpointV1Test(TestBase):
         self.app.include_router(endpoint.router, prefix="/api/v1")
         # Override every JWTBearer instance used in route dependencies
         for route in self.app.routes:
-            for dep in getattr(route, 'dependencies', []):
+            for dep in getattr(route, "dependencies", []):
                 if isinstance(dep.dependency, JWTBearer):
                     self.app.dependency_overrides[dep.dependency] = lambda: {}
         disable_installed_extensions_check()
@@ -39,7 +39,7 @@ class LeagueEndpointV1Test(TestBase):
         response = self.client.get(LEAGUE_BASE_URL)
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
         self.mock_service.get_leagues.assert_called_once_with(LeagueSearchParameters())
@@ -52,7 +52,7 @@ class LeagueEndpointV1Test(TestBase):
         response = self.client.get(f"{LEAGUE_BASE_URL}?name={league_fixture.name}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
         self.mock_service.get_leagues.assert_called_once_with(
@@ -67,7 +67,7 @@ class LeagueEndpointV1Test(TestBase):
         response = self.client.get(f"{LEAGUE_BASE_URL}?region={league_fixture.region}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
         self.mock_service.get_leagues.assert_called_once_with(
@@ -84,7 +84,7 @@ class LeagueEndpointV1Test(TestBase):
         )
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
         self.mock_service.get_leagues.assert_called_once_with(
@@ -104,8 +104,7 @@ class LeagueEndpointV1Test(TestBase):
 
     def test_get_league_by_id_not_found(self):
         league_fixture = fixtures.league_1_fixture
-        self.mock_service.get_league_by_id.side_effect = \
-            LeagueNotFoundException(league_fixture.id)
+        self.mock_service.get_league_by_id.side_effect = LeagueNotFoundException(league_fixture.id)
 
         response = self.client.get(f"{LEAGUE_BASE_URL}/{league_fixture.id}")
 

--- a/tests/riot/unit/riot_endpoints/test_match_endpoint_v1.py
+++ b/tests/riot/unit/riot_endpoints/test_match_endpoint_v1.py
@@ -22,7 +22,7 @@ class MatchEndpointV1Test(TestBase):
         self.app = FastAPI()
         self.app.include_router(endpoint.router, prefix="/api/v1")
         for route in self.app.routes:
-            for dep in getattr(route, 'dependencies', []):
+            for dep in getattr(route, "dependencies", []):
                 if isinstance(dep.dependency, JWTBearer):
                     self.app.dependency_overrides[dep.dependency] = lambda: {}
         disable_installed_extensions_check()
@@ -37,7 +37,7 @@ class MatchEndpointV1Test(TestBase):
         response = self.client.get(MATCH_BASE_URL)
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -46,12 +46,10 @@ class MatchEndpointV1Test(TestBase):
         expected = match_fixture.model_dump()
         self.mock_service.get_matches.return_value = [match_fixture]
 
-        response = self.client.get(
-            f"{MATCH_BASE_URL}?league_slug={match_fixture.league_slug}"
-        )
+        response = self.client.get(f"{MATCH_BASE_URL}?league_slug={match_fixture.league_slug}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -60,12 +58,10 @@ class MatchEndpointV1Test(TestBase):
         expected = match_fixture.model_dump()
         self.mock_service.get_matches.return_value = [match_fixture]
 
-        response = self.client.get(
-            f"{MATCH_BASE_URL}?tournament_id={match_fixture.tournament_id}"
-        )
+        response = self.client.get(f"{MATCH_BASE_URL}?tournament_id={match_fixture.tournament_id}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 

--- a/tests/riot/unit/riot_endpoints/test_professional_player_endpoint_v1.py
+++ b/tests/riot/unit/riot_endpoints/test_professional_player_endpoint_v1.py
@@ -22,7 +22,7 @@ class ProfessionalPlayerEndpointV1Test(TestBase):
         self.app = FastAPI()
         self.app.include_router(endpoint.router, prefix="/api/v1")
         for route in self.app.routes:
-            for dep in getattr(route, 'dependencies', []):
+            for dep in getattr(route, "dependencies", []):
                 if isinstance(dep.dependency, JWTBearer):
                     self.app.dependency_overrides[dep.dependency] = lambda: {}
         disable_installed_extensions_check()
@@ -39,7 +39,7 @@ class ProfessionalPlayerEndpointV1Test(TestBase):
         )
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -51,7 +51,7 @@ class ProfessionalPlayerEndpointV1Test(TestBase):
         response = self.client.get(f"{PLAYER_BASE_URL}?role={player_fixture.role.value}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -63,7 +63,7 @@ class ProfessionalPlayerEndpointV1Test(TestBase):
         response = self.client.get(f"{PLAYER_BASE_URL}?team_id={player_fixture.team_id}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -75,7 +75,7 @@ class ProfessionalPlayerEndpointV1Test(TestBase):
         response = self.client.get(PLAYER_BASE_URL)
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -91,8 +91,7 @@ class ProfessionalPlayerEndpointV1Test(TestBase):
 
     def test_get_player_by_id_not_found(self):
         player_fixture = fixtures.player_1_fixture
-        self.mock_service.get_player_by_id.side_effect = \
-            ProfessionalPlayerNotFoundException()
+        self.mock_service.get_player_by_id.side_effect = ProfessionalPlayerNotFoundException()
 
         response = self.client.get(f"{PLAYER_BASE_URL}/{player_fixture.id}")
 

--- a/tests/riot/unit/riot_endpoints/test_professional_team_endpoint_v1.py
+++ b/tests/riot/unit/riot_endpoints/test_professional_team_endpoint_v1.py
@@ -22,7 +22,7 @@ class ProfessionalTeamEndpointV1Test(TestBase):
         self.app = FastAPI()
         self.app.include_router(endpoint.router, prefix="/api/v1")
         for route in self.app.routes:
-            for dep in getattr(route, 'dependencies', []):
+            for dep in getattr(route, "dependencies", []):
                 if isinstance(dep.dependency, JWTBearer):
                     self.app.dependency_overrides[dep.dependency] = lambda: {}
         disable_installed_extensions_check()
@@ -37,7 +37,7 @@ class ProfessionalTeamEndpointV1Test(TestBase):
         response = self.client.get(f"{TEAM_BASE_URL}?slug={team_fixture.slug}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -49,7 +49,7 @@ class ProfessionalTeamEndpointV1Test(TestBase):
         response = self.client.get(f"{TEAM_BASE_URL}?name={team_fixture.name}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -61,7 +61,7 @@ class ProfessionalTeamEndpointV1Test(TestBase):
         response = self.client.get(f"{TEAM_BASE_URL}?code={team_fixture.code}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -73,7 +73,7 @@ class ProfessionalTeamEndpointV1Test(TestBase):
         response = self.client.get(f"{TEAM_BASE_URL}?status={team_fixture.status}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -85,7 +85,7 @@ class ProfessionalTeamEndpointV1Test(TestBase):
         response = self.client.get(f"{TEAM_BASE_URL}?league={team_fixture.home_league}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -97,7 +97,7 @@ class ProfessionalTeamEndpointV1Test(TestBase):
         response = self.client.get(TEAM_BASE_URL)
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 

--- a/tests/riot/unit/riot_endpoints/test_tournament_endpoint_v1.py
+++ b/tests/riot/unit/riot_endpoints/test_tournament_endpoint_v1.py
@@ -23,7 +23,7 @@ class TournamentEndpointV1Test(TestBase):
         self.app = FastAPI()
         self.app.include_router(endpoint.router, prefix="/api/v1")
         for route in self.app.routes:
-            for dep in getattr(route, 'dependencies', []):
+            for dep in getattr(route, "dependencies", []):
                 if isinstance(dep.dependency, JWTBearer):
                     self.app.dependency_overrides[dep.dependency] = lambda: {}
         disable_installed_extensions_check()
@@ -35,12 +35,10 @@ class TournamentEndpointV1Test(TestBase):
         expected = tournament_fixture.model_dump()
         self.mock_service.get_tournaments.return_value = [tournament_fixture]
 
-        response = self.client.get(
-            f"{TOURNAMENT_BASE_URL}?status={TournamentStatus.ACTIVE.value}"
-        )
+        response = self.client.get(f"{TOURNAMENT_BASE_URL}?status={TournamentStatus.ACTIVE.value}")
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -54,7 +52,7 @@ class TournamentEndpointV1Test(TestBase):
         )
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 
@@ -68,7 +66,7 @@ class TournamentEndpointV1Test(TestBase):
         )
 
         self.assertEqual(HTTPStatus.OK, response.status_code)
-        items = response.json().get('items')
+        items = response.json().get("items")
         self.assertEqual(1, len(items))
         self.assertEqual(expected, items[0])
 

--- a/tests/riot_scraper/test_job_runner.py
+++ b/tests/riot_scraper/test_job_runner.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from src.common.exceptions import FantasyLolException
 from src.riot_scraper.job_runner import JobRunner
 
-JOB_RUNNER_PATH = 'src.riot_scraper.job_runner'
+JOB_RUNNER_PATH = "src.riot_scraper.job_runner"
 
 
 class TestJobRunner(TestBase):
@@ -18,7 +18,7 @@ class TestJobRunner(TestBase):
         # Assert
         job_function_mock.assert_called_once()
 
-    @patch('time.sleep', return_value=None)
+    @patch("time.sleep", return_value=None)
     def test_run_retry_job_with_exception_then_success(self, sleep_mock):
         # Arrange
         job_function_mock = MagicMock()
@@ -34,7 +34,7 @@ class TestJobRunner(TestBase):
         self.assertEqual(job_function_mock.call_count, max_retries + 1)
         sleep_mock.assert_called_once()
 
-    @patch('time.sleep', return_value=None)
+    @patch("time.sleep", return_value=None)
     def test_run_retry_job_with_max_retries_exceeded(self, sleep_mock):
         # Arrange
         exception_message = "Test exception"
@@ -43,11 +43,11 @@ class TestJobRunner(TestBase):
         max_retries = 2
 
         # Act
-        with patch(f'{JOB_RUNNER_PATH}.logger.error') as log_error_mock:
+        with patch(f"{JOB_RUNNER_PATH}.logger.error") as log_error_mock:
             JobRunner.run_retry_job(job_function_mock, job_name, max_retries)
 
         # Assert
         job_function_mock.assert_called_with()
         self.assertEqual(job_function_mock.call_count, max_retries + 1)
         self.assertEqual(sleep_mock.call_count, max_retries)
-        log_error_mock.assert_called_once_with(f'{job_name} failed: {exception_message}')
+        log_error_mock.assert_called_once_with(f"{job_name} failed: {exception_message}")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4,34 +4,33 @@ import os
 from sqlalchemy import MetaData
 
 # JWT Auth Config Settings:
-os.environ['AUTH_SECRET'] = "1234567890"
-os.environ['AUTH_ALGORITHM'] = "HS256"
+os.environ["AUTH_SECRET"] = "1234567890"
+os.environ["AUTH_ALGORITHM"] = "HS256"
 
 # Email Verification Config Settings:
-os.environ['VERIFICATION_DOMAIN_URL'] = "http://localhost"
-os.environ['VERIFICATION_SENDER_EMAIL'] = "testEmail@gmail.com"
-os.environ['VERIFICATION_SENDER_PASSWORD'] = "testpassword"
-os.environ['VERIFICATION_SMTP_HOST'] = "smtp.gmail.com"
-os.environ['VERIFICATION_SMTP_PORT'] = "465"
+os.environ["VERIFICATION_DOMAIN_URL"] = "http://localhost"
+os.environ["VERIFICATION_SENDER_EMAIL"] = "testEmail@gmail.com"
+os.environ["VERIFICATION_SENDER_PASSWORD"] = "testpassword"
+os.environ["VERIFICATION_SMTP_HOST"] = "smtp.gmail.com"
+os.environ["VERIFICATION_SMTP_PORT"] = "465"
 
 from tests.test_util.db_util import TestDatabaseService
 from src.db import models  # type: ignore
 from src.db.database_connection_provider import DatabaseConnectionProvider
 from src.db.database_service import DatabaseService
 
-RIOT_API_REQUESTER_CLOUDSCRAPER_PATH = \
-    'src.riot_scraper.riot_api_requester.cloudscraper.create_scraper'
+RIOT_API_REQUESTER_CLOUDSCRAPER_PATH = (
+    "src.riot_scraper.riot_api_requester.cloudscraper.create_scraper"
+)
 
-BASE_CRUD_PATH = 'src.db.crud'
+BASE_CRUD_PATH = "src.db.crud"
 
 TEST_DATABASE_URL = os.environ.get(
-    'TEST_DATABASE_URL',
-    'postgresql://postgres:postgres@localhost:5432/fantasy_lol_test'
+    "TEST_DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/fantasy_lol_test"
 )
 
 
 class TestBase(unittest.TestCase):
-
     db_provider: DatabaseConnectionProvider
     db: DatabaseService
     test_db: TestDatabaseService
@@ -48,6 +47,7 @@ class TestBase(unittest.TestCase):
             def setUpOverride(self, *args, **kwargs):
                 TestBase.setUp(self)
                 return orig_setUp(self, *args, **kwargs)
+
             cls.setUp = setUpOverride  # type: ignore
 
     def setUp(self):

--- a/tests/test_util/db_util.py
+++ b/tests/test_util/db_util.py
@@ -8,12 +8,14 @@ class TestDatabaseService:
         self.connection_provider = connection_provider
 
     def get_all_league_memberships(
-            self,
-            league_id: FantasyLeagueID
+        self, league_id: FantasyLeagueID
     ) -> list[models.FantasyLeagueMembershipModel]:
         with self.connection_provider.get_db() as db:
-            return db.query(models.FantasyLeagueMembershipModel) \
-                .filter(models.FantasyLeagueMembershipModel.league_id == league_id).all()
+            return (
+                db.query(models.FantasyLeagueMembershipModel)
+                .filter(models.FantasyLeagueMembershipModel.league_id == league_id)
+                .all()
+            )
 
     def get_all_game_metadata(self):
         with self.connection_provider.get_db() as db:

--- a/tests/test_util/fantasy_fixtures.py
+++ b/tests/test_util/fantasy_fixtures.py
@@ -10,7 +10,10 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueStatus,
     FantasyLeagueID,
     FantasyTeam,
-    User, UserCreate, UserLogin, UserID
+    User,
+    UserCreate,
+    UserLogin,
+    UserID,
 )
 from src.common.schemas.riot_data_schemas import ProPlayerID
 
@@ -20,14 +23,11 @@ salt = bcrypt.gensalt()
 user_hashed_password = bcrypt.hashpw(str.encode(user_password), salt)
 
 user_create_fixture: UserCreate = UserCreate(
-    username=UserID("MyUsername"),
-    email="MyEmail@gmail.com",
-    password=user_password
+    username=UserID("MyUsername"), email="MyEmail@gmail.com", password=user_password
 )
 
 user_login_fixture: UserLogin = UserLogin(
-    username=user_create_fixture.username,
-    password=user_password
+    username=user_create_fixture.username, password=user_password
 )
 
 user_fixture: User = User(
@@ -36,7 +36,7 @@ user_fixture: User = User(
     email=user_create_fixture.email,
     password=user_hashed_password,
     permissions=f"{Permissions.FANTASY_READ.value},{Permissions.FANTASY_WRITE.value},"
-    f"{Permissions.RIOT_READ.value}"
+    f"{Permissions.RIOT_READ.value}",
 )
 
 user_2_fixture: User = User(
@@ -45,7 +45,7 @@ user_2_fixture: User = User(
     email="user2@email.com",
     password=user_hashed_password,
     permissions=f"{Permissions.FANTASY_READ.value},{Permissions.FANTASY_WRITE.value},"
-    f"{Permissions.RIOT_READ.value}"
+    f"{Permissions.RIOT_READ.value}",
 )
 
 user_3_fixture: User = User(
@@ -54,7 +54,7 @@ user_3_fixture: User = User(
     email="user3@email.com",
     password=user_hashed_password,
     permissions=f"{Permissions.FANTASY_READ.value},{Permissions.FANTASY_WRITE.value},"
-    f"{Permissions.RIOT_READ.value}"
+    f"{Permissions.RIOT_READ.value}",
 )
 
 user_4_fixture: User = User(
@@ -63,13 +63,11 @@ user_4_fixture: User = User(
     email="user4@email.com",
     password=user_hashed_password,
     permissions=f"{Permissions.FANTASY_READ.value},{Permissions.FANTASY_WRITE.value},"
-    f"{Permissions.RIOT_READ.value}"
+    f"{Permissions.RIOT_READ.value}",
 )
 
 fantasy_league_settings_fixture: FantasyLeagueSettings = FantasyLeagueSettings(
-    name="Fantasy League 1",
-    number_of_teams=6,
-    available_leagues=[]
+    name="Fantasy League 1", number_of_teams=6, available_leagues=[]
 )
 
 fantasy_league_fixture: FantasyLeague = FantasyLeague(
@@ -79,7 +77,7 @@ fantasy_league_fixture: FantasyLeague = FantasyLeague(
     name=fantasy_league_settings_fixture.name,
     number_of_teams=fantasy_league_settings_fixture.number_of_teams,
     available_leagues=fantasy_league_settings_fixture.available_leagues,
-    current_week=None
+    current_week=None,
 )
 
 fantasy_league_draft_fixture: FantasyLeague = FantasyLeague(
@@ -90,7 +88,7 @@ fantasy_league_draft_fixture: FantasyLeague = FantasyLeague(
     number_of_teams=fantasy_league_settings_fixture.number_of_teams,
     available_leagues=fantasy_league_settings_fixture.available_leagues,
     current_draft_position=1,
-    current_week=0
+    current_week=0,
 )
 
 fantasy_league_active_fixture: FantasyLeague = FantasyLeague(
@@ -100,10 +98,10 @@ fantasy_league_active_fixture: FantasyLeague = FantasyLeague(
     name=fantasy_league_settings_fixture.name,
     number_of_teams=fantasy_league_settings_fixture.number_of_teams,
     available_leagues=fantasy_league_settings_fixture.available_leagues,
-    current_week=1
+    current_week=1,
 )
 
-fantasy_league_scoring_settings_fixture: FantasyLeagueScoringSettings = \
+fantasy_league_scoring_settings_fixture: FantasyLeagueScoringSettings = (
     FantasyLeagueScoringSettings(
         fantasy_league_id=fantasy_league_fixture.id,
         kills=4,
@@ -113,8 +111,9 @@ fantasy_league_scoring_settings_fixture: FantasyLeagueScoringSettings = \
         wards_placed=0.2,
         wards_destroyed=0.2,
         kill_participation=15,
-        damage_percentage=8
+        damage_percentage=8,
     )
+)
 
 fantasy_team_full: FantasyTeam = FantasyTeam(
     fantasy_league_id=fantasy_league_active_fixture.id,
@@ -124,7 +123,7 @@ fantasy_team_full: FantasyTeam = FantasyTeam(
     jungle_player_id=ProPlayerID(str((randint(10000, 99999)))),
     mid_player_id=ProPlayerID(str((randint(10000, 99999)))),
     adc_player_id=ProPlayerID(str((randint(10000, 99999)))),
-    support_player_id=ProPlayerID(str((randint(10000, 99999))))
+    support_player_id=ProPlayerID(str((randint(10000, 99999)))),
 )
 
 fantasy_team_week_1: FantasyTeam = FantasyTeam(
@@ -135,7 +134,7 @@ fantasy_team_week_1: FantasyTeam = FantasyTeam(
     jungle_player_id=None,
     mid_player_id=None,
     adc_player_id=None,
-    support_player_id=None
+    support_player_id=None,
 )
 
 fantasy_team_week_2: FantasyTeam = FantasyTeam(
@@ -146,5 +145,5 @@ fantasy_team_week_2: FantasyTeam = FantasyTeam(
     jungle_player_id=None,
     mid_player_id=None,
     adc_player_id=None,
-    support_player_id=None
+    support_player_id=None,
 )

--- a/tests/test_util/riot_api_requester_util.py
+++ b/tests/test_util/riot_api_requester_util.py
@@ -1,5 +1,13 @@
-from src.common.schemas.riot_data_schemas import Match, League, ProfessionalTeam, MatchState, \
-    ProfessionalPlayer, Game, PlayerGameMetadata, PlayerGameStats
+from src.common.schemas.riot_data_schemas import (
+    Match,
+    League,
+    ProfessionalTeam,
+    MatchState,
+    ProfessionalPlayer,
+    Game,
+    PlayerGameMetadata,
+    PlayerGameStats,
+)
 from tests.test_util import riot_fixtures
 from typing import Any
 
@@ -13,10 +21,7 @@ get_leagues_mock_response = {
                 "region": riot_fixtures.league_1_fixture.region,
                 "image": riot_fixtures.league_1_fixture.image,
                 "priority": riot_fixtures.league_1_fixture.priority,
-                "displayPriority": {
-                    "position": 0,
-                    "status": "selected"
-                }
+                "displayPriority": {"position": 0, "status": "selected"},
             }
         ]
     }
@@ -31,7 +36,7 @@ get_tournaments_for_league_response = {
                         "id": riot_fixtures.tournament_fixture.id,
                         "slug": riot_fixtures.tournament_fixture.slug,
                         "startDate": riot_fixtures.tournament_fixture.start_date,
-                        "endDate": riot_fixtures.tournament_fixture.end_date
+                        "endDate": riot_fixtures.tournament_fixture.end_date,
                     }
                 ]
             }
@@ -47,7 +52,7 @@ def create_player_for_team_response(player: ProfessionalPlayer, player_number: i
         "firstName": f"player_{player_number}_first_name",
         "lastName": f"player_{player_number}_last_name",
         "image": player.image,
-        "role": player.role
+        "role": player.role,
     }
 
 
@@ -65,7 +70,7 @@ get_teams_response = {
                 "status": riot_fixtures.team_1_fixture.status,
                 "homeLeague": {
                     "name": riot_fixtures.league_1_fixture.name,
-                    "region": riot_fixtures.league_1_fixture.region
+                    "region": riot_fixtures.league_1_fixture.region,
                 },
                 "players": [
                     create_player_for_team_response(riot_fixtures.player_1_fixture, 1),
@@ -73,7 +78,7 @@ get_teams_response = {
                     create_player_for_team_response(riot_fixtures.player_3_fixture, 3),
                     create_player_for_team_response(riot_fixtures.player_4_fixture, 4),
                     create_player_for_team_response(riot_fixtures.player_5_fixture, 5),
-                ]
+                ],
             }
         ]
     }
@@ -81,8 +86,7 @@ get_teams_response = {
 
 
 def create_team_for_event_details_response(
-        team: ProfessionalTeam,
-        match: Match = riot_fixtures.match_fixture
+    team: ProfessionalTeam, match: Match = riot_fixtures.match_fixture
 ) -> dict:
     game_wins = None
     if team.name == match.team_1_name:
@@ -90,39 +94,24 @@ def create_team_for_event_details_response(
     elif team.name == match.team_2_name:
         game_wins = match.team_2_wins
 
-    assert (game_wins is not None)
+    assert game_wins is not None
     return {
         "id": team.id,
         "name": team.name,
         "code": team.code,
         "image": team.image,
-        "result": {
-            "gameWins": game_wins
-        }
+        "result": {"gameWins": game_wins},
     }
 
 
 def create_game_for_response(
-        game: Game,
-        blue_team: ProfessionalTeam | None = None,
-        red_team: ProfessionalTeam | None = None
+    game: Game, blue_team: ProfessionalTeam | None = None, red_team: ProfessionalTeam | None = None
 ) -> dict:
-    game_response = {
-        "id": game.id,
-        "number": game.number,
-        "state": game.state.value,
-        "vods": []
-    }
+    game_response = {"id": game.id, "number": game.number, "state": game.state.value, "vods": []}
     if blue_team and red_team:
         game_response["teams"] = [
-            {
-                "id": blue_team.id,
-                "side": "blue"
-            },
-            {
-                "id": red_team.id,
-                "side": "red"
-            }
+            {"id": blue_team.id, "side": "blue"},
+            {"id": red_team.id, "side": "red"},
         ]
     return game_response
 
@@ -132,66 +121,58 @@ get_event_details_response = {
         "event": {
             "id": riot_fixtures.match_fixture.id,
             "type": "match",
-            "tournament": {
-                "id": riot_fixtures.tournament_fixture.id
-            },
+            "tournament": {"id": riot_fixtures.tournament_fixture.id},
             "league": {
                 "id": riot_fixtures.league_1_fixture.id,
                 "slug": riot_fixtures.league_1_fixture.slug,
                 "image": riot_fixtures.league_1_fixture.image,
-                "name": riot_fixtures.league_1_fixture.name
+                "name": riot_fixtures.league_1_fixture.name,
             },
             "match": {
-                "strategy": {
-                    "count": riot_fixtures.match_fixture.strategy_count
-                },
+                "strategy": {"count": riot_fixtures.match_fixture.strategy_count},
                 "teams": [
                     create_team_for_event_details_response(riot_fixtures.team_1_fixture),
-                    create_team_for_event_details_response(riot_fixtures.team_2_fixture)
+                    create_team_for_event_details_response(riot_fixtures.team_2_fixture),
                 ],
                 "games": [
                     create_game_for_response(
                         riot_fixtures.game_1_fixture_completed,
                         riot_fixtures.team_1_fixture,
-                        riot_fixtures.team_2_fixture
+                        riot_fixtures.team_2_fixture,
                     ),
                     create_game_for_response(
                         riot_fixtures.game_2_fixture_inprogress,
                         riot_fixtures.team_1_fixture,
-                        riot_fixtures.team_2_fixture
+                        riot_fixtures.team_2_fixture,
                     ),
                     create_game_for_response(
                         riot_fixtures.game_3_fixture_unstarted,
                         riot_fixtures.team_2_fixture,
-                        riot_fixtures.team_1_fixture
-                    )
-                ]
+                        riot_fixtures.team_1_fixture,
+                    ),
+                ],
             },
-            "streams": []
+            "streams": [],
         }
     }
 }
 
 get_games_response: dict[str, dict[str, list[dict[str, Any]]]] = {
-    "data": {
-        "games": [
-            create_game_for_response(riot_fixtures.game_1_fixture_completed)
-        ]
-    }
+    "data": {"games": [create_game_for_response(riot_fixtures.game_1_fixture_completed)]}
 }
 
 
 def create_participant_metadata_for_response(
-        player_game_metadata: PlayerGameMetadata,
-        player: ProfessionalPlayer,
-        team: ProfessionalTeam,
+    player_game_metadata: PlayerGameMetadata,
+    player: ProfessionalPlayer,
+    team: ProfessionalTeam,
 ) -> dict:
     return {
         "participantId": player_game_metadata.participant_id,
         "esportsPlayerId": player_game_metadata.player_id,
         "summonerName": f"{team.code} {player.summoner_name}",
         "championId": player_game_metadata.champion_id,
-        "role": player_game_metadata.role
+        "role": player_game_metadata.role,
     }
 
 
@@ -206,29 +187,29 @@ get_livestats_window_response = {
                 create_participant_metadata_for_response(
                     riot_fixtures.player_1_game_metadata_fixture,
                     riot_fixtures.player_1_fixture,
-                    riot_fixtures.team_1_fixture
+                    riot_fixtures.team_1_fixture,
                 ),
                 create_participant_metadata_for_response(
                     riot_fixtures.player_2_game_metadata_fixture,
                     riot_fixtures.player_2_fixture,
-                    riot_fixtures.team_1_fixture
+                    riot_fixtures.team_1_fixture,
                 ),
                 create_participant_metadata_for_response(
                     riot_fixtures.player_3_game_metadata_fixture,
                     riot_fixtures.player_3_fixture,
-                    riot_fixtures.team_1_fixture
+                    riot_fixtures.team_1_fixture,
                 ),
                 create_participant_metadata_for_response(
                     riot_fixtures.player_4_game_metadata_fixture,
                     riot_fixtures.player_4_fixture,
-                    riot_fixtures.team_1_fixture
+                    riot_fixtures.team_1_fixture,
                 ),
                 create_participant_metadata_for_response(
                     riot_fixtures.player_5_game_metadata_fixture,
                     riot_fixtures.player_5_fixture,
-                    riot_fixtures.team_1_fixture
-                )
-            ]
+                    riot_fixtures.team_1_fixture,
+                ),
+            ],
         },
         "redTeamMetadata": {
             "esportsTeamId": riot_fixtures.team_2_fixture.id,
@@ -236,32 +217,32 @@ get_livestats_window_response = {
                 create_participant_metadata_for_response(
                     riot_fixtures.player_6_game_metadata_fixture,
                     riot_fixtures.player_6_fixture,
-                    riot_fixtures.team_2_fixture
+                    riot_fixtures.team_2_fixture,
                 ),
                 create_participant_metadata_for_response(
                     riot_fixtures.player_7_game_metadata_fixture,
                     riot_fixtures.player_7_fixture,
-                    riot_fixtures.team_2_fixture
+                    riot_fixtures.team_2_fixture,
                 ),
                 create_participant_metadata_for_response(
                     riot_fixtures.player_8_game_metadata_fixture,
                     riot_fixtures.player_8_fixture,
-                    riot_fixtures.team_2_fixture
+                    riot_fixtures.team_2_fixture,
                 ),
                 create_participant_metadata_for_response(
                     riot_fixtures.player_9_game_metadata_fixture,
                     riot_fixtures.player_9_fixture,
-                    riot_fixtures.team_2_fixture
+                    riot_fixtures.team_2_fixture,
                 ),
                 create_participant_metadata_for_response(
                     riot_fixtures.player_10_game_metadata_fixture,
                     riot_fixtures.player_10_fixture,
-                    riot_fixtures.team_2_fixture
+                    riot_fixtures.team_2_fixture,
                 ),
-            ]
-        }
+            ],
+        },
     },
-    "frames": []
+    "frames": [],
 }
 
 
@@ -291,29 +272,11 @@ def create_participant_for_response(player_game_stats: PlayerGameStats) -> dict:
         "armor": 115,
         "magicResistance": 91,
         "tenacity": 0.0,
-        "items": [
-            3340,
-            3053,
-            6630,
-            3047,
-            3065,
-            2055,
-            2055
-        ],
+        "items": [3340, 3053, 6630, 3047, 3065, 2055, 2055],
         "perkMetadata": {
             "styleId": 8000,
             "subStyleId": 8400,
-            "perks": [
-                8010,
-                9111,
-                9105,
-                8299,
-                8444,
-                8453,
-                5008,
-                5008,
-                5002
-            ]
+            "perks": [8010, 9111, 9105, 8299, 8444, 8453, 5008, 5008, 5002],
         },
         "abilities": [
             "Q",
@@ -332,14 +295,12 @@ def create_participant_for_response(player_game_stats: PlayerGameStats) -> dict:
             "W",
             "W",
             "R",
-            "W"
-        ]
+            "W",
+        ],
     }
 
 
-get_live_stats_details_empty_frames_response: dict[str, list] = {
-    "frames": []
-}
+get_live_stats_details_empty_frames_response: dict[str, list] = {"frames": []}
 
 get_live_stats_details_response = {
     "frames": [
@@ -355,92 +316,71 @@ get_live_stats_details_response = {
                 create_participant_for_response(riot_fixtures.player_7_game_stats_fixture),
                 create_participant_for_response(riot_fixtures.player_8_game_stats_fixture),
                 create_participant_for_response(riot_fixtures.player_9_game_stats_fixture),
-                create_participant_for_response(riot_fixtures.player_10_game_stats_fixture)
-            ]
+                create_participant_for_response(riot_fixtures.player_10_game_stats_fixture),
+            ],
         }
     ]
 }
 
 
 def create_get_schedule_response(
-        match: Match,
-        league: League = riot_fixtures.league_1_fixture,
-        team_1: ProfessionalTeam = riot_fixtures.team_1_fixture,
-        team_2: ProfessionalTeam = riot_fixtures.team_2_fixture
+    match: Match,
+    league: League = riot_fixtures.league_1_fixture,
+    team_1: ProfessionalTeam = riot_fixtures.team_1_fixture,
+    team_2: ProfessionalTeam = riot_fixtures.team_2_fixture,
 ) -> dict:
     team_1_result = None
     team_2_result = None
     if match.state == MatchState.COMPLETED:
         team_1_result = {
             "outcome": "win" if match.winning_team == team_1.name else "loss",
-            "gameWins": match.team_1_wins
+            "gameWins": match.team_1_wins,
         }
         team_2_result = {
             "outcome": "win" if match.winning_team == team_2.name else "loss",
-            "gameWins": match.team_2_wins
+            "gameWins": match.team_2_wins,
         }
     elif match.state == MatchState.INPROGRESS:
-        team_1_result = {
-            "outcome": None,
-            "gameWins": match.team_1_wins
-        }
-        team_2_result = {
-            "outcome": None,
-            "gameWins": match.team_2_wins
-        }
+        team_1_result = {"outcome": None, "gameWins": match.team_1_wins}
+        team_2_result = {"outcome": None, "gameWins": match.team_2_wins}
 
     get_schedule_response = {
         "data": {
             "schedule": {
-                "pages": {
-                    "older": "olderToken",
-                    "newer": "newerToken"
-                },
+                "pages": {"older": "olderToken", "newer": "newerToken"},
                 "events": [
                     {
                         "startTime": match.start_time,
                         "state": match.state,
                         "type": "match",
                         "blockName": match.block_name,
-                        "league": {
-                            "name": league.name,
-                            "slug": league.slug
-                        },
+                        "league": {"name": league.name, "slug": league.slug},
                         "match": {
                             "id": match.id,
-                            "flags": [
-                                "hasVod",
-                                "isSpoiler"
-                            ],
+                            "flags": ["hasVod", "isSpoiler"],
                             "teams": [
                                 {
                                     "name": team_1.name,
                                     "code": team_1.code,
                                     "image": team_1.image,
                                     "result": team_1_result,
-                                    "record": {
-                                        "wins": 1,
-                                        "losses": 1
-                                    }
+                                    "record": {"wins": 1, "losses": 1},
                                 },
                                 {
                                     "name": team_2.name,
                                     "code": team_2.code,
                                     "image": team_2.image,
                                     "result": team_2_result,
-                                    "record": {
-                                        "wins": 3,
-                                        "losses": 0
-                                    }
-                                }
+                                    "record": {"wins": 3, "losses": 0},
+                                },
                             ],
                             "strategy": {
                                 "type": match.strategy_type,
-                                "count": match.strategy_count
-                            }
-                        }
+                                "count": match.strategy_count,
+                            },
+                        },
                     }
-                ]
+                ],
             }
         }
     }

--- a/tests/test_util/riot_fixtures.py
+++ b/tests/test_util/riot_fixtures.py
@@ -11,7 +11,7 @@ from src.common.schemas.riot_data_schemas import (
     RiotLeagueID,
     RiotTournamentID,
     ProPlayerID,
-    ProTeamID
+    ProTeamID,
 )
 
 past_start_date = datetime.now(pytz.utc) - timedelta(days=5)
@@ -38,7 +38,7 @@ league_1_fixture = schemas.League(
     region="MOCKED REGION",
     image="http//:mocked-league-image.png",
     priority=1,
-    fantasy_available=False
+    fantasy_available=False,
 )
 
 league_2_fixture = schemas.League(
@@ -48,7 +48,7 @@ league_2_fixture = schemas.League(
     region="MOCKED REGION2",
     image="http//:mocked-league-2-image.png",
     priority=2,
-    fantasy_available=True
+    fantasy_available=True,
 )
 
 tournament_fixture = schemas.Tournament(
@@ -56,7 +56,7 @@ tournament_fixture = schemas.Tournament(
     slug="mock_slug_2023",
     start_date="2023-01-01",
     end_date="2023-02-03",
-    league_id=league_1_fixture.id
+    league_id=league_1_fixture.id,
 )
 
 future_tournament_fixture = schemas.Tournament(
@@ -64,7 +64,7 @@ future_tournament_fixture = schemas.Tournament(
     slug="future_slug",
     start_date=formatted_future_start_date,
     end_date=formatted_future_end_date,
-    league_id=league_1_fixture.id
+    league_id=league_1_fixture.id,
 )
 
 active_tournament_fixture = schemas.Tournament(
@@ -72,7 +72,7 @@ active_tournament_fixture = schemas.Tournament(
     slug="active_slug",
     start_date=formatted_past_start_date,
     end_date=formatted_future_end_date,
-    league_id=league_1_fixture.id
+    league_id=league_1_fixture.id,
 )
 
 team_1_fixture = schemas.ProfessionalTeam(
@@ -84,7 +84,7 @@ team_1_fixture = schemas.ProfessionalTeam(
     alternative_image="http://mock-team-1-alternative-image.png",
     background_image="http://mock-team-1-background.png",
     status="active",
-    home_league=league_1_fixture.name
+    home_league=league_1_fixture.name,
 )
 
 team_2_fixture = schemas.ProfessionalTeam(
@@ -96,7 +96,7 @@ team_2_fixture = schemas.ProfessionalTeam(
     alternative_image="http://mock-team-2-alternative-image.png",
     background_image="http://mock-team-2-background.png",
     status="active",
-    home_league=league_1_fixture.name
+    home_league=league_1_fixture.name,
 )
 
 match_fixture = schemas.Match(
@@ -113,7 +113,7 @@ match_fixture = schemas.Match(
     state=schemas.MatchState.INPROGRESS,
     team_1_wins=1,
     team_2_wins=0,
-    winning_team=None
+    winning_team=None,
 )
 
 completed_match_fixture = schemas.Match(
@@ -130,7 +130,7 @@ completed_match_fixture = schemas.Match(
     state=schemas.MatchState.COMPLETED,
     team_1_wins=1,
     team_2_wins=0,
-    winning_team=team_1_fixture.name
+    winning_team=team_1_fixture.name,
 )
 
 future_match_fixture = schemas.Match(
@@ -147,7 +147,7 @@ future_match_fixture = schemas.Match(
     state=schemas.MatchState.UNSTARTED,
     team_1_wins=None,
     team_2_wins=None,
-    winning_team=None
+    winning_team=None,
 )
 
 game_1_fixture_completed = schemas.Game(
@@ -157,12 +157,11 @@ game_1_fixture_completed = schemas.Game(
     red_team=team_1_fixture.id,
     blue_team=team_2_fixture.id,
     match_id=match_fixture.id,
-    has_game_data=True
+    has_game_data=True,
 )
 
 get_games_response_game_1_fixture = schemas.GetGamesResponseSchema(
-    id=game_1_fixture_completed.id,
-    state=game_1_fixture_completed.state
+    id=game_1_fixture_completed.id, state=game_1_fixture_completed.state
 )
 
 game_2_fixture_inprogress = schemas.Game(
@@ -171,7 +170,7 @@ game_2_fixture_inprogress = schemas.Game(
     number=2,
     red_team=team_1_fixture.id,
     blue_team=team_2_fixture.id,
-    match_id=match_fixture.id
+    match_id=match_fixture.id,
 )
 
 game_3_fixture_unstarted = schemas.Game(
@@ -180,7 +179,7 @@ game_3_fixture_unstarted = schemas.Game(
     number=3,
     red_team=team_1_fixture.id,
     blue_team=team_2_fixture.id,
-    match_id=match_fixture.id
+    match_id=match_fixture.id,
 )
 
 game_4_fixture_unneeded = schemas.Game(
@@ -189,7 +188,7 @@ game_4_fixture_unneeded = schemas.Game(
     number=4,
     red_team=team_1_fixture.id,
     blue_team=team_2_fixture.id,
-    match_id=match_fixture.id
+    match_id=match_fixture.id,
 )
 
 game_1_fixture_unstarted_future_match = schemas.Game(
@@ -198,7 +197,7 @@ game_1_fixture_unstarted_future_match = schemas.Game(
     number=3,
     red_team=team_1_fixture.id,
     blue_team=team_2_fixture.id,
-    match_id=future_match_fixture.id
+    match_id=future_match_fixture.id,
 )
 
 player_1_fixture = schemas.ProfessionalPlayer(
@@ -206,7 +205,7 @@ player_1_fixture = schemas.ProfessionalPlayer(
     summoner_name="MockerPlayer1",
     image="http://mocked-player-1.png",
     role=PlayerRole.TOP,
-    team_id=team_1_fixture.id
+    team_id=team_1_fixture.id,
 )
 
 player_2_fixture = schemas.ProfessionalPlayer(
@@ -214,7 +213,7 @@ player_2_fixture = schemas.ProfessionalPlayer(
     summoner_name="MockerPlayer2",
     image="http://mocked-player-2.png",
     role=PlayerRole.JUNGLE,
-    team_id=team_1_fixture.id
+    team_id=team_1_fixture.id,
 )
 
 player_3_fixture = schemas.ProfessionalPlayer(
@@ -222,7 +221,7 @@ player_3_fixture = schemas.ProfessionalPlayer(
     summoner_name="MockerPlayer3",
     image="http://mocked-player-3.png",
     role=PlayerRole.MID,
-    team_id=team_1_fixture.id
+    team_id=team_1_fixture.id,
 )
 
 player_4_fixture = schemas.ProfessionalPlayer(
@@ -230,7 +229,7 @@ player_4_fixture = schemas.ProfessionalPlayer(
     summoner_name="MockerPlayer4",
     image="http://mocked-player-4.png",
     role=PlayerRole.BOTTOM,
-    team_id=team_1_fixture.id
+    team_id=team_1_fixture.id,
 )
 
 player_5_fixture = schemas.ProfessionalPlayer(
@@ -238,7 +237,7 @@ player_5_fixture = schemas.ProfessionalPlayer(
     summoner_name="MockerPlayer5",
     image="http://mocked-player-5.png",
     role=PlayerRole.SUPPORT,
-    team_id=team_1_fixture.id
+    team_id=team_1_fixture.id,
 )
 
 player_6_fixture = schemas.ProfessionalPlayer(
@@ -246,7 +245,7 @@ player_6_fixture = schemas.ProfessionalPlayer(
     summoner_name="MockerPlayer6",
     image="http://mocked-player-6.png",
     role=PlayerRole.TOP,
-    team_id=team_2_fixture.id
+    team_id=team_2_fixture.id,
 )
 
 player_7_fixture = schemas.ProfessionalPlayer(
@@ -254,7 +253,7 @@ player_7_fixture = schemas.ProfessionalPlayer(
     summoner_name="MockerPlayer7",
     image="http://mocked-player-7.png",
     role=PlayerRole.JUNGLE,
-    team_id=team_2_fixture.id
+    team_id=team_2_fixture.id,
 )
 
 player_8_fixture = schemas.ProfessionalPlayer(
@@ -262,7 +261,7 @@ player_8_fixture = schemas.ProfessionalPlayer(
     summoner_name="MockerPlayer8",
     image="http://mocked-player-8.png",
     role=PlayerRole.MID,
-    team_id=team_2_fixture.id
+    team_id=team_2_fixture.id,
 )
 
 player_9_fixture = schemas.ProfessionalPlayer(
@@ -270,7 +269,7 @@ player_9_fixture = schemas.ProfessionalPlayer(
     summoner_name="MockerPlayer9",
     image="http://mocked-player-9.png",
     role=PlayerRole.BOTTOM,
-    team_id=team_2_fixture.id
+    team_id=team_2_fixture.id,
 )
 
 player_10_fixture = schemas.ProfessionalPlayer(
@@ -278,7 +277,7 @@ player_10_fixture = schemas.ProfessionalPlayer(
     summoner_name="MockerPlayer10",
     image="http://mocked-player-10.png",
     role=PlayerRole.SUPPORT,
-    team_id=team_2_fixture.id
+    team_id=team_2_fixture.id,
 )
 
 player_1_game_metadata_fixture = schemas.PlayerGameMetadata(
@@ -286,7 +285,7 @@ player_1_game_metadata_fixture = schemas.PlayerGameMetadata(
     player_id=player_1_fixture.id,
     participant_id=1,
     champion_id="champion1",
-    role=PlayerRole.TOP
+    role=PlayerRole.TOP,
 )
 
 player_2_game_metadata_fixture = schemas.PlayerGameMetadata(
@@ -294,7 +293,7 @@ player_2_game_metadata_fixture = schemas.PlayerGameMetadata(
     player_id=player_2_fixture.id,
     participant_id=2,
     champion_id="champion2",
-    role=PlayerRole.JUNGLE
+    role=PlayerRole.JUNGLE,
 )
 
 player_3_game_metadata_fixture = schemas.PlayerGameMetadata(
@@ -302,7 +301,7 @@ player_3_game_metadata_fixture = schemas.PlayerGameMetadata(
     player_id=player_3_fixture.id,
     participant_id=3,
     champion_id="champion3",
-    role=PlayerRole.MID
+    role=PlayerRole.MID,
 )
 
 player_4_game_metadata_fixture = schemas.PlayerGameMetadata(
@@ -310,7 +309,7 @@ player_4_game_metadata_fixture = schemas.PlayerGameMetadata(
     player_id=player_4_fixture.id,
     participant_id=4,
     champion_id="champion4",
-    role=PlayerRole.BOTTOM
+    role=PlayerRole.BOTTOM,
 )
 
 player_5_game_metadata_fixture = schemas.PlayerGameMetadata(
@@ -318,7 +317,7 @@ player_5_game_metadata_fixture = schemas.PlayerGameMetadata(
     player_id=player_5_fixture.id,
     participant_id=5,
     champion_id="champion5",
-    role=PlayerRole.SUPPORT
+    role=PlayerRole.SUPPORT,
 )
 
 player_6_game_metadata_fixture = schemas.PlayerGameMetadata(
@@ -326,7 +325,7 @@ player_6_game_metadata_fixture = schemas.PlayerGameMetadata(
     player_id=player_6_fixture.id,
     participant_id=6,
     champion_id="champion6",
-    role=PlayerRole.TOP
+    role=PlayerRole.TOP,
 )
 
 player_7_game_metadata_fixture = schemas.PlayerGameMetadata(
@@ -334,7 +333,7 @@ player_7_game_metadata_fixture = schemas.PlayerGameMetadata(
     player_id=player_7_fixture.id,
     participant_id=7,
     champion_id="champion7",
-    role=PlayerRole.JUNGLE
+    role=PlayerRole.JUNGLE,
 )
 
 player_8_game_metadata_fixture = schemas.PlayerGameMetadata(
@@ -342,7 +341,7 @@ player_8_game_metadata_fixture = schemas.PlayerGameMetadata(
     player_id=player_8_fixture.id,
     participant_id=8,
     champion_id="champion8",
-    role=PlayerRole.MID
+    role=PlayerRole.MID,
 )
 
 player_9_game_metadata_fixture = schemas.PlayerGameMetadata(
@@ -350,7 +349,7 @@ player_9_game_metadata_fixture = schemas.PlayerGameMetadata(
     player_id=player_9_fixture.id,
     participant_id=9,
     champion_id="champion9",
-    role=PlayerRole.BOTTOM
+    role=PlayerRole.BOTTOM,
 )
 
 player_10_game_metadata_fixture = schemas.PlayerGameMetadata(
@@ -358,7 +357,7 @@ player_10_game_metadata_fixture = schemas.PlayerGameMetadata(
     player_id=player_10_fixture.id,
     participant_id=10,
     champion_id="champion10",
-    role=PlayerRole.SUPPORT
+    role=PlayerRole.SUPPORT,
 )
 
 player_1_game_stats_fixture = schemas.PlayerGameStats(
@@ -372,7 +371,7 @@ player_1_game_stats_fixture = schemas.PlayerGameStats(
     kill_participation=20,
     champion_damage_share=20,
     wards_placed=random.randint(10, 20),
-    wards_destroyed=random.randint(10, 20)
+    wards_destroyed=random.randint(10, 20),
 )
 
 player_2_game_stats_fixture = schemas.PlayerGameStats(
@@ -386,7 +385,7 @@ player_2_game_stats_fixture = schemas.PlayerGameStats(
     kill_participation=20,
     champion_damage_share=20,
     wards_placed=random.randint(10, 20),
-    wards_destroyed=random.randint(10, 20)
+    wards_destroyed=random.randint(10, 20),
 )
 
 player_3_game_stats_fixture = schemas.PlayerGameStats(
@@ -400,7 +399,7 @@ player_3_game_stats_fixture = schemas.PlayerGameStats(
     kill_participation=20,
     champion_damage_share=20,
     wards_placed=random.randint(10, 20),
-    wards_destroyed=random.randint(10, 20)
+    wards_destroyed=random.randint(10, 20),
 )
 
 player_4_game_stats_fixture = schemas.PlayerGameStats(
@@ -414,7 +413,7 @@ player_4_game_stats_fixture = schemas.PlayerGameStats(
     kill_participation=20,
     champion_damage_share=20,
     wards_placed=random.randint(10, 20),
-    wards_destroyed=random.randint(10, 20)
+    wards_destroyed=random.randint(10, 20),
 )
 
 player_5_game_stats_fixture = schemas.PlayerGameStats(
@@ -428,7 +427,7 @@ player_5_game_stats_fixture = schemas.PlayerGameStats(
     kill_participation=20,
     champion_damage_share=20,
     wards_placed=random.randint(10, 20),
-    wards_destroyed=random.randint(10, 20)
+    wards_destroyed=random.randint(10, 20),
 )
 
 player_6_game_stats_fixture = schemas.PlayerGameStats(
@@ -442,7 +441,7 @@ player_6_game_stats_fixture = schemas.PlayerGameStats(
     kill_participation=20,
     champion_damage_share=20,
     wards_placed=random.randint(10, 20),
-    wards_destroyed=random.randint(10, 20)
+    wards_destroyed=random.randint(10, 20),
 )
 
 player_7_game_stats_fixture = schemas.PlayerGameStats(
@@ -456,7 +455,7 @@ player_7_game_stats_fixture = schemas.PlayerGameStats(
     kill_participation=20,
     champion_damage_share=20,
     wards_placed=random.randint(10, 20),
-    wards_destroyed=random.randint(10, 20)
+    wards_destroyed=random.randint(10, 20),
 )
 
 player_8_game_stats_fixture = schemas.PlayerGameStats(
@@ -470,7 +469,7 @@ player_8_game_stats_fixture = schemas.PlayerGameStats(
     kill_participation=20,
     champion_damage_share=20,
     wards_placed=random.randint(10, 20),
-    wards_destroyed=random.randint(10, 20)
+    wards_destroyed=random.randint(10, 20),
 )
 
 player_9_game_stats_fixture = schemas.PlayerGameStats(
@@ -484,7 +483,7 @@ player_9_game_stats_fixture = schemas.PlayerGameStats(
     kill_participation=20,
     champion_damage_share=20,
     wards_placed=random.randint(10, 20),
-    wards_destroyed=random.randint(10, 20)
+    wards_destroyed=random.randint(10, 20),
 )
 
 player_10_game_stats_fixture = schemas.PlayerGameStats(
@@ -498,7 +497,7 @@ player_10_game_stats_fixture = schemas.PlayerGameStats(
     kill_participation=20,
     champion_damage_share=20,
     wards_placed=random.randint(10, 20),
-    wards_destroyed=random.randint(10, 20)
+    wards_destroyed=random.randint(10, 20),
 )
 
 player_1_game_data_fixture = schemas.PlayerGameData(
@@ -515,7 +514,7 @@ player_1_game_data_fixture = schemas.PlayerGameData(
     kill_participation=player_1_game_stats_fixture.kill_participation,
     champion_damage_share=player_1_game_stats_fixture.champion_damage_share,
     wards_placed=player_1_game_stats_fixture.wards_placed,
-    wards_destroyed=player_1_game_stats_fixture.wards_destroyed
+    wards_destroyed=player_1_game_stats_fixture.wards_destroyed,
 )
 
 player_2_game_data_fixture = schemas.PlayerGameData(
@@ -532,7 +531,7 @@ player_2_game_data_fixture = schemas.PlayerGameData(
     kill_participation=player_2_game_stats_fixture.kill_participation,
     champion_damage_share=player_2_game_stats_fixture.champion_damage_share,
     wards_placed=player_2_game_stats_fixture.wards_placed,
-    wards_destroyed=player_2_game_stats_fixture.wards_destroyed
+    wards_destroyed=player_2_game_stats_fixture.wards_destroyed,
 )
 
 player_3_game_data_fixture = schemas.PlayerGameData(
@@ -549,7 +548,7 @@ player_3_game_data_fixture = schemas.PlayerGameData(
     kill_participation=player_3_game_stats_fixture.kill_participation,
     champion_damage_share=player_3_game_stats_fixture.champion_damage_share,
     wards_placed=player_3_game_stats_fixture.wards_placed,
-    wards_destroyed=player_3_game_stats_fixture.wards_destroyed
+    wards_destroyed=player_3_game_stats_fixture.wards_destroyed,
 )
 
 player_4_game_data_fixture = schemas.PlayerGameData(
@@ -566,7 +565,7 @@ player_4_game_data_fixture = schemas.PlayerGameData(
     kill_participation=player_4_game_stats_fixture.kill_participation,
     champion_damage_share=player_4_game_stats_fixture.champion_damage_share,
     wards_placed=player_4_game_stats_fixture.wards_placed,
-    wards_destroyed=player_4_game_stats_fixture.wards_destroyed
+    wards_destroyed=player_4_game_stats_fixture.wards_destroyed,
 )
 
 player_5_game_data_fixture = schemas.PlayerGameData(
@@ -583,7 +582,7 @@ player_5_game_data_fixture = schemas.PlayerGameData(
     kill_participation=player_5_game_stats_fixture.kill_participation,
     champion_damage_share=player_5_game_stats_fixture.champion_damage_share,
     wards_placed=player_5_game_stats_fixture.wards_placed,
-    wards_destroyed=player_5_game_stats_fixture.wards_destroyed
+    wards_destroyed=player_5_game_stats_fixture.wards_destroyed,
 )
 
 player_6_game_data_fixture = schemas.PlayerGameData(
@@ -600,7 +599,7 @@ player_6_game_data_fixture = schemas.PlayerGameData(
     kill_participation=player_6_game_stats_fixture.kill_participation,
     champion_damage_share=player_6_game_stats_fixture.champion_damage_share,
     wards_placed=player_6_game_stats_fixture.wards_placed,
-    wards_destroyed=player_6_game_stats_fixture.wards_destroyed
+    wards_destroyed=player_6_game_stats_fixture.wards_destroyed,
 )
 
 player_7_game_data_fixture = schemas.PlayerGameData(
@@ -617,7 +616,7 @@ player_7_game_data_fixture = schemas.PlayerGameData(
     kill_participation=player_7_game_stats_fixture.kill_participation,
     champion_damage_share=player_7_game_stats_fixture.champion_damage_share,
     wards_placed=player_7_game_stats_fixture.wards_placed,
-    wards_destroyed=player_7_game_stats_fixture.wards_destroyed
+    wards_destroyed=player_7_game_stats_fixture.wards_destroyed,
 )
 
 player_8_game_data_fixture = schemas.PlayerGameData(
@@ -634,7 +633,7 @@ player_8_game_data_fixture = schemas.PlayerGameData(
     kill_participation=player_8_game_stats_fixture.kill_participation,
     champion_damage_share=player_8_game_stats_fixture.champion_damage_share,
     wards_placed=player_8_game_stats_fixture.wards_placed,
-    wards_destroyed=player_8_game_stats_fixture.wards_destroyed
+    wards_destroyed=player_8_game_stats_fixture.wards_destroyed,
 )
 
 player_9_game_data_fixture = schemas.PlayerGameData(
@@ -651,7 +650,7 @@ player_9_game_data_fixture = schemas.PlayerGameData(
     kill_participation=player_9_game_stats_fixture.kill_participation,
     champion_damage_share=player_9_game_stats_fixture.champion_damage_share,
     wards_placed=player_9_game_stats_fixture.wards_placed,
-    wards_destroyed=player_9_game_stats_fixture.wards_destroyed
+    wards_destroyed=player_9_game_stats_fixture.wards_destroyed,
 )
 
 player_10_game_data_fixture = schemas.PlayerGameData(
@@ -668,11 +667,9 @@ player_10_game_data_fixture = schemas.PlayerGameData(
     kill_participation=player_10_game_stats_fixture.kill_participation,
     champion_damage_share=player_10_game_stats_fixture.champion_damage_share,
     wards_placed=player_10_game_stats_fixture.wards_placed,
-    wards_destroyed=player_10_game_stats_fixture.wards_destroyed
+    wards_destroyed=player_10_game_stats_fixture.wards_destroyed,
 )
 
 riot_schedule_fixture = schemas.StoredSchedule(
-    schedule_name="test_riot_schedule",
-    older_token_key="olderToken",
-    newer_token_key="newerToken"
+    schedule_name="test_riot_schedule", older_token_key="olderToken", newer_token_key="newerToken"
 )


### PR DESCRIPTION
   - Replace autopep8 and flake8 dev deps with ruff==0.4.8
   - Add [tool.ruff] config to pyproject.toml, delete .flake8
   - Rewrite scripts/linter.sh to use ruff check and ruff format
   - Update CI pipeline to run ruff check and ruff format --check
   - Apply ruff format across entire codebase (116 files reformatted)
   - Update README tech stack and linting docs