### PR TITLE
Add AuthPrincipal model and fix double JWT decode per request

### DIFF
--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -1,3 +1,4 @@
 from .auth_bearer import JWTBearer  # noqa: F401
 from .auth_handler import sign_jwt, decode_jwt, token_response  # noqa: F401
+from .auth_principal import AuthPrincipal  # noqa: F401
 from .permissions import Permissions  # noqa: F401

--- a/src/auth/auth_bearer.py
+++ b/src/auth/auth_bearer.py
@@ -3,6 +3,7 @@ from fastapi.security import HTTPBearer
 import logging
 
 from .auth_handler import decode_jwt  # type: ignore
+from .auth_principal import AuthPrincipal
 
 logger = logging.getLogger("fantasy-lol")
 
@@ -12,7 +13,7 @@ class JWTBearer(HTTPBearer):
         super(JWTBearer, self).__init__(auto_error=auto_error)
         self.required_permissions = required_permissions or []
 
-    async def __call__(self, request: Request):
+    async def __call__(self, request: Request) -> AuthPrincipal:  # type: ignore[override]
         credentials = await super(JWTBearer, self).__call__(request)
 
         if credentials:
@@ -26,7 +27,10 @@ class JWTBearer(HTTPBearer):
             if not self.has_permissions(payload):
                 raise HTTPException(status_code=403, detail="Insufficient permissions.")
 
-            return payload
+            return AuthPrincipal(
+                user_id=payload.get("user_id", ""),
+                permissions=payload.get("permissions", []),
+            )
         else:
             raise HTTPException(status_code=403, detail="Invalid authorization code.")
 

--- a/src/auth/auth_principal.py
+++ b/src/auth/auth_principal.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+from src.common.schemas.fantasy_schemas import UserID
+
+
+class AuthPrincipal(BaseModel):
+    user_id: UserID
+    permissions: list[str]

--- a/src/fantasy/endpoints/fantasy_league_endpoint_v1.py
+++ b/src/fantasy/endpoints/fantasy_league_endpoint_v1.py
@@ -2,6 +2,7 @@ from classy_fastapi import Routable, get, post, put
 from fastapi import Body, Depends
 
 from src.auth import JWTBearer, Permissions
+from src.auth.auth_principal import AuthPrincipal
 from src.common.schemas.fantasy_schemas import (
     FantasyLeague,
     FantasyLeagueID,
@@ -23,44 +24,45 @@ class FantasyLeagueEndpoint(Routable):
         path="/leagues",
         description="Get a list of Fantasy Leagues the calling user belongs to",
         tags=["Fantasy Leagues"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_READ]))],
         response_model=UsersFantasyLeagues,
     )
     def get_my_fantasy_leagues(
-        self, decoded_token: dict = Depends(JWTBearer())
+        self,
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_READ])),
     ) -> UsersFantasyLeagues:
-        user_id = UserID(decoded_token.get("user_id"))  # type: ignore
-        return self.__fantasy_league_service.get_users_pending_and_accepted_fantasy_leagues(user_id)
+        return self.__fantasy_league_service.get_users_pending_and_accepted_fantasy_leagues(
+            principal.user_id
+        )
 
     @post(
         path="/leagues",
         description="Create a Fantasy League",
         tags=["Fantasy Leagues"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
         response_model=FantasyLeague,
     )
     def create_fantasy_league(
         self,
-        decoded_token: dict = Depends(JWTBearer()),
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_WRITE])),
         fantasy_league: FantasyLeagueSettings = Body(...),
     ) -> FantasyLeague:
-        owner_id = UserID(decoded_token.get("user_id"))  # type: ignore
-        return self.__fantasy_league_service.create_fantasy_league(owner_id, fantasy_league)
+        return self.__fantasy_league_service.create_fantasy_league(
+            principal.user_id, fantasy_league
+        )
 
     @get(
         path="/leagues/{fantasy_league_id}/settings",
         description="Get the settings for a given Fantasy League. "
         "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_READ]))],
         response_model=FantasyLeagueSettings,
     )
     def get_fantasy_league_settings(
-        self, fantasy_league_id: FantasyLeagueID, decoded_token: dict = Depends(JWTBearer())
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_READ])),
     ) -> FantasyLeagueSettings:
-        owner_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_league_service.get_fantasy_league_settings(
-            owner_id, fantasy_league_id
+            principal.user_id, fantasy_league_id
         )
 
     @put(
@@ -68,18 +70,16 @@ class FantasyLeagueEndpoint(Routable):
         description="Update the settings for a given Fantasy League. "
         "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
         response_model=FantasyLeagueSettings,
     )
     def update_fantasy_league_settings(
         self,
         fantasy_league_id: FantasyLeagueID,
         fantasy_league_settings: FantasyLeagueSettings = Body(...),
-        decoded_token: dict = Depends(JWTBearer()),
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_WRITE])),
     ) -> FantasyLeagueSettings:
-        owner_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_league_service.update_fantasy_league_settings(
-            owner_id, fantasy_league_id, fantasy_league_settings
+            principal.user_id, fantasy_league_id, fantasy_league_settings
         )
 
     @get(
@@ -87,32 +87,32 @@ class FantasyLeagueEndpoint(Routable):
         description="Get the scoring settings for a given Fantasy League. "
         "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_READ]))],
         response_model=FantasyLeagueScoringSettings,
     )
     def get_fantasy_league_scoring_settings(
-        self, fantasy_league_id: FantasyLeagueID, decoded_token: dict = Depends(JWTBearer())
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_READ])),
     ) -> FantasyLeagueScoringSettings:
-        owner_id = UserID(decoded_token.get("user_id"))  # type: ignore
-        return self.__fantasy_league_service.get_scoring_settings(owner_id, fantasy_league_id)
+        return self.__fantasy_league_service.get_scoring_settings(
+            principal.user_id, fantasy_league_id
+        )
 
     @put(
         path="/leagues/{fantasy_league_id}/scoring",
         description="Update the scoring settings for a given Fantasy League. "
         "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
         response_model=FantasyLeagueScoringSettings,
     )
     def update_fantasy_league_scoring_settings(
         self,
         fantasy_league_id: FantasyLeagueID,
         scoring_settings: FantasyLeagueScoringSettings = Body(...),
-        decoded_token: dict = Depends(JWTBearer()),
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_WRITE])),
     ) -> FantasyLeagueScoringSettings:
-        user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_league_service.update_scoring_settings(
-            fantasy_league_id, user_id, scoring_settings
+            fantasy_league_id, principal.user_id, scoring_settings
         )
 
     @post(
@@ -120,42 +120,40 @@ class FantasyLeagueEndpoint(Routable):
         description="Invite a user to the given Fantasy League. "
         "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
     )
     def send_invite_user_to_fantasy_league(
         self,
         fantasy_league_id: FantasyLeagueID,
         username: str,
-        decoded_token: dict = Depends(JWTBearer()),
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_WRITE])),
     ) -> None:
-        owner_id = UserID(decoded_token.get("user_id"))  # type: ignore
         self.__fantasy_league_service.send_fantasy_league_invite(
-            owner_id, fantasy_league_id, username
+            principal.user_id, fantasy_league_id, username
         )
 
     @post(
         path="/leagues/{fantasy_league_id}/join",
         description="Join a Fantasy League the calling user has a pending invitation for",
         tags=["Fantasy Leagues"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
     )
     def join_fantasy_league(
-        self, fantasy_league_id: FantasyLeagueID, decoded_token: dict = Depends(JWTBearer())
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_WRITE])),
     ) -> None:
-        user_id = UserID(decoded_token.get("user_id"))  # type: ignore
-        self.__fantasy_league_service.join_fantasy_league(user_id, fantasy_league_id)
+        self.__fantasy_league_service.join_fantasy_league(principal.user_id, fantasy_league_id)
 
     @post(
         path="/leagues/{fantasy_league_id}/leave",
         description="Leave the given Fantasy League.",
         tags=["Fantasy Leagues"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
     )
     def leave_fantasy_league(
-        self, fantasy_league_id: FantasyLeagueID, decoded_token: dict = Depends(JWTBearer())
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_WRITE])),
     ) -> None:
-        user_id = UserID(decoded_token.get("user_id"))  # type: ignore
-        self.__fantasy_league_service.leave_fantasy_league(user_id, fantasy_league_id)
+        self.__fantasy_league_service.leave_fantasy_league(principal.user_id, fantasy_league_id)
 
     @post(
         path="/leagues/{fantasy_league_id}/revoke/{user_id_to_revoke}",
@@ -163,17 +161,15 @@ class FantasyLeagueEndpoint(Routable):
         "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
         status_code=204,
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
     )
     def revoke_from_fantasy_league(
         self,
         fantasy_league_id: FantasyLeagueID,
         user_id_to_revoke: UserID,
-        decoded_token: dict = Depends(JWTBearer()),
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_WRITE])),
     ) -> None:
-        user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         self.__fantasy_league_service.revoke_from_fantasy_league(
-            fantasy_league_id, user_id, user_id_to_revoke
+            fantasy_league_id, principal.user_id, user_id_to_revoke
         )
 
     @get(
@@ -182,14 +178,14 @@ class FantasyLeagueEndpoint(Routable):
         "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
         response_model=list[FantasyLeagueDraftOrderResponse],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_READ]))],
     )
     def get_fantasy_league_draft_order(
-        self, fantasy_league_id: FantasyLeagueID, decoded_token: dict = Depends(JWTBearer())
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_READ])),
     ) -> list[FantasyLeagueDraftOrderResponse]:
-        user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_league_service.get_fantasy_league_draft_order(
-            user_id, fantasy_league_id
+            principal.user_id, fantasy_league_id
         )
 
     @put(
@@ -197,15 +193,13 @@ class FantasyLeagueEndpoint(Routable):
         description="Update draft order of the Fantasy League. "
         "The caller must be the owner of the Fantasy League.",
         tags=["Fantasy Leagues"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
     )
     def update_fantasy_league_draft_order(
         self,
         fantasy_league_id: FantasyLeagueID,
-        decoded_token: dict = Depends(JWTBearer()),
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_WRITE])),
         updated_draft_order: list[FantasyLeagueDraftOrderResponse] = Body(...),
     ) -> None:
-        user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         self.__fantasy_league_service.update_fantasy_league_draft_order(
-            user_id, fantasy_league_id, updated_draft_order
+            principal.user_id, fantasy_league_id, updated_draft_order
         )

--- a/src/fantasy/endpoints/fantasy_team_endpoint_v1.py
+++ b/src/fantasy/endpoints/fantasy_team_endpoint_v1.py
@@ -2,7 +2,8 @@ from classy_fastapi import Routable, get, put
 from fastapi import Depends
 
 from src.auth import JWTBearer, Permissions
-from src.common.schemas.fantasy_schemas import FantasyTeam, FantasyLeagueID, UserID
+from src.auth.auth_principal import AuthPrincipal
+from src.common.schemas.fantasy_schemas import FantasyTeam, FantasyLeagueID
 from src.common.schemas.riot_data_schemas import ProPlayerID
 from src.fantasy.service import FantasyTeamService
 
@@ -16,52 +17,53 @@ class FantasyTeamEndpoint(Routable):
         path="/teams/{fantasy_league_id}",
         description="Get all of the callers teams by week for a Fantasy League.",
         tags=["Fantasy Teams"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_READ]))],
         response_model=list[FantasyTeam],
     )
     def get_fantasy_team_weeks_for_league(
-        self, fantasy_league_id: FantasyLeagueID, decoded_token: dict = Depends(JWTBearer())
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_READ])),
     ) -> list[FantasyTeam]:
-        user_id = UserID(decoded_token.get("user_id"))  # type: ignore
-        return self.__fantasy_team_service.get_all_fantasy_team_weeks(fantasy_league_id, user_id)
+        return self.__fantasy_team_service.get_all_fantasy_team_weeks(
+            fantasy_league_id, principal.user_id
+        )
 
     @put(
         path="/teams/{fantasy_league_id}/pickup/{player_id}",
         description="Pickup a player for the current week within a Fantasy League.",
         tags=["Fantasy Teams"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
         response_model=FantasyTeam,
     )
     def pickup_player(
         self,
         fantasy_league_id: FantasyLeagueID,
         player_id: ProPlayerID,
-        decoded_token: dict = Depends(JWTBearer()),
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_WRITE])),
     ) -> FantasyTeam:
-        user_id = UserID(decoded_token.get("user_id"))  # type: ignore
-        return self.__fantasy_team_service.pickup_player(fantasy_league_id, user_id, player_id)
+        return self.__fantasy_team_service.pickup_player(
+            fantasy_league_id, principal.user_id, player_id
+        )
 
     @put(
         path="/teams/{fantasy_league_id}/drop/{player_id}",
         description="Drop a player for the current week within a Fantasy League.",
         tags=["Fantasy Teams"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
         response_model=FantasyTeam,
     )
     def drop_player(
         self,
         fantasy_league_id: FantasyLeagueID,
         player_id: ProPlayerID,
-        decoded_token: dict = Depends(JWTBearer()),
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_WRITE])),
     ) -> FantasyTeam:
-        user_id = UserID(decoded_token.get("user_id"))  # type: ignore
-        return self.__fantasy_team_service.drop_player(fantasy_league_id, user_id, player_id)
+        return self.__fantasy_team_service.drop_player(
+            fantasy_league_id, principal.user_id, player_id
+        )
 
     @put(
         path="/teams/{fantasy_league_id}/swap/{player_to_drop_id}/{player_to_pickup_id}",
         description="Swap a player for another player in the current week within a Fantasy League.",
         tags=["Fantasy Teams"],
-        dependencies=[Depends(JWTBearer([Permissions.FANTASY_WRITE]))],
         response_model=FantasyTeam,
     )
     def swap_players(
@@ -69,9 +71,11 @@ class FantasyTeamEndpoint(Routable):
         fantasy_league_id: FantasyLeagueID,
         player_to_drop_id: ProPlayerID,
         player_to_pickup_id: ProPlayerID,
-        decoded_token: dict = Depends(JWTBearer()),
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_WRITE])),
     ) -> FantasyTeam:
-        user_id = UserID(decoded_token.get("user_id"))  # type: ignore
         return self.__fantasy_team_service.swap_players(
-            fantasy_league_id, user_id, player_to_drop_id, player_to_pickup_id
+            fantasy_league_id,
+            principal.user_id,
+            player_to_drop_id,
+            player_to_pickup_id,
         )

--- a/src/fantasy/endpoints/user_endpoint_v1.py
+++ b/src/fantasy/endpoints/user_endpoint_v1.py
@@ -2,7 +2,8 @@ from classy_fastapi import Routable, get, post, put
 from fastapi import Body, Depends
 
 from src.auth import JWTBearer
-from src.common.schemas.fantasy_schemas import UserCreate, UserLogin, UserID, EmailRequest
+from src.auth.auth_principal import AuthPrincipal
+from src.common.schemas.fantasy_schemas import UserCreate, UserLogin, EmailRequest
 from src.fantasy.service import UserService
 
 
@@ -34,12 +35,13 @@ class UserEndpointV1(Routable):
         path="/user/delete",
         description="Delete a Fantasy League of Legends account.",
         tags=["Users"],
-        dependencies=[Depends(JWTBearer())],
         status_code=204,
     )
-    def user_delete(self, decoded_token: dict = Depends(JWTBearer())):
-        user_id = UserID(decoded_token.get("user_id"))  # type: ignore
-        self.__user_service.delete_user(user_id)
+    def user_delete(
+        self,
+        principal: AuthPrincipal = Depends(JWTBearer()),
+    ):
+        self.__user_service.delete_user(principal.user_id)
 
     @get(
         path="/user/verify-email/{token}",


### PR DESCRIPTION
   - Create AuthPrincipal with typed user_id and permissions fields, replacing raw dict payload from JWTBearer
   - Update JWTBearer.__call__ to return AuthPrincipal
   - Replace double Depends(JWTBearer) pattern in all fantasy endpoints with a single Depends that checks permissions and returns the principal in one decode
   - Remove all # type: ignore casts on decoded_token.get("user_id")

   Closes #310