### PR TITLE
Normalize games: game_teams table + status fields + game_view

### DIFF
--- a/src/db/database_connection_provider.py
+++ b/src/db/database_connection_provider.py
@@ -5,7 +5,11 @@ from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy.pool import QueuePool
 
 from src.db.models import Base
-from src.db.views import create_player_game_view_query, create_match_view_query
+from src.db.views import (
+    create_player_game_view_query,
+    create_match_view_query,
+    create_game_view_query,
+)
 
 
 class DatabaseConnectionProvider:
@@ -26,6 +30,7 @@ class DatabaseConnectionProvider:
         with self.engine.connect() as connection:
             connection.execute(create_player_game_view_query)
             connection.execute(create_match_view_query)
+            connection.execute(create_game_view_query)
             connection.commit()
 
     @contextmanager

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -88,11 +88,21 @@ class GameModel(Base):  # type: ignore
     id = Column(String, primary_key=True, index=True)
     state = Column(Enum(GameState), nullable=False)
     number = Column(Integer)
-    red_team = Column(String)
-    blue_team = Column(String)
     match_id = Column(String, ForeignKey("matches.id", ondelete="CASCADE"))
-    has_game_data = Column(Boolean, default=True)
-    last_stats_fetch = Column(Boolean, default=False)
+    frames_status = Column(String, nullable=True)
+    details_status = Column(String, nullable=True)
+
+
+class GameTeamsModel(Base):  # type: ignore
+    __tablename__ = "game_teams"
+
+    game_id = Column(String, ForeignKey("games.id", ondelete="CASCADE"), primary_key=True)
+    team_id = Column(
+        String, ForeignKey("professional_teams.id", ondelete="CASCADE"), primary_key=True
+    )
+    side = Column(String, nullable=False)
+
+    __table_args__ = (PrimaryKeyConstraint("game_id", "team_id"),)
 
 
 class ProfessionalTeamModel(Base):  # type: ignore

--- a/src/db/riot_dao/game_dao.py
+++ b/src/db/riot_dao/game_dao.py
@@ -1,31 +1,48 @@
+import logging
+
 from sqlalchemy import text
 
 from src.common.schemas.riot_data_schemas import Game, RiotGameID, GameState
-from src.db.models import GameModel
+from src.db.models import GameModel, GameTeamsModel
+from src.db.views import GameView
+
+logger = logging.getLogger("riot")
 
 
 def put_game(session, game: Game) -> None:
-    db_game = GameModel(**game.model_dump())
+    db_game = GameModel(
+        id=game.id,
+        state=game.state,
+        number=game.number,
+        match_id=game.match_id,
+        details_status="unavailable" if not game.has_game_data else None,
+    )
     session.merge(db_game)
+    session.flush()
+
+    for team_id, side in [(game.red_team, "red"), (game.blue_team, "blue")]:
+        if team_id:
+            gt = GameTeamsModel(game_id=game.id, team_id=team_id, side=side)
+            session.merge(gt)
+
     session.commit()
 
 
 def bulk_save_games(session, games: list[Game]) -> None:
-    db_games = [GameModel(**game.model_dump()) for game in games]
-    session.bulk_save_objects(db_games)
-    session.commit()
+    for game in games:
+        put_game(session, game)
 
 
 def update_has_game_data(session, game_id: RiotGameID, has_game_data: bool) -> None:
-    db_game: GameModel | None = session.query(GameModel).filter(GameModel.id == game_id).first()
+    db_game = session.query(GameModel).filter(GameModel.id == game_id).first()
     if db_game is not None:
-        db_game.has_game_data = has_game_data
+        db_game.details_status = None if has_game_data else "unavailable"
         session.merge(db_game)
         session.commit()
 
 
 def update_game_state(session, game_id: RiotGameID, state: GameState) -> None:
-    db_game: GameModel | None = session.query(GameModel).filter(GameModel.id == game_id).first()
+    db_game = session.query(GameModel).filter(GameModel.id == game_id).first()
     if db_game is not None:
         db_game.state = state
         session.merge(db_game)
@@ -33,29 +50,36 @@ def update_game_state(session, game_id: RiotGameID, state: GameState) -> None:
 
 
 def update_game_last_stats_fetch(session, game_id: RiotGameID, last_fetch: bool) -> None:
-    db_game: GameModel | None = session.query(GameModel).filter(GameModel.id == game_id).first()
+    db_game = session.query(GameModel).filter(GameModel.id == game_id).first()
     if db_game is not None:
-        db_game.last_stats_fetch = last_fetch
+        db_game.details_status = "needs_final_fetch" if last_fetch else None
         session.merge(db_game)
         session.commit()
 
 
 def get_games_with_last_stats_fetch(session, last_stats_fetch: bool) -> list[Game]:
-    game_models = (
-        session.query(GameModel).filter(GameModel.last_stats_fetch == last_stats_fetch).all()
-    )
-    return [Game.model_validate(game_model) for game_model in game_models]
+    if last_stats_fetch:
+        game_models = (
+            session.query(GameView)
+            .filter(GameView.last_stats_fetch == True)  # noqa: E712
+            .all()
+        )
+    else:
+        game_models = (
+            session.query(GameView)
+            .filter(GameView.last_stats_fetch == False)  # noqa: E712
+            .all()
+        )
+    return [Game.model_validate(gm) for gm in game_models]
 
 
 def get_games(session, filters: list | None = None) -> list[Game]:
     if filters:
-        query = session.query(GameModel).filter(*filters)
+        query = session.query(GameView).filter(*filters)
     else:
-        query = session.query(GameModel)
-    game_models: list[GameModel] = query.all()
-    games = [Game.model_validate(game_model) for game_model in game_models]
-
-    return games
+        query = session.query(GameView)
+    game_models = query.all()
+    return [Game.model_validate(gm) for gm in game_models]
 
 
 def get_games_to_check_state(session) -> list[RiotGameID]:
@@ -68,13 +92,11 @@ def get_games_to_check_state(session) -> list[RiotGameID]:
     """
     result = session.execute(text(sql_query))
     rows = result.fetchall()
-    game_ids = [RiotGameID(row[0]) for row in rows]
-    return game_ids
+    return [RiotGameID(row[0]) for row in rows]
 
 
 def get_game_by_id(session, game_id: RiotGameID) -> Game | None:
-    game_model: GameModel | None = session.query(GameModel).filter(GameModel.id == game_id).first()
-    if game_model is None:
+    gm = session.query(GameView).filter(GameView.id == game_id).first()
+    if gm is None:
         return None
-    else:
-        return Game.model_validate(game_model)
+    return Game.model_validate(gm)

--- a/src/db/riot_dao/player_metadata_dao.py
+++ b/src/db/riot_dao/player_metadata_dao.py
@@ -33,7 +33,7 @@ def get_game_ids_without_player_metadata(session) -> list[RiotGameID]:
         FROM games
         LEFT JOIN player_game_metadata ON games.id = player_game_metadata.game_id
         WHERE games.state in ('COMPLETED', 'INPROGRESS')
-            AND (games.has_game_data = True)
+            AND (games.details_status IS NULL OR games.details_status != 'unavailable')
         GROUP BY games.id
         HAVING COUNT(player_game_metadata.game_id) <> 10
         OR COUNT(player_game_metadata.game_id) IS NULL;

--- a/src/db/riot_dao/player_stats_dao.py
+++ b/src/db/riot_dao/player_stats_dao.py
@@ -34,7 +34,7 @@ def get_game_ids_to_fetch_player_stats_for(session) -> list[RiotGameID]:
         WHERE ((games.state = 'COMPLETED'
                 AND (SELECT COUNT(*) FROM player_game_stats WHERE game_id = games.id) < 10)
                 OR games.state = 'INPROGRESS')
-            AND (games.has_game_data = True)
+            AND (games.details_status IS NULL OR games.details_status != 'unavailable')
         GROUP BY games.id
     """
     result = session.execute(text(sql_query))

--- a/src/db/views.py
+++ b/src/db/views.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Boolean, Column, Enum, Integer, String, PrimaryKeyConstraint, text
 from sqlalchemy.ext.declarative import declarative_base
 
-from src.common.schemas.riot_data_schemas import MatchState, PlayerRole
+from src.common.schemas.riot_data_schemas import GameState, MatchState, PlayerRole
 
 Base = declarative_base()
 
@@ -95,4 +95,34 @@ create_match_view_query = text("""
     JOIN leagues l ON m.league_id = l.id
     LEFT JOIN event_teams t1 ON m.id = t1.match_id AND t1.side = 1
     LEFT JOIN event_teams t2 ON m.id = t2.match_id AND t2.side = 2
+""")
+
+
+class GameView(Base):  # type: ignore
+    __tablename__ = "game_view"
+
+    id = Column(String, primary_key=True)
+    state = Column(Enum(GameState), nullable=False)
+    number = Column(Integer)
+    red_team = Column(String)
+    blue_team = Column(String)
+    match_id = Column(String)
+    has_game_data = Column(Boolean)
+    last_stats_fetch = Column(Boolean)
+
+
+create_game_view_query = text("""
+    CREATE OR REPLACE VIEW game_view AS
+    SELECT
+        g.id,
+        g.state,
+        g.number,
+        red.team_id AS red_team,
+        blue.team_id AS blue_team,
+        g.match_id,
+        COALESCE(g.details_status != 'unavailable', TRUE) AS has_game_data,
+        COALESCE(g.details_status = 'needs_final_fetch', FALSE) AS last_stats_fetch
+    FROM games g
+    LEFT JOIN game_teams red ON g.id = red.game_id AND red.side = 'red'
+    LEFT JOIN game_teams blue ON g.id = blue.game_id AND blue.side = 'blue'
 """)

--- a/src/riot/service/riot_game_service.py
+++ b/src/riot/service/riot_game_service.py
@@ -3,7 +3,7 @@ import logging
 from src.common.schemas.search_parameters import GameSearchParameters
 from src.common.schemas.riot_data_schemas import Game, RiotGameID
 from src.db.database_service import DatabaseService
-from src.db.models import GameModel
+from src.db.views import GameView
 from src.riot.exceptions import GameNotFoundException
 
 logger = logging.getLogger("riot")
@@ -16,9 +16,9 @@ class RiotGameService:
     def get_games(self, search_parameters: GameSearchParameters) -> list[Game]:
         filters = []
         if search_parameters.state is not None:
-            filters.append(GameModel.state == search_parameters.state)
+            filters.append(GameView.state == search_parameters.state)
         if search_parameters.match_id is not None:
-            filters.append(GameModel.match_id == search_parameters.match_id)
+            filters.append(GameView.match_id == search_parameters.match_id)
         games = self.db.get_games(filters)
         return games
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,13 +39,19 @@ def db_provider():
     with provider.engine.begin() as conn:
         conn.execute(text("DROP VIEW IF EXISTS player_game_view CASCADE"))
         conn.execute(text("DROP VIEW IF EXISTS match_view CASCADE"))
+        conn.execute(text("DROP VIEW IF EXISTS game_view CASCADE"))
     models.Base.metadata.drop_all(bind=provider.engine)
     models.Base.metadata.create_all(bind=provider.engine)
-    from src.db.views import create_player_game_view_query, create_match_view_query
+    from src.db.views import (
+        create_player_game_view_query,
+        create_match_view_query,
+        create_game_view_query,
+    )
 
     with provider.engine.connect() as conn:
         conn.execute(create_player_game_view_query)
         conn.execute(create_match_view_query)
+        conn.execute(create_game_view_query)
         conn.commit()
     return provider
 

--- a/tests/db/riot/test_riot_game.py
+++ b/tests/db/riot/test_riot_game.py
@@ -1,5 +1,5 @@
 from src.common.schemas.riot_data_schemas import Game, GameState
-from src.db.models import GameModel
+from src.db.views import GameView
 from tests.test_base import TestBase
 from tests.test_util import riot_fixtures
 
@@ -7,6 +7,8 @@ from tests.test_util import riot_fixtures
 class TestCrudRiotGame(TestBase):
     def setUp(self):
         self.db.put_league(riot_fixtures.league_1_fixture)
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        self.db.put_team(riot_fixtures.team_2_fixture)
         self.db.put_tournament(riot_fixtures.tournament_fixture)
         self.db.put_match(riot_fixtures.match_fixture)
         self.db.put_match(riot_fixtures.future_match_fixture)
@@ -91,7 +93,7 @@ class TestCrudRiotGame(TestBase):
         # Arrange
         filters = []
         expected_game = riot_fixtures.game_1_fixture_completed
-        filters.append(GameModel.state == expected_game.state)
+        filters.append(GameView.state == expected_game.state)
         self.db.put_game(expected_game)
         self.db.put_game(riot_fixtures.game_2_fixture_inprogress)
         self.db.put_game(riot_fixtures.game_3_fixture_unstarted)
@@ -110,7 +112,7 @@ class TestCrudRiotGame(TestBase):
         # Arrange
         filters = []
         expected_game = riot_fixtures.game_1_fixture_unstarted_future_match
-        filters.append(GameModel.match_id == expected_game.match_id)
+        filters.append(GameView.match_id == expected_game.match_id)
         self.db.put_game(expected_game)
         self.db.put_game(riot_fixtures.game_3_fixture_unstarted)
 

--- a/tests/db/riot/test_riot_player_metadata.py
+++ b/tests/db/riot/test_riot_player_metadata.py
@@ -14,6 +14,8 @@ from src.common.schemas.riot_data_schemas import (
 class TestCrudRiotPlayerMetadata(TestBase):
     def setUp(self):
         self.db.put_league(riot_fixtures.league_1_fixture)
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        self.db.put_team(riot_fixtures.team_2_fixture)
         self.db.put_tournament(riot_fixtures.tournament_fixture)
         self.db.put_match(riot_fixtures.match_fixture)
 

--- a/tests/db/riot/test_riot_player_stats.py
+++ b/tests/db/riot/test_riot_player_stats.py
@@ -8,6 +8,8 @@ from src.db.views import PlayerGameView
 class TestCrudRiotPlayerStats(TestBase):
     def setUp(self):
         self.db.put_league(riot_fixtures.league_1_fixture)
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        self.db.put_team(riot_fixtures.team_2_fixture)
         self.db.put_tournament(riot_fixtures.tournament_fixture)
         self.db.put_match(riot_fixtures.match_fixture)
 

--- a/tests/riot/integration/service/test_game_service.py
+++ b/tests/riot/integration/service/test_game_service.py
@@ -11,6 +11,8 @@ class GameServiceTest(TestBase):
     def setUp(self):
         super().setUp()
         self.db.put_league(riot_fixtures.league_1_fixture)
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        self.db.put_team(riot_fixtures.team_2_fixture)
         self.db.put_tournament(riot_fixtures.tournament_fixture)
         self.db.put_match(riot_fixtures.match_fixture)
         self.game_service = RiotGameService(self.db)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -43,16 +43,22 @@ class TestBase(unittest.TestCase):
 
         # Drop and recreate all tables so FK constraints are always current.
         from sqlalchemy import text
-        from src.db.views import create_player_game_view_query, create_match_view_query
+        from src.db.views import (
+            create_player_game_view_query,
+            create_match_view_query,
+            create_game_view_query,
+        )
 
         with cls.db_provider.engine.begin() as conn:
             conn.execute(text("DROP VIEW IF EXISTS player_game_view CASCADE"))
             conn.execute(text("DROP VIEW IF EXISTS match_view CASCADE"))
+            conn.execute(text("DROP VIEW IF EXISTS game_view CASCADE"))
         models.Base.metadata.drop_all(bind=cls.db_provider.engine)
         models.Base.metadata.create_all(bind=cls.db_provider.engine)
         with cls.db_provider.engine.connect() as conn:
             conn.execute(create_player_game_view_query)
             conn.execute(create_match_view_query)
+            conn.execute(create_game_view_query)
             conn.commit()
 
         if cls is not TestBase and cls.setUp is not TestBase.setUp:


### PR DESCRIPTION
## Summary

Normalizes the games table by extracting team sides into a `game_teams` junction table and replacing boolean flags with status strings.

### Schema changes

**games table:**
- Removed: `red_team`, `blue_team`, `has_game_data`, `last_stats_fetch`
- Added: `frames_status` (string, nullable), `details_status` (string, nullable)

**New `game_teams` table:**
- PK: `(game_id, team_id)`
- Column: `side` (string: 'red' or 'blue')
- FKs: `game_id` → `games.id`, `team_id` → `professional_teams.id`, both ON DELETE CASCADE

**New `game_view`:**
- Joins `games` + `game_teams` to reconstruct the flat Game schema
- Computes `has_game_data` and `last_stats_fetch` from `details_status`
- API response shape is unchanged

### Status mapping
- `details_status=NULL` → `has_game_data=true, last_stats_fetch=false` (default)
- `details_status='unavailable'` → `has_game_data=false`
- `details_status='needs_final_fetch'` → `last_stats_fetch=true`

### Testing
- 455 tests pass
- Updated player metadata/stats DAO queries for `details_status`
- Tests updated to insert teams before games (required by FK)
- Linting clean

Closes #381