### PR TITLE
Preserve fantasy_available and scrape_enabled when re-fetching leagues

### DIFF
--- a/src/db/riot_dao/riot_league_dao.py
+++ b/src/db/riot_dao/riot_league_dao.py
@@ -5,8 +5,16 @@ from src.db.models import LeagueModel
 
 
 def put_league(session, league: League) -> None:
-    db_league = LeagueModel(**league.model_dump())
-    session.merge(db_league)
+    existing = session.query(LeagueModel).filter(LeagueModel.id == league.id).first()
+    if existing:
+        existing.slug = league.slug
+        existing.name = league.name
+        existing.region = league.region
+        existing.image = league.image
+        existing.priority = league.priority
+    else:
+        db_league = LeagueModel(**league.model_dump())
+        session.add(db_league)
     session.commit()
 
 

--- a/tests/db/riot/test_riot_game.py
+++ b/tests/db/riot/test_riot_game.py
@@ -270,15 +270,19 @@ class TestCrudRiotGame(TestBase):
         self.assertEqual(0, len(game_ids))
 
     def test_get_games_to_check_status_excluded_when_scrape_disabled(self):
-        # Arrange - league with scrape_enabled=False
-        league = riot_fixtures.league_1_fixture.model_copy(deep=True)
-        league.scrape_enabled = False
-        self.db.put_league(league)
+        # Arrange - disable scraping on the league
+        with self.db_provider.get_db() as db:
+            from src.db.models import LeagueModel
 
-        match_in_past = riot_fixtures.match_fixture.model_copy(deep=True)
-        self.db.put_match(match_in_past)
+            league = (
+                db.query(LeagueModel)
+                .filter(LeagueModel.id == riot_fixtures.league_1_fixture.id)
+                .first()
+            )
+            league.scrape_enabled = False
+            db.commit()
+
         inprogress_game = riot_fixtures.game_2_fixture_inprogress.model_copy(deep=True)
-        inprogress_game.match_id = match_in_past.id
         self.db.put_game(inprogress_game)
 
         # Act

--- a/tests/db/riot/test_riot_league.py
+++ b/tests/db/riot/test_riot_league.py
@@ -32,6 +32,29 @@ class TestCrudRiotLeague(TestBase):
         league_after_put = self.db.get_league_by_id(league.id)
         self.assertEqual(updated_league, league_after_put)
 
+    def test_put_league_preserves_fantasy_available_and_scrape_enabled(self):
+        # Arrange - create league and enable both flags
+        league = riot_fixtures.league_1_fixture.model_copy(deep=True)
+        self.db.put_league(league)
+        with self.db_provider.get_db() as db:
+            db_league = db.query(LeagueModel).filter(LeagueModel.id == league.id).first()
+            db_league.fantasy_available = True
+            db_league.scrape_enabled = True
+            db.commit()
+
+        # Act - re-put the league (simulates scraper re-fetching with defaults)
+        league_from_scraper = league.model_copy(deep=True)
+        league_from_scraper.name = "Updated Name"
+        league_from_scraper.fantasy_available = False
+        league_from_scraper.scrape_enabled = False
+        self.db.put_league(league_from_scraper)
+
+        # Assert - flags should be preserved, name should be updated
+        result = self.db.get_league_by_id(league.id)
+        self.assertTrue(result.fantasy_available)
+        self.assertTrue(result.scrape_enabled)
+        self.assertEqual("Updated Name", result.name)
+
     def test_get_leagues_no_filters(self):
         # Arrange
         expected_league = riot_fixtures.league_1_fixture


### PR DESCRIPTION
## Summary

The league scraper was resetting `fantasy_available` and `scrape_enabled` to `false` every time it ran because `put_league` used `session.merge()` which overwrites all fields.

## Fix

`put_league` now checks if the league exists:
- **Exists**: only updates name, slug, region, image, priority (preserves flags)
- **New**: inserts with defaults (both flags false)

## Verified

- 495 tests passed (2 pre-existing failures unrelated)
- Lint, mypy clean