### PR TITLE
Fetch schedule per scrape-enabled league instead of globally

### DIFF
--- a/src/riot_scraper/riot_api/riot_api_client.py
+++ b/src/riot_scraper/riot_api/riot_api_client.py
@@ -99,11 +99,14 @@ class RiotApiClient:
 
         return GetLiveDetailsResponse.model_validate(response.json())
 
-    def get_schedule(self, page_token: str | None = None) -> GetScheduleResponse:
-        if page_token is None:
-            url = f"{self.esports_api_url}/getSchedule?hl=en-GB"
-        else:
-            url = f"{self.esports_api_url}/getSchedule?hl=en-GB&pageToken={page_token}"
+    def get_schedule(
+        self, page_token: str | None = None, league_id: RiotLeagueID | None = None
+    ) -> GetScheduleResponse:
+        url = f"{self.esports_api_url}/getSchedule?hl=en-GB"
+        if league_id is not None:
+            url += f"&leagueId={league_id}"
+        if page_token is not None:
+            url += f"&pageToken={page_token}"
 
         response = self.make_request(url)
         validate_response([HTTPStatus.OK], response.status_code, url)

--- a/src/riot_scraper/scrapers/match_scraper.py
+++ b/src/riot_scraper/scrapers/match_scraper.py
@@ -28,9 +28,17 @@ class RiotMatchScraper:
         self.job_runner = job_runner
 
     def sync_schedule(self) -> None:
+        leagues = self.db.get_leagues()
+        for league in leagues:
+            if not league.scrape_enabled:
+                continue
+            logger.info(f"Syncing schedule for league: {league.name} ({league.id})")
+            self._sync_league_schedule(league.id)
+
+    def _sync_league_schedule(self, league_id) -> None:
         page_token = None
         while True:
-            response = self.riot_api_requester.get_schedule(page_token)
+            response = self.riot_api_requester.get_schedule(page_token, league_id=league_id)
             schedule = response.data.schedule
             match_ids = []
 

--- a/tests/riot_scraper/test_match_scraper.py
+++ b/tests/riot_scraper/test_match_scraper.py
@@ -133,6 +133,12 @@ class TestRiotMatchScraper(TestBase):
             database_service=self.db,
             riot_api_requester=self.mock_api,
         )
+        # Create a scrape-enabled league for sync_schedule to iterate over
+        from tests.test_util import riot_fixtures
+
+        league = riot_fixtures.league_1_fixture.model_copy(deep=True)
+        league.slug = "test-league"
+        self.db.put_league(league)
 
     # --- sync_schedule tests ---
 


### PR DESCRIPTION
## Summary

Instead of fetching the entire global schedule (all ~50 leagues), the match scraper now only fetches schedules for leagues with `scrape_enabled=true`.

## How it works

The Riot schedule API supports a `leagueId` query param (only one per request). `sync_schedule` now iterates over scrape-enabled leagues and fetches each one's schedule separately.

## Changes

- `RiotApiClient.get_schedule`: added optional `league_id` param
- `match_scraper.sync_schedule`: iterates over scrape-enabled leagues, calls `_sync_league_schedule` per league
- Updated test setUp to create a scrape-enabled league

## Behavior

- Enabling a new league and re-running fetch-matches will fetch all its historical matches (paginates back until it hits existing data)
- Leagues with `scrape_enabled=false` are completely skipped

## Verified

- 492 tests passed (2 pre-existing failures unrelated)
- Lint, mypy clean