### PR TITLE
Add server docker-compose and file logging feature flag

### DIFF
--- a/docker-files/docker-compose.server.yml
+++ b/docker-files/docker-compose.server.yml
@@ -5,6 +5,8 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "127.0.0.1:5432:5432"
     volumes:
       - ${POSTGRES_DATA_PATH}:/var/lib/postgresql/data
     healthcheck:

--- a/scripts/docker_server.sh
+++ b/scripts/docker_server.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd docker-files || exit 1
+docker compose -p fantasy_lol -f docker-compose.server.yml --env-file ../.env up -d --build


### PR DESCRIPTION
- docker-compose.server.yml: production-ready compose for home server deployment. All values (postgres credentials, data path) come from .env via variable substitution. Only port 8000 (nginx) is exposed.
- FILE_LOGGING_ENABLED: defaults to True for local dev. Set to False on the server when Loki handles all log collection.
- Updated example.env with new config options.