### PR TITLE
Pipeline upgrade

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,12 +15,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.12
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
@@ -64,12 +65,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.12
+          cache: 'pip'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
  - Bump actions/checkout and actions/setup-python from v2 to v4 (v2 uses Node 16 which is EOL)
  - Add cache: 'pip' to both CI jobs for faster dependency installs
  - Delete unused docker-image.yml workflow