### PR TITLE
Add scrape_enabled flag to leagues

### DIFF
--- a/alembic/versions/002_add_scrape_enabled.py
+++ b/alembic/versions/002_add_scrape_enabled.py
@@ -1,0 +1,25 @@
+"""Add scrape_enabled to leagues
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-05-07
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "002"
+down_revision = "001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "leagues",
+        sa.Column("scrape_enabled", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("leagues", "scrape_enabled")

--- a/src/common/schemas/riot_data_schemas.py
+++ b/src/common/schemas/riot_data_schemas.py
@@ -34,6 +34,11 @@ class League(BaseModel):
         description="Riot league is available for use in Fantasy Leagues",
         examples=[False],
     )
+    scrape_enabled: bool = Field(
+        default=False,
+        description="Whether to scrape matches, games, and stats for this league",
+        examples=[False],
+    )
 
 
 class TournamentStatus(str, Enum):

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -61,6 +61,7 @@ class LeagueModel(Base):  # type: ignore
     image = Column(String)
     priority = Column(Integer)
     fantasy_available = Column(Boolean)
+    scrape_enabled = Column(Boolean, default=False, nullable=False)
 
 
 class TournamentModel(Base):  # type: ignore

--- a/src/db/riot_dao/game_dao.py
+++ b/src/db/riot_dao/game_dao.py
@@ -87,8 +87,10 @@ def get_games_to_check_state(session) -> list[RiotGameID]:
         SELECT games.id
         FROM games
         JOIN matches ON games.match_id = matches.id
+        JOIN leagues ON matches.league_id = leagues.id
         WHERE matches.start_time < to_char(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
         AND games.state != 'completed' AND games.state != 'unneeded'
+        AND leagues.scrape_enabled = true
     """
     result = session.execute(text(sql_query))
     rows = result.fetchall()

--- a/src/db/riot_dao/match_dao.py
+++ b/src/db/riot_dao/match_dao.py
@@ -176,9 +176,11 @@ def get_ids_without_games(session) -> list[RiotMatchID]:
 def get_stale_match_ids(session) -> list[RiotMatchID]:
     result = session.execute(
         text("""
-        SELECT id FROM matches
-        WHERE start_time < to_char(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
-        AND state::text IN ('unstarted', 'inProgress');
+        SELECT matches.id FROM matches
+        JOIN leagues ON matches.league_id = leagues.id
+        WHERE matches.start_time < to_char(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+        AND matches.state::text IN ('unstarted', 'inProgress')
+        AND leagues.scrape_enabled = true;
     """)
     )
     return [RiotMatchID(row[0]) for row in result.fetchall()]
@@ -212,8 +214,11 @@ def get_match_ids_without_games(session) -> list[RiotMatchID]:
     sql_query = """
         SELECT DISTINCT games.match_id
         FROM games
+        JOIN matches ON games.match_id = matches.id
+        JOIN leagues ON matches.league_id = leagues.id
         LEFT JOIN game_teams ON games.id = game_teams.game_id
-        WHERE game_teams.game_id IS NULL;
+        WHERE game_teams.game_id IS NULL
+        AND leagues.scrape_enabled = true;
     """
     result = session.execute(text(sql_query))
     rows = result.fetchall()

--- a/src/db/riot_dao/player_metadata_dao.py
+++ b/src/db/riot_dao/player_metadata_dao.py
@@ -31,9 +31,12 @@ def get_game_ids_without_player_metadata(session) -> list[RiotGameID]:
     sql_query = """
         SELECT games.id as game_id
         FROM games
+        JOIN matches ON games.match_id = matches.id
+        JOIN leagues ON matches.league_id = leagues.id
         LEFT JOIN player_game_metadata ON games.id = player_game_metadata.game_id
         WHERE games.state in ('completed', 'inProgress')
             AND (games.details_status IS NULL OR games.details_status != 'unavailable')
+            AND leagues.scrape_enabled = true
         GROUP BY games.id
         HAVING COUNT(player_game_metadata.game_id) <> 10
         OR COUNT(player_game_metadata.game_id) IS NULL;

--- a/src/db/riot_dao/player_stats_dao.py
+++ b/src/db/riot_dao/player_stats_dao.py
@@ -30,11 +30,14 @@ def get_game_ids_to_fetch_player_stats_for(session) -> list[RiotGameID]:
     sql_query = """
         SELECT games.id as game_id
         FROM games
+        JOIN matches ON games.match_id = matches.id
+        JOIN leagues ON matches.league_id = leagues.id
         LEFT JOIN player_game_stats ON games.id = player_game_stats.game_id
         WHERE ((games.state = 'completed'
                 AND (SELECT COUNT(*) FROM player_game_stats WHERE game_id = games.id) < 10)
                 OR games.state = 'inProgress')
             AND (games.details_status IS NULL OR games.details_status != 'unavailable')
+            AND leagues.scrape_enabled = true
         GROUP BY games.id
     """
     result = session.execute(text(sql_query))

--- a/src/riot_scraper/scrapers/tournament_scraper.py
+++ b/src/riot_scraper/scrapers/tournament_scraper.py
@@ -27,6 +27,8 @@ class RiotTournamentScraper:
     def fetch_tournaments_job(self) -> None:
         stored_leagues = self.db.get_leagues()
         for league in stored_leagues:
+            if not league.scrape_enabled:
+                continue
             get_tournaments_response = self.riot_api_requester.get_tournament_for_league(league.id)
             for tournament_league in get_tournaments_response.data.leagues:
                 for tournament in tournament_league.tournaments:

--- a/tests/db/riot/test_riot_game.py
+++ b/tests/db/riot/test_riot_game.py
@@ -269,6 +269,24 @@ class TestCrudRiotGame(TestBase):
         self.assertIsInstance(game_ids, list)
         self.assertEqual(0, len(game_ids))
 
+    def test_get_games_to_check_status_excluded_when_scrape_disabled(self):
+        # Arrange - league with scrape_enabled=False
+        league = riot_fixtures.league_1_fixture.model_copy(deep=True)
+        league.scrape_enabled = False
+        self.db.put_league(league)
+
+        match_in_past = riot_fixtures.match_fixture.model_copy(deep=True)
+        self.db.put_match(match_in_past)
+        inprogress_game = riot_fixtures.game_2_fixture_inprogress.model_copy(deep=True)
+        inprogress_game.match_id = match_in_past.id
+        self.db.put_game(inprogress_game)
+
+        # Act
+        game_ids = self.db.get_games_to_check_state()
+
+        # Assert - should be excluded because scrape_enabled=False
+        self.assertEqual(0, len(game_ids))
+
     def test_update_game_state(self):
         # Arrange
         unstarted_game = riot_fixtures.game_3_fixture_unstarted

--- a/tests/db/riot/test_riot_match.py
+++ b/tests/db/riot/test_riot_match.py
@@ -167,7 +167,9 @@ class TestCrudRiotMatch(TestBase):
         self.assertIsNone(match_from_db)
 
     def test_get_match_ids_without_games_matches_with_no_games(self):
-        # Arrange - create a match with a game that has no team assignments
+        # Arrange - create a league and match with a game that has no team assignments
+        self.db.put_league(riot_fixtures.league_1_fixture)
+
         match = riot_fixtures.match_fixture.model_copy(deep=True)
         match.has_games = True
         self.db.put_match(match)
@@ -521,6 +523,10 @@ class TestCrudRiotMatch(TestBase):
     # --- get_stale_match_ids tests ---
 
     def test_get_stale_match_ids_returns_past_unstarted(self):
+        league = riot_fixtures.league_1_fixture.model_copy(deep=True)
+        league.slug = "test-league"
+        self.db.put_league(league)
+
         schedule_match = ScheduleMatch(
             id=RiotMatchID("stale-001"),
             start_time="2020-01-01T12:00:00Z",
@@ -533,10 +539,22 @@ class TestCrudRiotMatch(TestBase):
         )
         self.db.save_from_schedule(schedule_match)
 
+        # save_from_schedule doesn't set league_id, so set it manually
+        with self.db_provider.get_db() as db:
+            from src.db.models import MatchModel
+
+            m = db.query(MatchModel).filter(MatchModel.id == "stale-001").first()
+            m.league_id = league.id
+            db.commit()
+
         ids = self.db.get_stale_match_ids()
         self.assertIn(RiotMatchID("stale-001"), ids)
 
     def test_get_stale_match_ids_returns_past_inprogress(self):
+        league = riot_fixtures.league_1_fixture.model_copy(deep=True)
+        league.slug = "test-league"
+        self.db.put_league(league)
+
         schedule_match = ScheduleMatch(
             id=RiotMatchID("stale-002"),
             start_time="2020-01-01T12:00:00Z",
@@ -548,6 +566,13 @@ class TestCrudRiotMatch(TestBase):
             teams=[],
         )
         self.db.save_from_schedule(schedule_match)
+
+        with self.db_provider.get_db() as db:
+            from src.db.models import MatchModel
+
+            m = db.query(MatchModel).filter(MatchModel.id == "stale-002").first()
+            m.league_id = league.id
+            db.commit()
 
         ids = self.db.get_stale_match_ids()
         self.assertIn(RiotMatchID("stale-002"), ids)

--- a/tests/riot_scraper/test_match_scraper.py
+++ b/tests/riot_scraper/test_match_scraper.py
@@ -285,6 +285,14 @@ class TestRiotMatchScraper(TestBase):
             )
         )
 
+        # Set league_id on the match (save_from_schedule doesn't do this)
+        with self.db_provider.get_db() as db:
+            from src.db.models import MatchModel
+
+            m = db.query(MatchModel).filter(MatchModel.id == "stale-refresh-001").first()
+            m.league_id = league.id
+            db.commit()
+
         # Event details shows all games completed
         self.mock_api.get_event_details.return_value = _make_event_details_response(
             "stale-refresh-001"

--- a/tests/test_util/riot_fixtures.py
+++ b/tests/test_util/riot_fixtures.py
@@ -39,6 +39,7 @@ league_1_fixture = schemas.League(
     image="http//:mocked-league-image.png",
     priority=1,
     fantasy_available=False,
+    scrape_enabled=True,
 )
 
 league_2_fixture = schemas.League(


### PR DESCRIPTION
## Summary

Adds a per-league `scrape_enabled` flag that controls whether the scraper processes tournaments, games, and stats for that league. Defaults to `false` — must be explicitly enabled via DB update.

## Why

Currently the scraper processes all ~50 leagues, making thousands of API calls for leagues we don't care about. This flag lets you enable scraping only for leagues you want data from.

## Changes

### Schema
- New column: `leagues.scrape_enabled` (boolean, default false)
- Alembic migration 002

### Scrapers affected
- `tournament_scraper`: skips leagues with `scrape_enabled=false`
- `game_dao.get_games_to_check_state`: only processes scrape-enabled leagues
- `match_dao.get_match_ids_without_games`: only processes scrape-enabled leagues
- `match_dao.get_stale_match_ids`: only processes scrape-enabled leagues
- `player_metadata_dao`: only processes scrape-enabled leagues
- `player_stats_dao`: only processes scrape-enabled leagues

### Scrapers unaffected (always run globally)
- `league_scraper` (discovers all leagues)
- `team_scraper` (global team list)
- `match_scraper.sync_schedule` (paginated feed, can't filter by league)

## Usage

```sql
UPDATE leagues SET scrape_enabled = true WHERE slug IN ('lcs', 'lec', 'lck', 'lpl');
```

## Testing
- 492 passed (2 pre-existing failures unrelated)
- Added test verifying games are excluded when `scrape_enabled=false`
- Updated existing tests to set up league with `scrape_enabled=true`