### PR TITLE
Fix game_scraper overwriting game number with null

### DIFF
--- a/src/riot_scraper/scrapers/game_scraper.py
+++ b/src/riot_scraper/scrapers/game_scraper.py
@@ -48,6 +48,7 @@ class RiotGameScraper:
                     new_game = Game(
                         id=game.id,
                         state=GameState(game.state),
+                        number=game.number,
                         match_id=match_id,
                     )
                 else:
@@ -56,6 +57,7 @@ class RiotGameScraper:
                     new_game = Game(
                         id=game.id,
                         state=GameState(game.state),
+                        number=game.number,
                         red_team=ProTeamID(red_team_id),
                         blue_team=ProTeamID(blue_team_id),
                         match_id=match_id,


### PR DESCRIPTION
## Summary

The game_scraper created Game objects without setting the `number` field (defaults to None). Since `put_game` uses `session.merge()`, it overwrote existing game rows that already had `number` set by `save_from_details`, nulling out the game number.

## Fix

Added `number=game.number` to both code paths in the game_scraper.

## Note

The other two fixes originally in this PR (timestamp util and game_teams query) have already been merged to main separately. This PR now contains only the game number fix.

## Verified

- 492 tests passed (2 pre-existing failures unrelated)
- Rebased on latest main