### PR TITLE
Add admin page for triggering scraper jobs

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -13,6 +13,7 @@ from src.db.database_service import DatabaseService
 from src.fantasy.endpoints import FantasyLeagueEndpoint, FantasyTeamEndpoint, UserEndpointV1
 from src.fantasy.service import FantasyLeagueService, FantasyTeamService, UserService
 from src.riot.endpoints import (
+    AdminEndpoint,
     GameEndpoint,
     GameStatsEndpoint,
     LeagueEndpoint,
@@ -64,6 +65,7 @@ def create_app(database_service: DatabaseService) -> FastAPI:
     app.include_router(GameStatsEndpoint(game_stats_service).router, prefix="/api/v1/riot")
     app.include_router(ProfessionalTeamEndpoint(team_service).router, prefix="/api/v1/riot")
     app.include_router(ProfessionalPlayerEndpoint(player_service).router, prefix="/api/v1/riot")
+    app.include_router(AdminEndpoint().router, prefix="/api/v1/admin")
 
     # Fantasy services and endpoints
     user_service = UserService(database_service)

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -47,6 +47,7 @@ class AppConfig(BaseSettings):
     RIOT_API_KEY: str = "0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z"
     ESPORTS_API_URL: str = "https://esports-api.lolesports.com/persisted/gw"
     ESPORTS_FEED_URL: str = "https://feed.lolesports.com/livestats/v1"
+    SCRAPER_INTERNAL_URL: str = "http://master-scraper:8004"
 
     # Job schedules
     LEAGUE_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(trigger="cron", hour="10", minute="00")

--- a/src/riot/endpoints/__init__.py
+++ b/src/riot/endpoints/__init__.py
@@ -1,3 +1,4 @@
+from .admin_endpoint import AdminEndpoint  # noqa: F401
 from .game_endpoint_v1 import GameEndpoint  # noqa: F401
 from .game_stats_endpoint import GameStatsEndpoint  # noqa: F401
 from .league_endpoint_v1 import LeagueEndpoint  # noqa: F401

--- a/src/riot/endpoints/admin_endpoint.py
+++ b/src/riot/endpoints/admin_endpoint.py
@@ -1,0 +1,66 @@
+import logging
+
+import httpx
+from classy_fastapi import Routable, post
+from fastapi import Depends
+
+from src.auth import JWTBearer, Permissions
+from src.common.config import app_config
+
+logger = logging.getLogger("api.admin")
+
+SCRAPER_JOBS = {
+    "fetch-leagues": "/api/v1/fetch-leagues",
+    "fetch-tournaments": "/api/v1/fetch-tournaments",
+    "fetch-teams": "/api/v1/fetch-teams",
+    "fetch-matches": "/api/v1/fetch-matches-from-schedule",
+    "fetch-games": "/api/v1/fetch-games-from-matches",
+    "update-game-states": "/api/v1/update-game-states",
+}
+
+
+class AdminEndpoint(Routable):
+    @post(
+        path="/trigger/{job_name}",
+        description="Trigger a scraper job by name",
+        tags=["Admin"],
+        dependencies=[Depends(JWTBearer([Permissions.RIOT_ADMIN]))],
+        status_code=202,
+    )
+    async def trigger_job(self, job_name: str) -> dict:
+        if job_name not in SCRAPER_JOBS:
+            return {"error": f"Unknown job: {job_name}. Available: {list(SCRAPER_JOBS.keys())}"}
+
+        scraper_path = SCRAPER_JOBS[job_name]
+        url = f"{app_config.SCRAPER_INTERNAL_URL}{scraper_path}"
+        logger.info("Triggering scraper job=%s url=%s", job_name, url)
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, timeout=10)
+
+        if response.status_code == 202:
+            return {"message": f"Job '{job_name}' triggered successfully"}
+        else:
+            logger.error("Failed to trigger job=%s status=%s", job_name, response.status_code)
+            return {"error": f"Scraper returned {response.status_code}"}
+
+    @post(
+        path="/trigger-all",
+        description="Trigger all scraper jobs in sequence",
+        tags=["Admin"],
+        dependencies=[Depends(JWTBearer([Permissions.RIOT_ADMIN]))],
+        status_code=202,
+    )
+    async def trigger_all_jobs(self) -> dict:
+        logger.info("Triggering all scraper jobs")
+        results = {}
+        async with httpx.AsyncClient() as client:
+            for job_name, path in SCRAPER_JOBS.items():
+                url = f"{app_config.SCRAPER_INTERNAL_URL}{path}"
+                try:
+                    response = await client.post(url, timeout=10)
+                    results[job_name] = "triggered" if response.status_code == 202 else "failed"
+                except Exception as e:
+                    logger.error("Failed to trigger job=%s: %s", job_name, str(e))
+                    results[job_name] = f"error: {str(e)}"
+        return {"results": results}

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -21,6 +21,11 @@ const router = createRouter({
       name: 'dashboard',
       component: () => import('../views/DashboardView.vue'),
     },
+    {
+      path: '/admin',
+      name: 'admin',
+      component: () => import('../views/AdminView.vue'),
+    },
   ],
 })
 

--- a/ui/src/views/AdminView.vue
+++ b/ui/src/views/AdminView.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { api } from '../api/client'
+
+const jobs = [
+  { name: 'fetch-leagues', label: 'Fetch Leagues' },
+  { name: 'fetch-tournaments', label: 'Fetch Tournaments' },
+  { name: 'fetch-teams', label: 'Fetch Teams' },
+  { name: 'fetch-matches', label: 'Fetch Matches' },
+  { name: 'fetch-games', label: 'Fetch Games' },
+  { name: 'update-game-states', label: 'Update Game States' },
+]
+
+const results = ref<Record<string, string>>({})
+const loading = ref<Record<string, boolean>>({})
+const triggeringAll = ref(false)
+
+async function triggerJob(jobName: string) {
+  loading.value[jobName] = true
+  results.value[jobName] = ''
+  try {
+    const res = await api.post(`/admin/trigger/${jobName}`)
+    results.value[jobName] = res.data.message || res.data.error
+  } catch {
+    results.value[jobName] = 'Failed to trigger'
+  } finally {
+    loading.value[jobName] = false
+  }
+}
+
+async function triggerAll() {
+  triggeringAll.value = true
+  try {
+    const res = await api.post('/admin/trigger-all')
+    results.value = res.data.results
+  } catch {
+    results.value = { all: 'Failed to trigger' }
+  } finally {
+    triggeringAll.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="min-h-screen bg-gray-900">
+    <nav class="flex items-center justify-between border-b border-gray-700 px-6 py-4">
+      <h1 class="text-xl font-bold text-white">MythicForge Admin</h1>
+      <RouterLink to="/" class="text-sm text-gray-400 hover:text-white">← Back</RouterLink>
+    </nav>
+    <main class="mx-auto max-w-2xl p-6">
+      <h2 class="mb-6 text-lg font-semibold text-white">Scraper Job Triggers</h2>
+
+      <button
+        class="mb-6 w-full rounded bg-indigo-600 px-4 py-3 font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+        :disabled="triggeringAll"
+        @click="triggerAll"
+      >
+        {{ triggeringAll ? 'Triggering all...' : 'Trigger All Jobs' }}
+      </button>
+
+      <div class="space-y-3">
+        <div
+          v-for="job in jobs"
+          :key="job.name"
+          class="flex items-center justify-between rounded bg-gray-800 px-4 py-3"
+        >
+          <span class="text-white">{{ job.label }}</span>
+          <div class="flex items-center gap-3">
+            <span v-if="results[job.name]" class="text-sm text-gray-400">
+              {{ results[job.name] }}
+            </span>
+            <button
+              class="rounded bg-gray-700 px-3 py-1 text-sm text-gray-300 hover:bg-gray-600 disabled:opacity-50"
+              :disabled="loading[job.name]"
+              @click="triggerJob(job.name)"
+            >
+              {{ loading[job.name] ? '...' : 'Trigger' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>


### PR DESCRIPTION
## Summary

Adds an admin UI page and API endpoints for manually triggering scraper jobs from anywhere, protected by the RIOT_ADMIN permission.

## How it works

The API proxies trigger requests to the scraper service over the Docker internal network. No need to expose port 8004 externally.

```
Browser → /api/v1/admin/trigger/fetch-leagues → API → http://master-scraper:8004/api/v1/fetch-leagues
```

## Changes

### API
- `src/riot/endpoints/admin_endpoint.py` — New endpoints:
  - `POST /api/v1/admin/trigger/{job_name}` — trigger a single job
  - `POST /api/v1/admin/trigger-all` — trigger all jobs in sequence
- Protected by `RIOT_ADMIN` permission
- `SCRAPER_INTERNAL_URL` config (defaults to `http://master-scraper:8004`)

### UI
- `ui/src/views/AdminView.vue` — Admin page with trigger buttons and status feedback
- Route: `/admin`

### Available jobs
- fetch-leagues, fetch-tournaments, fetch-teams, fetch-matches, fetch-games, update-game-states

## Granting admin access

```sql
UPDATE users SET permissions = 'fantasy:Read,fantasy:Write,riot:Read,riot:Admin'
WHERE username = 'your-username';
```

## Testing
- UI build passes
- ruff, mypy pass
- Admin endpoints return 403 without RIOT_ADMIN permission (existing JWTBearer behavior)