### PR TITLE
Add game_metadata, game_participant_perks, and game_dragons tables

### DIFF
--- a/src/common/schemas/riot_data_schemas.py
+++ b/src/common/schemas/riot_data_schemas.py
@@ -359,6 +359,32 @@ class TeamGameStats(BaseModel):
     total_kills: int
 
 
+class GameMetadata(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    game_id: RiotGameID
+    patch_version: str
+
+
+class GameParticipantPerks(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    game_id: RiotGameID
+    participant_id: int
+    style_id: int
+    sub_style_id: int
+    perks: list[int]
+
+
+class GameDragons(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    game_id: RiotGameID
+    dragon_number: int
+    team_id: ProTeamID
+    dragon_type: str
+
+
 class StoredSchedule(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -31,6 +31,9 @@ from src.common.schemas.riot_data_schemas import (
     PlayerGameStats,
     StoredSchedule,
     TeamGameStats,
+    GameMetadata,
+    GameParticipantPerks,
+    GameDragons,
 )
 from src.db.database_connection_provider import DatabaseConnectionProvider
 from src.db.fantasy_dao import (
@@ -42,6 +45,9 @@ from src.db.fantasy_dao import (
 )
 from src.db.riot_dao import (
     game_dao,
+    game_dragons_dao,
+    game_metadata_dao,
+    game_participant_perks_dao,
     match_dao,
     player_dao,
     player_metadata_dao,
@@ -170,6 +176,34 @@ class DatabaseService:
     def put_team_stats(self, team_stats: TeamGameStats) -> None:
         with self.connection_provider.get_db() as db:
             team_stats_dao.put_team_stats(db, team_stats)
+
+    def put_game_metadata(self, metadata: GameMetadata) -> None:
+        with self.connection_provider.get_db() as db:
+            game_metadata_dao.put_game_metadata(db, metadata)
+
+    def get_game_metadata(self, game_id: RiotGameID) -> GameMetadata | None:
+        with self.connection_provider.get_db() as db:
+            return game_metadata_dao.get_game_metadata(db, game_id)
+
+    def put_game_participant_perks(self, perks: GameParticipantPerks) -> None:
+        with self.connection_provider.get_db() as db:
+            game_participant_perks_dao.put_game_participant_perks(db, perks)
+
+    def get_game_participant_perks(
+        self, game_id: RiotGameID, participant_id: int
+    ) -> GameParticipantPerks | None:
+        with self.connection_provider.get_db() as db:
+            return game_participant_perks_dao.get_game_participant_perks(
+                db, game_id, participant_id
+            )
+
+    def put_game_dragon(self, dragon: GameDragons) -> None:
+        with self.connection_provider.get_db() as db:
+            game_dragons_dao.put_game_dragon(db, dragon)
+
+    def get_game_dragons(self, game_id: RiotGameID) -> list[GameDragons]:
+        with self.connection_provider.get_db() as db:
+            return game_dragons_dao.get_game_dragons(db, game_id)
 
     def put_league(self, league: League) -> None:
         with self.connection_provider.get_db() as db:

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -105,6 +105,38 @@ class GameTeamsModel(Base):  # type: ignore
     __table_args__ = (PrimaryKeyConstraint("game_id", "team_id"),)
 
 
+class GameMetadataModel(Base):  # type: ignore
+    __tablename__ = "game_metadata"
+
+    game_id = Column(String, ForeignKey("games.id", ondelete="CASCADE"), primary_key=True)
+    patch_version = Column(String)
+
+
+class GameParticipantPerksModel(Base):  # type: ignore
+    __tablename__ = "game_participant_perks"
+
+    game_id = Column(String, ForeignKey("games.id", ondelete="CASCADE"), primary_key=True)
+    participant_id = Column(Integer, primary_key=True)
+    style_id = Column(Integer)
+    sub_style_id = Column(Integer)
+    perks = Column(JSON)
+
+    __table_args__ = (PrimaryKeyConstraint("game_id", "participant_id"),)
+
+
+class GameDragonsModel(Base):  # type: ignore
+    __tablename__ = "game_dragons"
+
+    game_id = Column(String, ForeignKey("games.id", ondelete="CASCADE"), primary_key=True)
+    dragon_number = Column(Integer, primary_key=True)
+    team_id = Column(
+        String, ForeignKey("professional_teams.id", ondelete="CASCADE"), nullable=False
+    )
+    dragon_type = Column(String, nullable=False)
+
+    __table_args__ = (PrimaryKeyConstraint("game_id", "dragon_number"),)
+
+
 class ProfessionalTeamModel(Base):  # type: ignore
     __tablename__ = "professional_teams"
 

--- a/src/db/riot_dao/game_dragons_dao.py
+++ b/src/db/riot_dao/game_dragons_dao.py
@@ -1,0 +1,12 @@
+from src.common.schemas.riot_data_schemas import GameDragons, RiotGameID
+from src.db.models import GameDragonsModel
+
+
+def put_game_dragon(session, dragon: GameDragons) -> None:
+    session.merge(GameDragonsModel(**dragon.model_dump()))
+    session.commit()
+
+
+def get_game_dragons(session, game_id: RiotGameID) -> list[GameDragons]:
+    rows = session.query(GameDragonsModel).filter(GameDragonsModel.game_id == game_id).all()
+    return [GameDragons.model_validate(row) for row in rows]

--- a/src/db/riot_dao/game_metadata_dao.py
+++ b/src/db/riot_dao/game_metadata_dao.py
@@ -1,0 +1,14 @@
+from src.common.schemas.riot_data_schemas import GameMetadata, RiotGameID
+from src.db.models import GameMetadataModel
+
+
+def put_game_metadata(session, metadata: GameMetadata) -> None:
+    session.merge(GameMetadataModel(**metadata.model_dump()))
+    session.commit()
+
+
+def get_game_metadata(session, game_id: RiotGameID) -> GameMetadata | None:
+    row = session.query(GameMetadataModel).filter(GameMetadataModel.game_id == game_id).first()
+    if row is None:
+        return None
+    return GameMetadata.model_validate(row)

--- a/src/db/riot_dao/game_participant_perks_dao.py
+++ b/src/db/riot_dao/game_participant_perks_dao.py
@@ -1,0 +1,23 @@
+from src.common.schemas.riot_data_schemas import GameParticipantPerks, RiotGameID
+from src.db.models import GameParticipantPerksModel
+
+
+def put_game_participant_perks(session, perks: GameParticipantPerks) -> None:
+    session.merge(GameParticipantPerksModel(**perks.model_dump()))
+    session.commit()
+
+
+def get_game_participant_perks(
+    session, game_id: RiotGameID, participant_id: int
+) -> GameParticipantPerks | None:
+    row = (
+        session.query(GameParticipantPerksModel)
+        .filter(
+            GameParticipantPerksModel.game_id == game_id,
+            GameParticipantPerksModel.participant_id == participant_id,
+        )
+        .first()
+    )
+    if row is None:
+        return None
+    return GameParticipantPerks.model_validate(row)

--- a/tests/db/riot/test_cascade_deletes.py
+++ b/tests/db/riot/test_cascade_deletes.py
@@ -1,6 +1,11 @@
 from tests.test_base import TestBase
 from tests.test_util import riot_fixtures
-from src.common.schemas.riot_data_schemas import TeamGameStats
+from src.common.schemas.riot_data_schemas import (
+    GameDragons,
+    GameMetadata,
+    GameParticipantPerks,
+    TeamGameStats,
+)
 from src.db.models import LeagueModel, ProfessionalTeamModel, GameModel, MatchModel, EventTeamsModel
 
 
@@ -181,3 +186,54 @@ class TestCascadeDeletes(TestBase):
         with self.db_provider.get_db() as session:
             rows = session.query(EventTeamsModel).filter(EventTeamsModel.match_id == match_id).all()
             self.assertEqual(0, len(rows))
+
+    def test_deleting_game_cascades_to_game_metadata(self):
+        self.db.put_tournament(riot_fixtures.tournament_fixture)
+        self.db.put_match(riot_fixtures.match_fixture)
+        game = riot_fixtures.game_1_fixture_completed
+        self.db.put_game(game)
+        self.db.put_game_metadata(GameMetadata(game_id=game.id, patch_version="14.1"))
+        self.assertIsNotNone(self.db.get_game_metadata(game.id))
+
+        self._delete_game(game.id)
+
+        self.assertIsNone(self.db.get_game_metadata(game.id))
+
+    def test_deleting_game_cascades_to_game_participant_perks(self):
+        self.db.put_tournament(riot_fixtures.tournament_fixture)
+        self.db.put_match(riot_fixtures.match_fixture)
+        game = riot_fixtures.game_1_fixture_completed
+        self.db.put_game(game)
+        self.db.put_game_participant_perks(
+            GameParticipantPerks(
+                game_id=game.id,
+                participant_id=1,
+                style_id=8100,
+                sub_style_id=8300,
+                perks=[8112],
+            )
+        )
+        self.assertIsNotNone(self.db.get_game_participant_perks(game.id, 1))
+
+        self._delete_game(game.id)
+
+        self.assertIsNone(self.db.get_game_participant_perks(game.id, 1))
+
+    def test_deleting_game_cascades_to_game_dragons(self):
+        self.db.put_tournament(riot_fixtures.tournament_fixture)
+        self.db.put_match(riot_fixtures.match_fixture)
+        game = riot_fixtures.game_1_fixture_completed
+        self.db.put_game(game)
+        self.db.put_game_dragon(
+            GameDragons(
+                game_id=game.id,
+                dragon_number=1,
+                team_id=riot_fixtures.team_1_fixture.id,
+                dragon_type="infernal",
+            )
+        )
+        self.assertEqual(1, len(self.db.get_game_dragons(game.id)))
+
+        self._delete_game(game.id)
+
+        self.assertEqual(0, len(self.db.get_game_dragons(game.id)))

--- a/tests/db/riot/test_game_new_tables.py
+++ b/tests/db/riot/test_game_new_tables.py
@@ -1,0 +1,87 @@
+from tests.test_base import TestBase
+from tests.test_util import riot_fixtures
+
+from src.common.schemas.riot_data_schemas import (
+    GameMetadata,
+    GameParticipantPerks,
+    GameDragons,
+    RiotGameID,
+)
+
+
+class TestGameMetadata(TestBase):
+    def setUp(self):
+        self.db.put_league(riot_fixtures.league_1_fixture)
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        self.db.put_team(riot_fixtures.team_2_fixture)
+        self.db.put_tournament(riot_fixtures.tournament_fixture)
+        self.db.put_match(riot_fixtures.match_fixture)
+        self.db.put_game(riot_fixtures.game_1_fixture_completed)
+
+    def test_put_and_get_game_metadata(self):
+        game_id = riot_fixtures.game_1_fixture_completed.id
+        metadata = GameMetadata(game_id=game_id, patch_version="14.1.1")
+
+        self.assertIsNone(self.db.get_game_metadata(game_id))
+        self.db.put_game_metadata(metadata)
+        result = self.db.get_game_metadata(game_id)
+        self.assertEqual(metadata, result)
+
+    def test_get_game_metadata_not_found(self):
+        self.assertIsNone(self.db.get_game_metadata(RiotGameID("nonexistent")))
+
+
+class TestGameParticipantPerks(TestBase):
+    def setUp(self):
+        self.db.put_league(riot_fixtures.league_1_fixture)
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        self.db.put_team(riot_fixtures.team_2_fixture)
+        self.db.put_tournament(riot_fixtures.tournament_fixture)
+        self.db.put_match(riot_fixtures.match_fixture)
+        self.db.put_game(riot_fixtures.game_1_fixture_completed)
+
+    def test_put_and_get_game_participant_perks(self):
+        game_id = riot_fixtures.game_1_fixture_completed.id
+        perks = GameParticipantPerks(
+            game_id=game_id,
+            participant_id=1,
+            style_id=8100,
+            sub_style_id=8300,
+            perks=[8112, 8126, 8138, 8135, 8304, 8345],
+        )
+
+        self.assertIsNone(self.db.get_game_participant_perks(game_id, 1))
+        self.db.put_game_participant_perks(perks)
+        result = self.db.get_game_participant_perks(game_id, 1)
+        self.assertEqual(perks, result)
+
+    def test_get_game_participant_perks_not_found(self):
+        game_id = riot_fixtures.game_1_fixture_completed.id
+        self.assertIsNone(self.db.get_game_participant_perks(game_id, 99))
+
+
+class TestGameDragons(TestBase):
+    def setUp(self):
+        self.db.put_league(riot_fixtures.league_1_fixture)
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        self.db.put_team(riot_fixtures.team_2_fixture)
+        self.db.put_tournament(riot_fixtures.tournament_fixture)
+        self.db.put_match(riot_fixtures.match_fixture)
+        self.db.put_game(riot_fixtures.game_1_fixture_completed)
+
+    def test_put_and_get_game_dragons(self):
+        game_id = riot_fixtures.game_1_fixture_completed.id
+        team_id = riot_fixtures.team_1_fixture.id
+        dragon = GameDragons(
+            game_id=game_id, dragon_number=1, team_id=team_id, dragon_type="infernal"
+        )
+
+        self.assertEqual([], self.db.get_game_dragons(game_id))
+        self.db.put_game_dragon(dragon)
+        result = self.db.get_game_dragons(game_id)
+        self.assertEqual(1, len(result))
+        self.assertEqual(dragon, result[0])
+
+    def test_get_game_dragons_empty(self):
+        game_id = riot_fixtures.game_1_fixture_completed.id
+        self.assertEqual([], self.db.get_game_dragons(game_id))


### PR DESCRIPTION
## Summary

Adds three new tables to capture Riot API data that was previously fetched but discarded.

### New tables

**`game_metadata`**: `game_id` PK (FK → games, cascade delete)
- `patch_version` (string)

**`game_participant_perks`**: `(game_id, participant_id)` PK (FK → games, cascade delete)
- `style_id` (int), `sub_style_id` (int), `perks` (JSON integer array)

**`game_dragons`**: `(game_id, dragon_number)` PK (FK → games, cascade delete)
- `team_id` (FK → professional_teams, cascade delete), `dragon_type` (string)

### Implementation
- SQLAlchemy models, Pydantic schemas, DAOs with put/get operations
- DatabaseService methods for all three tables
- 6 CRUD tests + 3 cascade delete tests

### Testing
- 464 tests pass (455 existing + 9 new)
- Linting clean

Closes #383