### PR TITLE
Update match scraper to write event_teams with team IDs

### DIFF
--- a/src/db/models.py
+++ b/src/db/models.py
@@ -67,12 +67,19 @@ class EventTeamsModel(Base):  # type: ignore
     __tablename__ = "event_teams"
 
     match_id = Column(String, ForeignKey("matches.id", ondelete="CASCADE"), primary_key=True)
-    team_name = Column(String, primary_key=True)
+    team_id = Column(
+        String, ForeignKey("professional_teams.id", ondelete="CASCADE"), primary_key=True
+    )
     side = Column(Integer, nullable=False)
+    team_code = Column(String, nullable=True)
+    team_name = Column(String, nullable=True)
+    team_image = Column(String, nullable=True)
     game_wins = Column(Integer, nullable=True)
     outcome = Column(String, nullable=True)
+    wins = Column(Integer, nullable=True)
+    losses = Column(Integer, nullable=True)
 
-    __table_args__ = (PrimaryKeyConstraint("match_id", "team_name"),)
+    __table_args__ = (PrimaryKeyConstraint("match_id", "team_id"),)
 
 
 class GameModel(Base):  # type: ignore

--- a/src/db/riot_dao/match_dao.py
+++ b/src/db/riot_dao/match_dao.py
@@ -1,12 +1,27 @@
+import logging
+
 from sqlalchemy import text, select, func, or_, cast, Date
 
 from src.common.schemas.riot_data_schemas import Match, RiotMatchID, RiotLeagueID
-from src.db.models import MatchModel, EventTeamsModel, LeagueModel, TournamentModel
+from src.db.models import (
+    MatchModel,
+    EventTeamsModel,
+    LeagueModel,
+    TournamentModel,
+    ProfessionalTeamModel,
+)
 from src.db.views import MatchView
+
+logger = logging.getLogger("riot")
+
+
+def _resolve_team_by_name(session, team_name: str):
+    return (
+        session.query(ProfessionalTeamModel).filter(ProfessionalTeamModel.name == team_name).first()
+    )
 
 
 def put_match(session, match: Match) -> None:
-    # Resolve league_id from league_slug
     league = session.query(LeagueModel).filter(LeagueModel.slug == match.league_slug).first()
     league_id = league.id if league else None
 
@@ -24,7 +39,6 @@ def put_match(session, match: Match) -> None:
     session.merge(db_match)
     session.flush()
 
-    # Determine winning outcome
     winning_team = match.winning_team
     team_1_outcome = (
         "win"
@@ -37,27 +51,27 @@ def put_match(session, match: Match) -> None:
         else ("loss" if winning_team and winning_team != match.team_2_name else None)
     )
 
-    # We don't have team IDs in the Match schema, so store team_name as team_id placeholder
-    # Use team_name as the identifier since that's what the flat schema provides
-    if match.team_1_name:
-        et1 = EventTeamsModel(
+    for side, name, game_wins, outcome in [
+        (1, match.team_1_name, match.team_1_wins, team_1_outcome),
+        (2, match.team_2_name, match.team_2_wins, team_2_outcome),
+    ]:
+        if not name:
+            continue
+        team = _resolve_team_by_name(session, name)
+        if team is None:
+            logger.warning(f"Team '{name}' not found in professional_teams, skipping event_team")
+            continue
+        et = EventTeamsModel(
             match_id=match.id,
-            team_name=match.team_1_name,
-            side=1,
-            game_wins=match.team_1_wins,
-            outcome=team_1_outcome,
+            team_id=team.id,
+            side=side,
+            team_code=team.code,
+            team_name=name,
+            team_image=team.image,
+            game_wins=game_wins,
+            outcome=outcome,
         )
-        session.merge(et1)
-
-    if match.team_2_name:
-        et2 = EventTeamsModel(
-            match_id=match.id,
-            team_name=match.team_2_name,
-            side=2,
-            game_wins=match.team_2_wins,
-            outcome=team_2_outcome,
-        )
-        session.merge(et2)
+        session.merge(et)
 
     session.commit()
 

--- a/src/riot_scraper/scrapers/match_scraper.py
+++ b/src/riot_scraper/scrapers/match_scraper.py
@@ -181,6 +181,8 @@ class RiotMatchScraper:
             get_event_details_response = self.riot_api_requester.get_event_details(match.id)
             assert get_event_details_response is not None
 
+            event_detail = get_event_details_response.data.event
+
             new_match = Match(
                 id=match.id,
                 start_time=event.startTime,
@@ -188,7 +190,7 @@ class RiotMatchScraper:
                 league_slug=event.league.slug,
                 strategy_type=match.strategy.type,
                 strategy_count=match.strategy.count,
-                tournament_id=get_event_details_response.data.event.tournament.id,
+                tournament_id=event_detail.tournament.id,
                 team_1_name=match.teams[0].name,
                 team_2_name=match.teams[1].name,
                 state=event.state,

--- a/tests/db/riot/test_riot_match.py
+++ b/tests/db/riot/test_riot_match.py
@@ -9,6 +9,8 @@ class TestCrudRiotMatch(TestBase):
     def setUp(self):
         self.db.put_league(riot_fixtures.league_1_fixture)
         self.db.put_tournament(riot_fixtures.tournament_fixture)
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        self.db.put_team(riot_fixtures.team_2_fixture)
 
     def test_put_match_no_existing_match(self):
         # Arrange

--- a/tests/riot/integration/service/test_match_service.py
+++ b/tests/riot/integration/service/test_match_service.py
@@ -12,6 +12,8 @@ class MatchServiceTest(TestBase):
         super().setUp()
         self.db.put_league(riot_fixtures.league_1_fixture)
         self.db.put_tournament(riot_fixtures.tournament_fixture)
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        self.db.put_team(riot_fixtures.team_2_fixture)
         self.match_service = RiotMatchService(self.db)
 
     def test_get_matches_by_league_slug_existing_match(self):


### PR DESCRIPTION
## Summary

Updates the match write path to resolve team names to actual `professional_teams` IDs and write richer `event_teams` rows.

### Changes

**EventTeamsModel:**
- PK changed from `(match_id, team_name)` to `(match_id, team_id)`
- Added FK: `team_id` → `professional_teams.id` with ON DELETE CASCADE
- Added columns: `team_code`, `team_name`, `team_image`, `wins`, `losses`

**put_match DAO:**
- Resolves team names to `professional_teams` IDs via DB lookup
- Writes `team_code`, `team_name`, `team_image`, `game_wins`, `outcome` to event_teams
- Logs warning and skips event_team row if team not found

**Match scraper:**
- Uses `event_detail` for `tournament_id` (no functional change, cleaner reference)

### Testing
- 455 tests pass
- Match tests updated to insert teams before matches (required by team_id FK)
- Linting clean

Closes #384