### PR TITLE
Add first_name/last_name to players, split home_league on teams

### DIFF
--- a/src/common/schemas/riot_data_schemas.py
+++ b/src/common/schemas/riot_data_schemas.py
@@ -205,8 +205,11 @@ class ProfessionalTeam(BaseModel):
         examples=["http://static.lolesports.com/teams/1596305556675_T1T1.png"],
     )
     status: str = Field(default=None, description="The status of the team", examples=["active"])
-    home_league: str | None = Field(
+    home_league_name: str | None = Field(
         default=None, description="The home league name of the team", examples=["LCK"]
+    )
+    home_league_region: str | None = Field(
+        default=None, description="The home league region of the team", examples=["KOREA"]
     )
 
 
@@ -230,6 +233,10 @@ class ProfessionalPlayer(BaseModel):
     summoner_name: str = Field(
         default=None, description="The summoner name of the player", examples=["Faker"]
     )
+    first_name: str = Field(
+        default="", description="The first name of the player", examples=["Sang-hyeok"]
+    )
+    last_name: str = Field(default="", description="The last name of the player", examples=["Lee"])
     image: str = Field(
         default=None,
         description="The url for the players image",

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -92,7 +92,8 @@ class ProfessionalTeamModel(Base):  # type: ignore
     alternative_image = Column(String, nullable=True)
     background_image = Column(String, nullable=True)
     status = Column(String)
-    home_league = Column(String, nullable=True)
+    home_league_name = Column(String, nullable=True)
+    home_league_region = Column(String, nullable=True)
 
 
 class ProfessionalPlayerModel(Base):  # type: ignore
@@ -103,6 +104,8 @@ class ProfessionalPlayerModel(Base):  # type: ignore
         String, ForeignKey("professional_teams.id", ondelete="CASCADE"), primary_key=True
     )
     summoner_name = Column(String)
+    first_name = Column(String, default="")
+    last_name = Column(String, default="")
     image = Column(String)
     role = Column(Enum(PlayerRole), nullable=False)
 

--- a/src/db/riot_dao/riot_league_dao.py
+++ b/src/db/riot_dao/riot_league_dao.py
@@ -55,7 +55,7 @@ def get_league_ids_for_player(session, player_id: ProPlayerID) -> list[RiotLeagu
         SELECT DISTINCT l.id
         FROM professional_players p
         JOIN professional_teams t ON p.team_id = t.id
-        JOIN leagues l ON t.home_league = l.name
+        JOIN leagues l ON t.home_league_name = l.name
         WHERE p.id = '{player_id}'
         """
     result = session.execute(text(sql_query))

--- a/src/riot/service/riot_professional_team_service.py
+++ b/src/riot/service/riot_professional_team_service.py
@@ -26,7 +26,7 @@ class RiotProfessionalTeamService:
         if search_parameters.status is not None:
             filters.append(ProfessionalTeamModel.status == search_parameters.status)
         if search_parameters.league is not None:
-            filters.append(ProfessionalTeamModel.home_league == search_parameters.league)
+            filters.append(ProfessionalTeamModel.home_league_name == search_parameters.league)
 
         professional_teams = self.db.get_teams(filters)
         return professional_teams

--- a/src/riot_scraper/scrapers/team_scraper.py
+++ b/src/riot_scraper/scrapers/team_scraper.py
@@ -39,7 +39,8 @@ class RiotTeamScraper:
                 alternative_image=team.alternativeImage,
                 background_image=team.backgroundImage,
                 status=team.status,
-                home_league=team.homeLeague.name if team.homeLeague else None,
+                home_league_name=team.homeLeague.name if team.homeLeague else None,
+                home_league_region=team.homeLeague.region if team.homeLeague else None,
             )
             self.db.put_team(new_team)
 
@@ -47,6 +48,8 @@ class RiotTeamScraper:
                 new_player = ProfessionalPlayer(
                     id=player.id,
                     summoner_name=player.summonerName,
+                    first_name=player.firstName,
+                    last_name=player.lastName,
                     image=player.image,
                     role=player.role,
                     team_id=team.id,

--- a/tests/db/riot/test_riot_team.py
+++ b/tests/db/riot/test_riot_team.py
@@ -194,7 +194,7 @@ class TestCrudRiotTeam(TestBase):
         # Arrange
         filters = []
         expected_team = riot_fixtures.team_1_fixture
-        filters.append(ProfessionalTeamModel.home_league == expected_team.home_league)
+        filters.append(ProfessionalTeamModel.home_league_name == expected_team.home_league_name)
         self.db.put_team(expected_team)
 
         # Act
@@ -211,7 +211,7 @@ class TestCrudRiotTeam(TestBase):
         # Arrange
         filters = []
         team_1 = riot_fixtures.team_1_fixture
-        filters.append(ProfessionalTeamModel.home_league == team_1.home_league)
+        filters.append(ProfessionalTeamModel.home_league_name == team_1.home_league_name)
 
         # Act
         teams_from_db = self.db.get_teams(filters)

--- a/tests/riot/integration/service/test_professional_team_service.py
+++ b/tests/riot/integration/service/test_professional_team_service.py
@@ -124,7 +124,7 @@ class ProfessionalTeamServiceTest(TestBase):
         # Arrange
         expected_team = riot_fixtures.team_1_fixture
         self.db.put_team(expected_team)
-        search_parameters = TeamSearchParameters(league=expected_team.home_league)
+        search_parameters = TeamSearchParameters(league=expected_team.home_league_name)
 
         # Act
         professional_team_from_db = self.professional_team_service.get_teams(search_parameters)

--- a/tests/riot/unit/riot_endpoints/test_professional_team_endpoint_v1.py
+++ b/tests/riot/unit/riot_endpoints/test_professional_team_endpoint_v1.py
@@ -18,7 +18,7 @@ class TestProfessionalTeamEndpointV1:
             ("name", lambda t: t.name),
             ("code", lambda t: t.code),
             ("status", lambda t: t.status),
-            ("league", lambda t: t.home_league),
+            ("league", lambda t: t.home_league_name),
         ],
         ids=["slug", "name", "code", "status", "league"],
     )

--- a/tests/test_util/riot_fixtures.py
+++ b/tests/test_util/riot_fixtures.py
@@ -84,7 +84,8 @@ team_1_fixture = schemas.ProfessionalTeam(
     alternative_image="http://mock-team-1-alternative-image.png",
     background_image="http://mock-team-1-background.png",
     status="active",
-    home_league=league_1_fixture.name,
+    home_league_name=league_1_fixture.name,
+    home_league_region="MOCKED REGION",
 )
 
 team_2_fixture = schemas.ProfessionalTeam(
@@ -96,7 +97,8 @@ team_2_fixture = schemas.ProfessionalTeam(
     alternative_image="http://mock-team-2-alternative-image.png",
     background_image="http://mock-team-2-background.png",
     status="active",
-    home_league=league_1_fixture.name,
+    home_league_name=league_1_fixture.name,
+    home_league_region="MOCKED REGION",
 )
 
 match_fixture = schemas.Match(
@@ -203,6 +205,8 @@ game_1_fixture_unstarted_future_match = schemas.Game(
 player_1_fixture = schemas.ProfessionalPlayer(
     id=ProPlayerID(generate_random_id()),
     summoner_name="MockerPlayer1",
+    first_name="FirstName1",
+    last_name="LastName1",
     image="http://mocked-player-1.png",
     role=PlayerRole.TOP,
     team_id=team_1_fixture.id,


### PR DESCRIPTION
## Summary

Adds missing fields to players and teams that the Riot API provides but were previously discarded.

### Changes

**Players:**
- Added `first_name` (string, default empty) and `last_name` (string, default empty) to `ProfessionalPlayer` schema and `ProfessionalPlayerModel`
- Updated team scraper to persist `firstName`/`lastName` from the Riot API

**Teams:**
- Replaced `home_league` (string) with `home_league_name` (string) and `home_league_region` (string) on `ProfessionalTeam` schema and `ProfessionalTeamModel`
- Updated team scraper to persist both `homeLeague.name` and `homeLeague.region`
- Updated team service league filter to use `home_league_name`
- Updated `riot_league_dao` SQL join to use `home_league_name`

### Testing
- All 454 tests pass
- Updated fixtures and test assertions for new field names
- Linting clean (ruff, mypy)

Closes #382