### PR TITLE
Add structured logging with Loki support and request tracing

### DIFF
--- a/example.env
+++ b/example.env
@@ -11,6 +11,10 @@ CORS_ORIGINS=["*"]
 AUTH_SECRET="change-me-to-a-secure-random-string"
 AUTH_ALGORITHM="HS256"
 
+# Logging (Loki/Grafana — optional, disabled by default)
+LOKI_ENABLED=False
+LOKI_URL="http://localhost:3100/loki/api/v1/push"
+
 # Email Verification
 REQUIRE_EMAIL_VERIFICATION=True
 VERIFICATION_DOMAIN_URL="http://localhost"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "classy_fastapi==0.6.1",
     "docker==7.1.0",
     "alembic==1.13.1",
+    "python-logging-loki==0.3.1",
 ]
 
 [project.optional-dependencies]

--- a/src/app.py
+++ b/src/app.py
@@ -7,6 +7,7 @@ from fastapi_pagination.utils import disable_installed_extensions_check
 
 from src.common.config import app_config
 from src.common.logger import configure_logger
+from src.common.middleware import RequestLoggingMiddleware
 from src.db.database_connection_provider import DatabaseConnectionProvider
 from src.db.database_service import DatabaseService
 from src.fantasy.endpoints import FantasyLeagueEndpoint, FantasyTeamEndpoint, UserEndpointV1
@@ -44,6 +45,7 @@ def create_app(database_service: DatabaseService) -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    app.add_middleware(RequestLoggingMiddleware)
     disable_installed_extensions_check()
 
     # Riot services and endpoints

--- a/src/auth/auth_bearer.py
+++ b/src/auth/auth_bearer.py
@@ -5,7 +5,7 @@ import logging
 from .auth_handler import decode_jwt  # type: ignore
 from .auth_principal import AuthPrincipal
 
-logger = logging.getLogger("fantasy-lol")
+logger = logging.getLogger("api.auth")
 
 
 class JWTBearer(HTTPBearer):

--- a/src/auth/auth_handler.py
+++ b/src/auth/auth_handler.py
@@ -4,7 +4,7 @@ import logging
 
 from src.common import app_config
 
-logger = logging.getLogger("fantasy-lol")
+logger = logging.getLogger("api.auth")
 
 JWT_SECRET = app_config.AUTH_SECRET
 JWT_ALGORITHM = app_config.AUTH_ALGORITHM

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -38,6 +38,10 @@ class AppConfig(BaseSettings):
     # Email verification
     REQUIRE_EMAIL_VERIFICATION: bool = True
 
+    # Logging
+    LOKI_ENABLED: bool = False
+    LOKI_URL: str = "http://localhost:3100/loki/api/v1/push"
+
     # Riot API
     RIOT_API_KEY: str = "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"
     ESPORTS_API_URL: str = "https://esports-api.lolesports.com/persisted/gw"

--- a/src/common/logger.py
+++ b/src/common/logger.py
@@ -1,37 +1,74 @@
 import logging
+from contextvars import ContextVar
 from pathlib import Path
 from logging.handlers import RotatingFileHandler
 
 from .config import app_config
 
+request_id_var: ContextVar[str] = ContextVar("request_id", default="")
 
-def configure_logger(logger_name: str):
+
+class RequestIdFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        rid = request_id_var.get()
+        record.request_id = f"[req:{rid}] " if rid else ""  # type: ignore[attr-defined]
+        return True
+
+
+def configure_logger(service: str) -> None:
     max_file_size = 1024 * 1024 * 100  # 100 MB
-    backup_count = 5  # keep up to 5 files
+    backup_count = 5
     Path("./logs/").mkdir(parents=True, exist_ok=True)
-    if app_config.DEBUG_LOGGING:
-        logging_level = logging.DEBUG
-    else:
-        logging_level = logging.INFO
 
-    fantasy_lol_logger = logging.getLogger(logger_name)
-    fantasy_lol_logger.setLevel(logging_level)
-    formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
+    logging_level = logging.DEBUG if app_config.DEBUG_LOGGING else logging.INFO
+
+    root_logger = logging.getLogger(service)
+    root_logger.setLevel(logging_level)
+
+    # Avoid duplicate handlers on re-init
+    if root_logger.handlers:
+        return
+
+    rid_filter = RequestIdFilter()
+
+    # Console handler
+    console_fmt = logging.Formatter(
+        "[%(levelname)s] %(asctime)s [%(name)s] %(request_id)s%(message)s"
+    )
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging_level)
+    console_handler.setFormatter(console_fmt)
+    console_handler.addFilter(rid_filter)
+    root_logger.addHandler(console_handler)
 
     # File handler
+    file_fmt = logging.Formatter("[%(levelname)s] %(asctime)s [%(name)s] %(request_id)s%(message)s")
     file_handler = RotatingFileHandler(
-        filename=f"./logs/{logger_name}.log",
+        filename=f"./logs/{service}.log",
         mode="a+",
         maxBytes=max_file_size,
         backupCount=backup_count,
         encoding="utf-8",
     )
     file_handler.setLevel(logging_level)
-    file_handler.setFormatter(formatter)
-    fantasy_lol_logger.addHandler(file_handler)
+    file_handler.setFormatter(file_fmt)
+    file_handler.addFilter(rid_filter)
+    root_logger.addHandler(file_handler)
 
-    # Console handler
-    console_handler = logging.StreamHandler()
-    console_handler.setLevel(logging_level)
-    console_handler.setFormatter(formatter)
-    fantasy_lol_logger.addHandler(console_handler)
+    # Loki handler
+    if app_config.LOKI_ENABLED:
+        try:
+            import logging_loki  # type: ignore[import-untyped,import-not-found]
+
+            loki_handler = logging_loki.LokiHandler(
+                url=app_config.LOKI_URL,
+                tags={"app": "mythicforge", "service": service},
+                version="1",
+            )
+            loki_fmt = logging.Formatter("[%(levelname)s] %(request_id)s%(message)s")
+            loki_handler.setFormatter(loki_fmt)
+            loki_handler.addFilter(rid_filter)
+            loki_handler.setLevel(logging_level)
+            root_logger.addHandler(loki_handler)
+        except ImportError:
+            root_logger.warning("python-logging-loki not installed, Loki logging disabled")

--- a/src/common/middleware.py
+++ b/src/common/middleware.py
@@ -1,0 +1,41 @@
+import logging
+import time
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from src.common.logger import request_id_var
+
+logger = logging.getLogger("api")
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[no-untyped-def]
+        rid = str(uuid.uuid4())
+        token = request_id_var.set(rid)
+        start = time.perf_counter()
+        try:
+            response = await call_next(request)
+            duration_ms = (time.perf_counter() - start) * 1000
+            logger.info(
+                "%s %s %s %.0fms",
+                request.method,
+                request.url.path,
+                response.status_code,
+                duration_ms,
+            )
+            return response
+        except Exception as e:
+            duration_ms = (time.perf_counter() - start) * 1000
+            logger.error(
+                "%s %s 500 %.0fms - %s",
+                request.method,
+                request.url.path,
+                duration_ms,
+                str(e),
+            )
+            raise
+        finally:
+            request_id_var.reset(token)

--- a/src/db/riot_dao/game_dao.py
+++ b/src/db/riot_dao/game_dao.py
@@ -6,7 +6,7 @@ from src.common.schemas.riot_data_schemas import Game, RiotGameID, GameState
 from src.db.models import GameModel, GameTeamsModel
 from src.db.views import GameView
 
-logger = logging.getLogger("riot")
+logger = logging.getLogger("api.db")
 
 
 def put_game(session, game: Game) -> None:

--- a/src/db/riot_dao/match_dao.py
+++ b/src/db/riot_dao/match_dao.py
@@ -19,7 +19,7 @@ from src.db.models import (
 )
 from src.db.views import MatchView
 
-logger = logging.getLogger("riot")
+logger = logging.getLogger("api.db")
 
 
 def _resolve_team_by_name(session, team_name: str):

--- a/src/fantasy/service/fantasy_league_service.py
+++ b/src/fantasy/service/fantasy_league_service.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 
 from src.db.database_service import DatabaseService
@@ -25,6 +26,8 @@ from src.fantasy.exceptions import (
 
 from src.fantasy.util import FantasyLeagueUtil
 
+logger = logging.getLogger("api.fantasy")
+
 
 class FantasyLeagueService:
     def __init__(self, database_service: DatabaseService):
@@ -34,6 +37,7 @@ class FantasyLeagueService:
     def create_fantasy_league(
         self, owner_id: UserID, league_settings: FantasyLeagueSettings
     ) -> FantasyLeague:
+        logger.info("Creating fantasy league for owner=%s name=%s", owner_id, league_settings.name)
         if len(league_settings.available_leagues) > 0:
             self.fantasy_league_util.validate_available_leagues(league_settings.available_leagues)
 
@@ -163,6 +167,7 @@ class FantasyLeagueService:
     def send_fantasy_league_invite(
         self, owner_id: UserID, league_id: FantasyLeagueID, username: str
     ) -> None:
+        logger.info("Sending invite to user=%s for league=%s", username, league_id)
         fantasy_league_model = self.fantasy_league_util.validate_league(
             league_id, [FantasyLeagueStatus.PRE_DRAFT]
         )
@@ -182,6 +187,7 @@ class FantasyLeagueService:
         )
 
     def join_fantasy_league(self, user_id: UserID, league_id: FantasyLeagueID) -> None:
+        logger.info("User=%s joining league=%s", user_id, league_id)
         fantasy_league_model = self.fantasy_league_util.validate_league(
             league_id, [FantasyLeagueStatus.PRE_DRAFT]
         )
@@ -315,6 +321,7 @@ class FantasyLeagueService:
             )
 
     def start_fantasy_draft(self, user_id: UserID, fantasy_league_id: FantasyLeagueID) -> None:
+        logger.info("Starting draft for league=%s by user=%s", fantasy_league_id, user_id)
         fantasy_league = self.fantasy_league_util.validate_league(
             fantasy_league_id, [FantasyLeagueStatus.PRE_DRAFT]
         )

--- a/src/fantasy/service/fantasy_team_service.py
+++ b/src/fantasy/service/fantasy_team_service.py
@@ -1,3 +1,5 @@
+import logging
+
 from src.db.database_service import DatabaseService
 from src.common.schemas.riot_data_schemas import ProfessionalPlayer, ProPlayerID
 from src.common.schemas.fantasy_schemas import (
@@ -13,6 +15,8 @@ from src.common.exceptions.professional_player_not_found_exception import (
 )
 from src.fantasy.exceptions import FantasyMembershipException, FantasyDraftException
 from src.fantasy.util import FantasyTeamUtil, FantasyLeagueUtil
+
+logger = logging.getLogger("api.fantasy")
 
 
 class FantasyTeamService:
@@ -38,6 +42,9 @@ class FantasyTeamService:
     def pickup_player(
         self, fantasy_league_id: FantasyLeagueID, user_id: UserID, player_id: ProPlayerID
     ) -> FantasyTeam:
+        logger.info(
+            "Player pickup: user=%s league=%s player=%s", user_id, fantasy_league_id, player_id
+        )
         fantasy_league = self.fantasy_league_util.validate_league(
             fantasy_league_id, [FantasyLeagueStatus.DRAFT, FantasyLeagueStatus.ACTIVE]
         )
@@ -79,6 +86,9 @@ class FantasyTeamService:
     def drop_player(
         self, fantasy_league_id: FantasyLeagueID, user_id: UserID, player_id: ProPlayerID
     ) -> FantasyTeam:
+        logger.info(
+            "Player drop: user=%s league=%s player=%s", user_id, fantasy_league_id, player_id
+        )
         fantasy_league = self.fantasy_league_util.validate_league(
             fantasy_league_id, [FantasyLeagueStatus.ACTIVE]
         )

--- a/src/fantasy/service/fantasy_user_service.py
+++ b/src/fantasy/service/fantasy_user_service.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 import bcrypt
 import secrets
@@ -21,6 +22,8 @@ from .email_verification_service import EmailVerificationService
 
 DEFAULT_PERMISSIONS = [Permissions.FANTASY_READ, Permissions.FANTASY_WRITE, Permissions.RIOT_READ]
 
+logger = logging.getLogger("api.fantasy")
+
 
 class UserService:
     def __init__(
@@ -32,6 +35,7 @@ class UserService:
         self.email_verification_service = email_verification_service
 
     def user_signup(self, user_create: UserCreate) -> str:
+        logger.info("User signup attempt: username=%s", user_create.username)
         self.validate_username_and_email(user_create.username, user_create.email)
 
         if app_config.REQUIRE_EMAIL_VERIFICATION:
@@ -96,6 +100,7 @@ class UserService:
         return bcrypt.hashpw(pw_bytes, salt)
 
     def login_user(self, user_credentials: UserLogin) -> dict:
+        logger.info("Login attempt: username=%s", user_credentials.username)
         user = self.db.get_user_by_username(user_credentials.username)
         if user is None:
             raise InvalidUsernameOrPasswordException()

--- a/src/riot/service/riot_game_service.py
+++ b/src/riot/service/riot_game_service.py
@@ -6,7 +6,7 @@ from src.db.database_service import DatabaseService
 from src.db.views import GameView
 from src.riot.exceptions import GameNotFoundException
 
-logger = logging.getLogger("riot")
+logger = logging.getLogger("api.riot")
 
 
 class RiotGameService:

--- a/src/riot/service/riot_game_stats_service.py
+++ b/src/riot/service/riot_game_stats_service.py
@@ -6,7 +6,7 @@ from src.common.schemas.riot_data_schemas import PlayerGameData
 from src.db.database_service import DatabaseService
 from src.db.views import PlayerGameView
 
-logger = logging.getLogger("riot")
+logger = logging.getLogger("api.riot")
 
 
 class RiotGameStatsService:

--- a/src/riot/service/riot_league_service.py
+++ b/src/riot/service/riot_league_service.py
@@ -6,7 +6,7 @@ from src.common.schemas.search_parameters import LeagueSearchParameters
 from src.db.database_service import DatabaseService
 from src.db.models import LeagueModel
 
-logger = logging.getLogger("riot")
+logger = logging.getLogger("api.riot")
 
 
 class RiotLeagueService:

--- a/src/riot/service/riot_match_service.py
+++ b/src/riot/service/riot_match_service.py
@@ -6,7 +6,7 @@ from src.db.database_service import DatabaseService
 from src.db.views import MatchView
 from src.riot.exceptions import MatchNotFoundException
 
-logger = logging.getLogger("riot")
+logger = logging.getLogger("api.riot")
 
 
 class RiotMatchService:

--- a/src/riot/service/riot_professional_player_service.py
+++ b/src/riot/service/riot_professional_player_service.py
@@ -6,7 +6,7 @@ from src.db.database_service import DatabaseService
 from src.db.models import ProfessionalPlayerModel
 from src.common.exceptions import ProfessionalPlayerNotFoundException
 
-logger = logging.getLogger("riot")
+logger = logging.getLogger("api.riot")
 
 
 class RiotProfessionalPlayerService:

--- a/src/riot/service/riot_professional_team_service.py
+++ b/src/riot/service/riot_professional_team_service.py
@@ -8,7 +8,7 @@ from src.db.models import ProfessionalTeamModel
 
 from src.riot.exceptions import ProfessionalTeamNotFoundException
 
-logger = logging.getLogger("riot")
+logger = logging.getLogger("api.riot")
 
 
 class RiotProfessionalTeamService:

--- a/src/riot/service/riot_tournament_service.py
+++ b/src/riot/service/riot_tournament_service.py
@@ -7,7 +7,7 @@ from src.db.database_service import DatabaseService
 from src.db.models import TournamentModel
 from src.riot.exceptions import TournamentNotFoundException
 
-logger = logging.getLogger("riot")
+logger = logging.getLogger("api.riot")
 
 
 class RiotTournamentService:

--- a/src/riot_scraper/job_runner.py
+++ b/src/riot_scraper/job_runner.py
@@ -4,7 +4,7 @@ from typing import Callable
 
 from src.common.exceptions import FantasyLolException
 
-logger = logging.getLogger("scraper")
+logger = logging.getLogger("scraper.runner")
 
 
 class JobRunner:

--- a/src/riot_scraper/job_scheduler.py
+++ b/src/riot_scraper/job_scheduler.py
@@ -10,7 +10,7 @@ from src.common import app_config
 from src.common.config import ScheduleConfig
 from src.riot.exceptions import JobConfigException
 
-logger = logging.getLogger("scraper")
+logger = logging.getLogger("scraper.scheduler")
 
 
 class JobScheduler:

--- a/src/riot_scraper/riot_api/api_requester.py
+++ b/src/riot_scraper/riot_api/api_requester.py
@@ -3,7 +3,7 @@ import logging
 import certifi
 from requests import Response
 
-logger = logging.getLogger("scraper")
+logger = logging.getLogger("scraper.api")
 
 
 class ApiRequester:

--- a/src/riot_scraper/riot_api/riot_api_client.py
+++ b/src/riot_scraper/riot_api/riot_api_client.py
@@ -15,7 +15,7 @@ from src.riot_scraper.riot_api.schemas.get_schedule import GetScheduleResponse
 from src.riot_scraper.riot_api.schemas.get_teams import GetTeamsResponse
 from src.riot_scraper.riot_api.schemas.get_tournament import GetTournamentsResponse
 
-logger = logging.getLogger("scraper")
+logger = logging.getLogger("scraper.api")
 
 
 class RiotApiClient:

--- a/src/riot_scraper/scrapers/game_data_scraper.py
+++ b/src/riot_scraper/scrapers/game_data_scraper.py
@@ -8,7 +8,7 @@ from src.riot_scraper.riot_api.riot_api_client import RiotApiClient
 from src.riot_scraper.job_runner import JobRunner
 from src.riot_scraper.timestamp_util import TimestampUtil
 
-logger = logging.getLogger("scraper")
+logger = logging.getLogger("scraper.game_data")
 
 
 class RiotGameDataScraper:

--- a/src/riot_scraper/scrapers/game_scraper.py
+++ b/src/riot_scraper/scrapers/game_scraper.py
@@ -5,7 +5,7 @@ from src.db.database_service import DatabaseService
 from src.riot_scraper.riot_api.riot_api_client import RiotApiClient
 from src.riot_scraper.job_runner import JobRunner
 
-logger = logging.getLogger("riot")
+logger = logging.getLogger("scraper.game")
 
 
 class RiotGameScraper:

--- a/src/riot_scraper/scrapers/game_stats_scraper.py
+++ b/src/riot_scraper/scrapers/game_stats_scraper.py
@@ -16,7 +16,7 @@ from src.riot_scraper.riot_api.riot_api_client import RiotApiClient
 from src.riot_scraper.job_runner import JobRunner
 from src.riot_scraper.timestamp_util import TimestampUtil
 
-logger = logging.getLogger("scraper")
+logger = logging.getLogger("scraper.game_stats")
 
 
 class RiotGameStatsScraper:

--- a/src/riot_scraper/scrapers/league_scraper.py
+++ b/src/riot_scraper/scrapers/league_scraper.py
@@ -5,7 +5,7 @@ from src.db.database_service import DatabaseService
 from src.riot_scraper.riot_api.riot_api_client import RiotApiClient
 from src.riot_scraper.job_runner import JobRunner
 
-logger = logging.getLogger("scraper")
+logger = logging.getLogger("scraper.league")
 
 
 class RiotLeagueScraper:

--- a/src/riot_scraper/scrapers/match_scraper.py
+++ b/src/riot_scraper/scrapers/match_scraper.py
@@ -13,7 +13,7 @@ from src.db.database_service import DatabaseService
 from src.riot_scraper.riot_api.riot_api_client import RiotApiClient
 from src.riot_scraper.job_runner import JobRunner
 
-logger = logging.getLogger("scraper")
+logger = logging.getLogger("scraper.match")
 
 
 class RiotMatchScraper:

--- a/src/riot_scraper/scrapers/team_scraper.py
+++ b/src/riot_scraper/scrapers/team_scraper.py
@@ -5,7 +5,7 @@ from src.db.database_service import DatabaseService
 from src.riot_scraper.riot_api.riot_api_client import RiotApiClient
 from src.riot_scraper.job_runner import JobRunner
 
-logger = logging.getLogger("scraper")
+logger = logging.getLogger("scraper.team")
 
 
 class RiotTeamScraper:

--- a/src/riot_scraper/scrapers/tournament_scraper.py
+++ b/src/riot_scraper/scrapers/tournament_scraper.py
@@ -5,7 +5,7 @@ from src.db.database_service import DatabaseService
 from src.riot_scraper.riot_api.riot_api_client import RiotApiClient
 from src.riot_scraper.job_runner import JobRunner
 
-logger = logging.getLogger("scraper")
+logger = logging.getLogger("scraper.tournament")
 
 
 class RiotTournamentScraper:


### PR DESCRIPTION
## Summary

Overhauls the logging system to provide useful debugging context and adds optional Grafana/Loki integration behind a feature flag.

## What changed

### Logging infrastructure
- **Hierarchical loggers** — `api.riot`, `api.fantasy`, `api.auth`, `api.db`, `scraper.match`, `scraper.game`, etc. Configuring the root (`api` or `scraper`) covers all children.
- **Request ID middleware** — Generates a UUID per HTTP request, attaches it to all log records via context var. Logs request completion with method, path, status code, and duration.
- **Dual format**:
  - Console/file: `[LEVEL] timestamp [logger] [req:uuid] message`
  - Loki: `[LEVEL] [req:uuid] message` with labels for filtering

### Loki integration (feature-flagged)
- `LOKI_ENABLED=False` by default — no impact on existing deployments
- `LOKI_URL=http://localhost:3100/loki/api/v1/push`
- Pushes directly via `python-logging-loki` (no sidecar needed)
- Labels: `app=mythicforge`, `service=api|scraper`, `level`, `logger`
- Request ID in log line for LogQL filtering: `{app="mythicforge"} |= "req:uuid"`

### Service-layer logging
- Fantasy league operations: create, invite, join, start draft
- Fantasy team operations: pickup, drop
- User operations: signup, login
- All include relevant entity IDs for debugging context

### Logger name updates (30 files)
- `"riot"` → `"api.riot"`
- `"fantasy-lol"` → `"api.auth"`
- `"scraper"` → `"scraper.match"`, `"scraper.game"`, etc.

## New dependency
- `python-logging-loki==0.3.1`

## Testing
- Full test suite: 487 passed (2 pre-existing failures unrelated to this PR)
- `ruff check`, `ruff format`, `mypy src` all pass
- Verified locally with postgres

## Example log output

```
[INFO] 2026-05-06 20:30:00 [api.fantasy] [req:a1b2c3d4-...] Creating fantasy league for owner=usr-123 name=My League
[INFO] 2026-05-06 20:30:00 [api] [req:a1b2c3d4-...] POST /api/v1/fantasy/leagues 200 45ms
```