### PR TITLE
Add .dockerignore and stop baking secrets into Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.idea
+.venv
+.env
+__pycache__
+*.pyc
+tests
+scripts
+docker-files
+*.md
+.flake8
+.gitignore
+.gitattributes
+LICENSE

--- a/docker-files/Dockerfile-fantasy
+++ b/docker-files/Dockerfile-fantasy
@@ -7,8 +7,6 @@ COPY ../src /app/src
 
 RUN pip install --no-cache-dir .
 
-COPY ../.env /app
-
 EXPOSE 8000
 
 ENV PYTHONPATH="/app/src"

--- a/docker-files/Dockerfile-riot
+++ b/docker-files/Dockerfile-riot
@@ -7,8 +7,6 @@ COPY ../src /app/src
 
 RUN pip install --no-cache-dir .
 
-COPY ../.env /app
-
 EXPOSE 8002
 
 ENV PYTHONPATH="/app/src"

--- a/docker-files/Dockerfile-scraper
+++ b/docker-files/Dockerfile-scraper
@@ -7,8 +7,6 @@ COPY ../src /app/src
 
 RUN pip install --no-cache-dir .
 
-COPY ../.env /app
-
 ENV PYTHONPATH="/app/src"
 
 CMD ["python", "-m", "riot_scraper.app"]

--- a/docker-files/docker-compose.local.yml
+++ b/docker-files/docker-compose.local.yml
@@ -20,9 +20,11 @@ services:
       context: ..
       dockerfile: docker-files/Dockerfile-riot
     ports:
-      - "8000:8000"
+      - "8002:8002"
     volumes:
       - fantasy_logs:/app/logs
+    env_file:
+      - ../.env
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/fantasy_lol
     depends_on:
@@ -34,9 +36,11 @@ services:
       context: ..
       dockerfile: docker-files/Dockerfile-fantasy
     ports:
-      - "8002:8002"
+      - "8000:8000"
     volumes:
       - fantasy_logs:/app/logs
+    env_file:
+      - ../.env
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/fantasy_lol
     depends_on:
@@ -53,6 +57,8 @@ services:
     volumes:
       - fantasy_logs:/app/logs
       - /var/run/docker.sock:/var/run/docker.sock
+    env_file:
+      - ../.env
     environment:
       - MASTER_SCRAPER=true
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/fantasy_lol


### PR DESCRIPTION
   - Add .dockerignore to exclude .git, .venv, .env, __pycache__, tests, scripts, and other non-runtime files from Docker images
   - Remove COPY .env from all 3 Dockerfiles
   - Add env_file: ../.env to docker-compose.local.yml so secrets are injected at runtime, with DATABASE_URL overridden to use the compose-internal db hostname