### PR TITLE
Add server docker-compose and file logging feature flag

### DIFF
--- a/docker-files/docker-compose.server.yml
+++ b/docker-files/docker-compose.server.yml
@@ -1,0 +1,58 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - ${POSTGRES_DATA_PATH}:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  db-migrate:
+    build:
+      context: ..
+      dockerfile: docker-files/Dockerfile-migrate
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+    depends_on:
+      db:
+        condition: service_healthy
+
+  api:
+    build:
+      context: ..
+      dockerfile: docker-files/Dockerfile-api
+    env_file:
+      - ../.env
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+    depends_on:
+      db-migrate:
+        condition: service_completed_successfully
+
+  ui:
+    build:
+      context: ..
+      dockerfile: docker-files/Dockerfile-ui
+    ports:
+      - "8000:8000"
+    depends_on:
+      - api
+
+  master-scraper:
+    build:
+      context: ..
+      dockerfile: docker-files/Dockerfile-scraper
+    env_file:
+      - ../.env
+    environment:
+      - MASTER_SCRAPER=true
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+    depends_on:
+      db-migrate:
+        condition: service_completed_successfully

--- a/example.env
+++ b/example.env
@@ -14,6 +14,13 @@ AUTH_ALGORITHM="HS256"
 # Logging (Loki/Grafana — optional, disabled by default)
 LOKI_ENABLED=False
 LOKI_URL="http://localhost:3100/loki/api/v1/push"
+FILE_LOGGING_ENABLED=True
+
+# Server deployment (used by docker-compose.server.yml)
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=fantasy_lol
+POSTGRES_DATA_PATH=/path/to/your/postgres/data
 
 # Email Verification
 REQUIRE_EMAIL_VERIFICATION=True

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -41,6 +41,7 @@ class AppConfig(BaseSettings):
     # Logging
     LOKI_ENABLED: bool = False
     LOKI_URL: str = "http://localhost:3100/loki/api/v1/push"
+    FILE_LOGGING_ENABLED: bool = True
 
     # Riot API
     RIOT_API_KEY: str = "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"

--- a/src/common/logger.py
+++ b/src/common/logger.py
@@ -18,7 +18,6 @@ class RequestIdFilter(logging.Filter):
 def configure_logger(service: str) -> None:
     max_file_size = 1024 * 1024 * 100  # 100 MB
     backup_count = 5
-    Path("./logs/").mkdir(parents=True, exist_ok=True)
 
     logging_level = logging.DEBUG if app_config.DEBUG_LOGGING else logging.INFO
 
@@ -42,18 +41,22 @@ def configure_logger(service: str) -> None:
     root_logger.addHandler(console_handler)
 
     # File handler
-    file_fmt = logging.Formatter("[%(levelname)s] %(asctime)s [%(name)s] %(request_id)s%(message)s")
-    file_handler = RotatingFileHandler(
-        filename=f"./logs/{service}.log",
-        mode="a+",
-        maxBytes=max_file_size,
-        backupCount=backup_count,
-        encoding="utf-8",
-    )
-    file_handler.setLevel(logging_level)
-    file_handler.setFormatter(file_fmt)
-    file_handler.addFilter(rid_filter)
-    root_logger.addHandler(file_handler)
+    if app_config.FILE_LOGGING_ENABLED:
+        Path("./logs/").mkdir(parents=True, exist_ok=True)
+        file_fmt = logging.Formatter(
+            "[%(levelname)s] %(asctime)s [%(name)s] %(request_id)s%(message)s"
+        )
+        file_handler = RotatingFileHandler(
+            filename=f"./logs/{service}.log",
+            mode="a+",
+            maxBytes=max_file_size,
+            backupCount=backup_count,
+            encoding="utf-8",
+        )
+        file_handler.setLevel(logging_level)
+        file_handler.setFormatter(file_fmt)
+        file_handler.addFilter(rid_filter)
+        root_logger.addHandler(file_handler)
 
     # Loki handler
     if app_config.LOKI_ENABLED:


### PR DESCRIPTION
## Summary

Adds a production-ready docker-compose for home server deployment and makes file logging optional.

## Changes

### docker-compose.server.yml
- All config comes from `.env` via variable substitution (postgres credentials, data path)
- Only port 8000 exposed (nginx handles everything, Cloudflare tunnel points here)
- No debug ports (5432, 8002, 8004 not exposed)
- Postgres data path is configurable for mounting to external drives

### FILE_LOGGING_ENABLED flag
- Defaults to `True` (local dev keeps file logs)
- Set to `False` on server when Loki handles all log collection
- Skips log directory creation when disabled

### example.env
- Added `FILE_LOGGING_ENABLED`
- Added server deployment vars: `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_DATA_PATH`

## Usage

```bash
# Local dev (unchanged)
cd docker-files && docker-compose -f docker-compose.local.yml up -d

# Server deployment
cd docker-files && docker-compose -f docker-compose.server.yml up -d
```

Server `.env` example:
```
POSTGRES_DATA_PATH=/mnt/external-drive/postgres
POSTGRES_USER=postgres
POSTGRES_PASSWORD=<strong-password>
POSTGRES_DB=fantasy_lol
LOKI_ENABLED=True
FILE_LOGGING_ENABLED=False
```