### PR TITLE
Set league_id in save_from_schedule when league exists

### DIFF
--- a/src/db/riot_dao/match_dao.py
+++ b/src/db/riot_dao/match_dao.py
@@ -85,11 +85,17 @@ def put_match(session, match: Match) -> None:
 
 
 def save_from_schedule(session, schedule_match: ScheduleMatch) -> None:
+    league = (
+        session.query(LeagueModel).filter(LeagueModel.slug == schedule_match.league_slug).first()
+    )
+    league_id = league.id if league else None
+
     db_match = MatchModel(
         id=schedule_match.id,
         start_time=schedule_match.start_time,
         block_name=schedule_match.block_name,
         league_slug=schedule_match.league_slug,
+        league_id=league_id,
         strategy_type=schedule_match.strategy_type,
         strategy_count=schedule_match.strategy_count,
         state=schedule_match.state,

--- a/tests/db/riot/test_riot_match.py
+++ b/tests/db/riot/test_riot_match.py
@@ -380,6 +380,55 @@ class TestCrudRiotMatch(TestBase):
         self.assertEqual("New Team 1", result.team_1_name)
         self.assertEqual("New Team 2", result.team_2_name)
 
+    def test_save_from_schedule_sets_league_id_when_league_exists(self):
+        # Arrange - create a league first
+        league = riot_fixtures.league_1_fixture.model_copy(deep=True)
+        league.slug = "known-league"
+        self.db.put_league(league)
+
+        schedule_match = ScheduleMatch(
+            id=RiotMatchID("sched-league-001"),
+            start_time="2024-01-01T12:00:00Z",
+            block_name="Week 1",
+            league_slug="known-league",
+            strategy_type="bestOf",
+            strategy_count=1,
+            state=MatchState.UNSTARTED,
+            teams=[],
+        )
+
+        # Act
+        self.db.save_from_schedule(schedule_match)
+
+        # Assert - league_id should be set
+        with self.db_provider.get_db() as db:
+            from src.db.models import MatchModel
+
+            m = db.query(MatchModel).filter(MatchModel.id == "sched-league-001").first()
+            self.assertEqual(league.id, m.league_id)
+
+    def test_save_from_schedule_league_id_null_when_league_not_found(self):
+        schedule_match = ScheduleMatch(
+            id=RiotMatchID("sched-league-002"),
+            start_time="2024-01-01T12:00:00Z",
+            block_name="Week 1",
+            league_slug="unknown-league",
+            strategy_type="bestOf",
+            strategy_count=1,
+            state=MatchState.UNSTARTED,
+            teams=[],
+        )
+
+        # Act
+        self.db.save_from_schedule(schedule_match)
+
+        # Assert - league_id should be null
+        with self.db_provider.get_db() as db:
+            from src.db.models import MatchModel
+
+            m = db.query(MatchModel).filter(MatchModel.id == "sched-league-002").first()
+            self.assertIsNone(m.league_id)
+
     # --- all_exist tests ---
 
     def test_all_exist_returns_true_when_all_present(self):
@@ -539,14 +588,6 @@ class TestCrudRiotMatch(TestBase):
         )
         self.db.save_from_schedule(schedule_match)
 
-        # save_from_schedule doesn't set league_id, so set it manually
-        with self.db_provider.get_db() as db:
-            from src.db.models import MatchModel
-
-            m = db.query(MatchModel).filter(MatchModel.id == "stale-001").first()
-            m.league_id = league.id
-            db.commit()
-
         ids = self.db.get_stale_match_ids()
         self.assertIn(RiotMatchID("stale-001"), ids)
 
@@ -566,13 +607,6 @@ class TestCrudRiotMatch(TestBase):
             teams=[],
         )
         self.db.save_from_schedule(schedule_match)
-
-        with self.db_provider.get_db() as db:
-            from src.db.models import MatchModel
-
-            m = db.query(MatchModel).filter(MatchModel.id == "stale-002").first()
-            m.league_id = league.id
-            db.commit()
 
         ids = self.db.get_stale_match_ids()
         self.assertIn(RiotMatchID("stale-002"), ids)

--- a/tests/riot_scraper/test_match_scraper.py
+++ b/tests/riot_scraper/test_match_scraper.py
@@ -285,14 +285,6 @@ class TestRiotMatchScraper(TestBase):
             )
         )
 
-        # Set league_id on the match (save_from_schedule doesn't do this)
-        with self.db_provider.get_db() as db:
-            from src.db.models import MatchModel
-
-            m = db.query(MatchModel).filter(MatchModel.id == "stale-refresh-001").first()
-            m.league_id = league.id
-            db.commit()
-
         # Event details shows all games completed
         self.mock_api.get_event_details.return_value = _make_event_details_response(
             "stale-refresh-001"


### PR DESCRIPTION
## Summary

`save_from_schedule` was saving matches with `league_slug` but never resolving `league_id`. This meant all downstream queries that JOIN on leagues couldn't find these matches — causing the 'Fetch Games' job to return no results on a fresh DB.

## Fix

Resolves `league_id` from the slug at save time, same pattern as `put_match`.

## Tests

- Added: verifies `league_id` is set when league exists in DB
- Added: verifies `league_id` is null when league slug not found
- Removed manual `league_id` workarounds from stale match and scraper tests (no longer needed)

## For existing data

Run this to backfill `league_id` on matches that were saved before this fix:
```sql
UPDATE matches
SET league_id = leagues.id
FROM leagues
WHERE matches.league_slug = leagues.slug
AND matches.league_id IS NULL;
```

## Verified

- 494 tests passed
- ruff, mypy clean