### PR TITLE
Add input validation and login brute-force protection

### DIFF
--- a/src/common/schemas/fantasy_schemas.py
+++ b/src/common/schemas/fantasy_schemas.py
@@ -25,12 +25,16 @@ class UserCreate(BaseModel):
     def validate_username(cls, username: str):
         if len(username) < 3:
             raise ValueError("Username must be at least 3 characters long")
+        if len(username) > 32:
+            raise ValueError("Username must be at most 32 characters long")
         return username
 
     @field_validator("password")
     def validate_password(cls, password: str):
         if len(password) < 8:
             raise ValueError("Password must be at least 8 characters long")
+        if len(password) > 128:
+            raise ValueError("Password must be at most 128 characters long")
         return password
 
 

--- a/src/fantasy/service/fantasy_user_service.py
+++ b/src/fantasy/service/fantasy_user_service.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import uuid
 import bcrypt
 import secrets
@@ -103,6 +104,7 @@ class UserService:
         logger.info("Login attempt: username=%s", user_credentials.username)
         user = self.db.get_user_by_username(user_credentials.username)
         if user is None:
+            time.sleep(2)
             raise InvalidUsernameOrPasswordException()
 
         if not user.verified:
@@ -110,6 +112,7 @@ class UserService:
 
         passwords_match = bcrypt.checkpw(user_credentials.password.encode(), user.password)
         if not passwords_match:
+            time.sleep(2)
             raise InvalidUsernameOrPasswordException()
 
         return sign_jwt(user.id, user.get_permissions())

--- a/ui/src/views/SignupView.vue
+++ b/ui/src/views/SignupView.vue
@@ -17,8 +17,32 @@ const passwordMismatch = computed(
   () => confirmPassword.value.length > 0 && password.value !== confirmPassword.value
 )
 
+const usernameError = computed(() => {
+  if (username.value.length === 0) return ''
+  if (username.value.length < 3) return 'Username must be at least 3 characters'
+  if (username.value.length > 32) return 'Username must be at most 32 characters'
+  return ''
+})
+
+const passwordError = computed(() => {
+  if (password.value.length === 0) return ''
+  if (password.value.length < 8) return 'Password must be at least 8 characters'
+  if (password.value.length > 128) return 'Password must be at most 128 characters'
+  return ''
+})
+
+const formValid = computed(
+  () =>
+    username.value.length >= 3 &&
+    username.value.length <= 32 &&
+    email.value.length > 0 &&
+    password.value.length >= 8 &&
+    password.value.length <= 128 &&
+    !passwordMismatch.value
+)
+
 async function handleSignup() {
-  if (passwordMismatch.value) return
+  if (!formValid.value) return
   loading.value = true
   try {
     await auth.signup(username.value, email.value, password.value)
@@ -48,9 +72,12 @@ async function handleSignup() {
         type="text"
         required
         minlength="3"
+        maxlength="32"
         autocomplete="username"
-        class="mb-4 w-full rounded border border-gray-600 bg-gray-700 px-3 py-2 text-white placeholder-gray-400 focus:border-indigo-500 focus:outline-none"
+        class="mb-1 w-full rounded border border-gray-600 bg-gray-700 px-3 py-2 text-white placeholder-gray-400 focus:border-indigo-500 focus:outline-none"
       />
+      <p v-if="usernameError" class="mb-4 text-sm text-red-400">{{ usernameError }}</p>
+      <div v-else class="mb-4" />
 
       <label for="email" class="mb-1 block text-sm text-gray-300">Email</label>
       <input
@@ -63,9 +90,11 @@ async function handleSignup() {
       />
 
       <label for="password" class="mb-1 block text-sm text-gray-300">Password</label>
-      <div class="mb-4">
+      <div class="mb-1">
         <PasswordInput id="password" v-model="password" autocomplete="new-password" :minlength="8" />
       </div>
+      <p v-if="passwordError" class="mb-4 text-sm text-red-400">{{ passwordError }}</p>
+      <div v-else class="mb-4" />
 
       <label for="confirmPassword" class="mb-1 block text-sm text-gray-300">Confirm Password</label>
       <div class="mb-1">
@@ -82,7 +111,7 @@ async function handleSignup() {
 
       <button
         type="submit"
-        :disabled="loading || passwordMismatch"
+        :disabled="loading || !formValid"
         class="w-full rounded bg-indigo-600 py-2 font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
       >
         {{ loading ? 'Creating account...' : 'Sign Up' }}


### PR DESCRIPTION
## Summary

Adds server-side input validation with max lengths and a 2-second delay on failed login attempts to prevent brute-force attacks. Client-side validation in the signup form gives immediate feedback.

## Changes

### Server-side
- Username: min 3, max 32 characters
- Password: min 8, max 128 characters (prevents bcrypt DoS with extremely long strings)
- Email: already validated via pydantic EmailStr (no change)
- Failed login attempts (wrong username or password) sleep 2 seconds before responding, making brute-force impractically slow without storing any state

### Client-side
- Inline validation errors shown as user types
- maxlength attributes on inputs
- Submit button disabled until all requirements met
- Validation messages: username length, password length, password mismatch

## Testing
- Full test suite: 487 passed (2 pre-existing failures unrelated)
- UI build passes (vue-tsc + vite build)
- Lint, format, mypy all pass
- UI test framework not yet set up — client-side validation untested (tracked separately)