### PR TITLE
Add server docker-compose and file logging feature flag

### DIFF
--- a/scripts/docker_server.sh
+++ b/scripts/docker_server.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd docker-files || exit 1
+docker compose -p fantasy_lol -f docker-compose.server.yml --env-file ../.env up -d --build


### PR DESCRIPTION
## Summary

Adds a production-ready docker-compose for home server deployment and makes file logging optional.

## Changes

### docker-compose.server.yml
- All config from `.env` via variable substitution (postgres credentials, data path)
- Only port 8000 exposed (nginx, Cloudflare tunnel points here)
- No debug ports (5432, 8002, 8004 not exposed)
- Postgres data path configurable for external drive mounts

### FILE_LOGGING_ENABLED flag
- Defaults to `True` (local dev keeps file logs)
- Set to `False` on server when Loki handles log collection

### scripts/docker_server.sh
- Run script that passes `--env-file ../.env` to compose

### example.env
- Added `FILE_LOGGING_ENABLED`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_DATA_PATH`

## Usage

```bash
./scripts/docker_server.sh
```