### PR TITLE
422 UI redesign

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,9 +8,11 @@
       "name": "ui",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource/inter": "^5.2.8",
         "@primevue/themes": "^4.5.4",
         "@tailwindcss/vite": "^4.2.4",
         "axios": "^1.15.2",
+        "lucide-vue-next": "^1.0.0",
         "pinia": "^3.0.4",
         "primevue": "^4.5.5",
         "tailwindcss": "^4.2.4",
@@ -101,6 +103,15 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1670,6 +1681,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lucide-vue-next": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-1.0.0.tgz",
+      "integrity": "sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
       }
     },
     "node_modules/magic-string": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,9 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource/inter": "^5.2.8",
     "@primevue/themes": "^4.5.4",
     "@tailwindcss/vite": "^4.2.4",
     "axios": "^1.15.2",
+    "lucide-vue-next": "^1.0.0",
     "pinia": "^3.0.4",
     "primevue": "^4.5.5",
     "tailwindcss": "^4.2.4",

--- a/ui/src/components/common/PasswordInput.vue
+++ b/ui/src/components/common/PasswordInput.vue
@@ -25,13 +25,13 @@ const visible = ref(false)
       required
       :minlength="minlength"
       :autocomplete="autocomplete"
-      class="w-full rounded border bg-gray-700 px-3 py-2 pr-10 text-white placeholder-gray-400 focus:outline-none"
-      :class="hasError ? 'border-red-500 focus:border-red-500' : 'border-gray-600 focus:border-indigo-500'"
+      class="w-full rounded-lg border bg-surface-elevated px-3 py-2 pr-10 text-foreground placeholder-foreground-muted focus:outline-none"
+      :class="hasError ? 'border-danger focus:border-danger' : 'border-border focus:border-primary'"
       @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
     />
     <button
       type="button"
-      class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-200"
+      class="absolute inset-y-0 right-0 flex items-center pr-3 text-foreground-muted hover:text-foreground"
       :aria-label="visible ? 'Hide password' : 'Show password'"
       @click="visible = !visible"
     >

--- a/ui/src/components/dashboard/ActivityCard.vue
+++ b/ui/src/components/dashboard/ActivityCard.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { Zap, ArrowRightLeft, UserPlus, PlusCircle } from 'lucide-vue-next'
+import type { ActivityEvent } from '../../types/fantasy'
+import type { Component } from 'vue'
+
+const activities: (ActivityEvent & { icon: Component; style: { bg: string; color: string } })[] = [
+  { id: '1', type: 'score', description: 'Faker scored 32.5 pts in T1 vs GEN', timestamp: '2m ago', icon: Zap, style: { bg: 'rgba(59,130,246,0.12)', color: 'var(--color-primary)' } },
+  { id: '2', type: 'trade', description: 'Trade accepted: Chovy for ShowMaker', timestamp: '15m ago', icon: ArrowRightLeft, style: { bg: 'rgba(245,158,11,0.12)', color: 'var(--color-accent)' } },
+  { id: '3', type: 'pickup', description: 'MidLaneMaster drafted Ruler', timestamp: '1h ago', icon: UserPlus, style: { bg: 'rgba(34,197,94,0.12)', color: 'var(--color-success)' } },
+  { id: '4', type: 'score', description: 'Zeus earned First Blood bonus (+5 pts)', timestamp: '2h ago', icon: Zap, style: { bg: 'rgba(59,130,246,0.12)', color: 'var(--color-primary)' } },
+  { id: '5', type: 'pickup', description: 'Kiin added from waivers', timestamp: '3h ago', icon: PlusCircle, style: { bg: 'rgba(100,116,139,0.12)', color: 'var(--color-foreground-muted)' } },
+]
+</script>
+
+<template>
+  <div class="rounded-xl p-5 flex flex-col gap-4 bg-surface border border-border-subtle">
+    <h2 class="text-base font-semibold text-foreground">Recent Activity</h2>
+
+    <div class="flex flex-col gap-3">
+      <div v-for="a in activities" :key="a.id" class="flex items-start gap-3">
+        <div
+          class="w-8 h-8 rounded-lg shrink-0 flex items-center justify-center"
+          :style="{ background: a.style.bg, color: a.style.color }"
+        >
+          <component :is="a.icon" class="w-4 h-4" />
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-sm leading-snug text-foreground">{{ a.description }}</p>
+          <p class="text-xs mt-0.5 text-foreground-muted">{{ a.timestamp }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/ui/src/components/dashboard/LeaderboardCard.vue
+++ b/ui/src/components/dashboard/LeaderboardCard.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { ChevronUp, ChevronDown, Minus } from 'lucide-vue-next'
+import type { LeaderboardEntry } from '../../types/fantasy'
+
+const entries: LeaderboardEntry[] = [
+  { user_id: '1', username: 'ProGamer99', position: 1, points: 1247.5, is_current_user: false },
+  { user_id: '2', username: 'Summoner42', position: 2, points: 1198.3, is_current_user: true },
+  { user_id: '3', username: 'MidLaneMaster', position: 3, points: 1156.8, is_current_user: false },
+  { user_id: '4', username: 'JungleDiff', position: 4, points: 1089.2, is_current_user: false },
+  { user_id: '5', username: 'ADCarry1', position: 5, points: 1034.7, is_current_user: false },
+]
+
+// Mock trends (not in LeaderboardEntry, just for display)
+const trends: Record<string, 'up' | 'down' | 'same'> = {
+  '1': 'same', '2': 'up', '3': 'down', '4': 'up', '5': 'down',
+}
+
+function trendIcon(userId: string) {
+  const t = trends[userId]
+  if (t === 'up') return ChevronUp
+  if (t === 'down') return ChevronDown
+  return Minus
+}
+
+function trendColor(userId: string) {
+  const t = trends[userId]
+  if (t === 'up') return 'var(--color-success)'
+  if (t === 'down') return 'var(--color-danger)'
+  return 'var(--color-foreground-muted)'
+}
+
+function rankStyle(rank: number) {
+  if (rank === 1) return { background: 'var(--color-accent)', color: '#000' }
+  if (rank === 2) return { background: 'rgba(148,163,184,0.25)', color: 'var(--color-foreground)' }
+  if (rank === 3) return { background: 'rgba(180,120,60,0.25)', color: '#c87941' }
+  return { background: 'var(--color-surface)', color: 'var(--color-foreground-muted)' }
+}
+</script>
+
+<template>
+  <div class="rounded-xl p-5 flex flex-col gap-4 bg-surface border border-border-subtle">
+    <div class="flex items-center justify-between">
+      <h2 class="text-base font-semibold text-foreground">Leaderboard</h2>
+      <button class="text-xs font-medium text-primary">Full Standings</button>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <div
+        v-for="e in entries"
+        :key="e.user_id"
+        class="flex items-center gap-3 px-3 py-2.5 rounded-lg"
+        :class="e.is_current_user ? 'bg-primary/10 border border-primary/30' : 'bg-surface-elevated border border-transparent'"
+      >
+        <div
+          class="w-7 h-7 rounded-full shrink-0 flex items-center justify-center text-xs font-bold"
+          :style="rankStyle(e.position)"
+        >
+          {{ e.position }}
+        </div>
+
+        <div class="flex-1 min-w-0">
+          <span
+            class="text-sm font-medium truncate block"
+            :class="e.is_current_user ? 'text-primary' : 'text-foreground'"
+          >
+            {{ e.username }}
+            <span v-if="e.is_current_user" class="text-xs ml-1 text-foreground-muted">(You)</span>
+          </span>
+        </div>
+
+        <div class="flex items-center gap-1 shrink-0">
+          <span class="text-sm font-bold tabular-nums text-foreground">
+            {{ e.points.toLocaleString() }}
+          </span>
+          <component :is="trendIcon(e.user_id)" class="w-3.5 h-3.5" :style="{ color: trendColor(e.user_id) }" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/ui/src/components/dashboard/LeagueCard.vue
+++ b/ui/src/components/dashboard/LeagueCard.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+const league = {
+  name: 'Worlds Fantasy 2024',
+  currentWeek: 8,
+  totalWeeks: 12,
+  members: 10,
+  status: 'active' as const,
+  rank: 2,
+}
+
+const statusColors: Record<string, { bg: string; text: string }> = {
+  active: { bg: 'rgba(34,197,94,0.12)', text: 'var(--color-success)' },
+  draft: { bg: 'rgba(245,158,11,0.12)', text: 'var(--color-accent)' },
+  completed: { bg: 'rgba(100,116,139,0.12)', text: 'var(--color-foreground-muted)' },
+}
+
+const sc = statusColors[league.status]
+const progress = (league.currentWeek / league.totalWeeks) * 100
+</script>
+
+<template>
+  <div class="rounded-xl p-5 flex flex-col gap-4 bg-surface border border-border-subtle">
+    <div class="flex items-center justify-between">
+      <h2 class="text-base font-semibold text-foreground">My Fantasy League</h2>
+      <span
+        class="px-2.5 py-1 rounded-full text-xs font-semibold uppercase tracking-wide"
+        :style="{ background: sc.bg, color: sc.text }"
+      >
+        {{ league.status }}
+      </span>
+    </div>
+
+    <h3 class="text-lg font-bold text-foreground">{{ league.name }}</h3>
+
+    <div class="grid grid-cols-3 gap-3">
+      <div class="flex flex-col items-center py-3 rounded-lg bg-surface-elevated">
+        <span class="text-2xl font-bold text-primary">{{ league.currentWeek }}</span>
+        <span class="text-xs mt-1 text-foreground-muted">Week</span>
+      </div>
+      <div class="flex flex-col items-center py-3 rounded-lg bg-surface-elevated">
+        <span class="text-2xl font-bold text-foreground">{{ league.members }}</span>
+        <span class="text-xs mt-1 text-foreground-muted">Members</span>
+      </div>
+      <div class="flex flex-col items-center py-3 rounded-lg bg-surface-elevated">
+        <span class="text-2xl font-bold text-accent">#{{ league.rank }}</span>
+        <span class="text-xs mt-1 text-foreground-muted">Your Rank</span>
+      </div>
+    </div>
+
+    <div>
+      <div class="flex justify-between text-xs mb-1.5 text-foreground-muted">
+        <span>Season Progress</span>
+        <span>{{ league.currentWeek }}/{{ league.totalWeeks }} weeks</span>
+      </div>
+      <div class="h-2 rounded-full overflow-hidden bg-surface-elevated">
+        <div
+          class="h-full rounded-full bg-primary transition-all"
+          :style="{ width: `${progress}%` }"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/ui/src/components/dashboard/LiveMatchesCard.vue
+++ b/ui/src/components/dashboard/LiveMatchesCard.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import type { LiveMatch } from '../../types/fantasy'
+
+const matches: LiveMatch[] = [
+  { match_id: '1', team_1_name: 'T1', team_2_name: 'GEN', team_1_score: 2, team_2_score: 1, league_slug: 'worlds', start_time: '2024-11-02T08:00:00Z' },
+  { match_id: '2', team_1_name: 'BLG', team_2_name: 'WBG', team_1_score: 1, team_2_score: 1, league_slug: 'worlds', start_time: '2024-11-02T10:00:00Z' },
+  { match_id: '3', team_1_name: 'FNC', team_2_name: 'G2', team_1_score: 0, team_2_score: 0, league_slug: 'lec', start_time: '2024-11-02T12:00:00Z' },
+]
+</script>
+
+<template>
+  <div class="rounded-xl p-5 flex flex-col gap-4 bg-surface border border-border-subtle">
+    <div class="flex items-center justify-between">
+      <h2 class="text-base font-semibold text-foreground flex items-center gap-2">
+        <span class="w-2 h-2 rounded-full shrink-0 bg-live animate-pulse-live" />
+        Live Matches
+      </h2>
+      <RouterLink to="/matches" class="text-xs font-medium text-primary">View All</RouterLink>
+    </div>
+
+    <div class="flex flex-col gap-3">
+      <div
+        v-for="m in matches"
+        :key="m.match_id"
+        class="rounded-lg p-3 bg-surface-elevated"
+      >
+        <p class="text-xs mb-2 text-foreground-muted">{{ m.league_slug.toUpperCase() }}</p>
+        <div class="flex items-center justify-between gap-2">
+          <div class="flex items-center gap-2 flex-1 min-w-0">
+            <div class="w-8 h-8 rounded-full shrink-0 flex items-center justify-center text-[10px] font-bold text-white bg-primary">
+              {{ m.team_1_name.slice(0, 3) }}
+            </div>
+            <span class="font-semibold text-sm truncate text-foreground">{{ m.team_1_name }}</span>
+          </div>
+
+          <div class="text-center shrink-0 px-3">
+            <div class="text-lg font-bold tabular-nums text-foreground">
+              {{ m.team_1_score }} — {{ m.team_2_score }}
+            </div>
+            <div class="text-[11px] font-semibold mt-0.5 text-live">LIVE</div>
+          </div>
+
+          <div class="flex items-center gap-2 flex-1 min-w-0 justify-end">
+            <span class="font-semibold text-sm truncate text-foreground">{{ m.team_2_name }}</span>
+            <div class="w-8 h-8 rounded-full shrink-0 flex items-center justify-center text-[10px] font-bold text-white bg-primary">
+              {{ m.team_2_name.slice(0, 3) }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/ui/src/components/dashboard/MyTeamCard.vue
+++ b/ui/src/components/dashboard/MyTeamCard.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { TrendingUp, TrendingDown, Minus } from 'lucide-vue-next'
+import type { RosterEntry } from '../../types/fantasy'
+
+const roster: RosterEntry[] = [
+  { player_id: '1', summoner_name: 'Zeus', role: 'top', team_code: 'T1', points: 87.5, trend: 'up' },
+  { player_id: '2', summoner_name: 'Oner', role: 'jungle', team_code: 'T1', points: 92.3, trend: 'up' },
+  { player_id: '3', summoner_name: 'Faker', role: 'mid', team_code: 'T1', points: 105.2, trend: 'up' },
+  { player_id: '4', summoner_name: 'Gumayusi', role: 'bottom', team_code: 'T1', points: 78.9, trend: 'down' },
+  { player_id: '5', summoner_name: 'Keria', role: 'support', team_code: 'T1', points: 68.4, trend: 'neutral' },
+]
+
+const total = roster.reduce((s, p) => s + p.points, 0).toFixed(1)
+
+const roleLabels: Record<string, string> = {
+  top: 'Top', jungle: 'Jungle', mid: 'Mid', bottom: 'ADC', support: 'Support',
+}
+
+const roleColors: Record<string, string> = {
+  top: '#3b82f6', jungle: '#22c55e', mid: '#a855f7', bottom: '#f59e0b', support: '#06b6d4',
+}
+
+function trendIcon(trend: string) {
+  if (trend === 'up') return TrendingUp
+  if (trend === 'down') return TrendingDown
+  return Minus
+}
+
+function trendColor(trend: string) {
+  if (trend === 'up') return 'var(--color-success)'
+  if (trend === 'down') return 'var(--color-danger)'
+  return 'var(--color-foreground-muted)'
+}
+</script>
+
+<template>
+  <div class="rounded-xl p-5 flex flex-col gap-4 lg:col-span-2 bg-surface border border-border-subtle">
+    <div class="flex items-center justify-between">
+      <h2 class="text-base font-semibold text-foreground">My Team</h2>
+      <div class="flex items-center gap-2">
+        <span class="text-sm text-foreground-muted">Weekly Total</span>
+        <span class="text-xl font-bold text-primary">{{ total }} pts</span>
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <div
+        v-for="p in roster"
+        :key="p.player_id"
+        class="flex items-center gap-4 px-4 py-3 rounded-lg bg-surface-elevated"
+      >
+        <span
+          class="text-xs font-bold w-14 text-center py-1 rounded-md shrink-0"
+          :style="{ background: `${roleColors[p.role]}1a`, color: roleColors[p.role] }"
+        >
+          {{ roleLabels[p.role] }}
+        </span>
+
+        <div
+          class="w-8 h-8 rounded-full shrink-0 flex items-center justify-center text-[10px] font-bold text-white bg-primary"
+        >
+          {{ p.team_code }}
+        </div>
+
+        <div class="flex-1 min-w-0">
+          <p class="font-semibold text-sm text-foreground">{{ p.summoner_name }}</p>
+          <p class="text-xs text-foreground-muted">{{ p.team_code }}</p>
+        </div>
+
+        <div class="flex items-center gap-1.5 shrink-0">
+          <span class="text-base font-bold text-foreground">{{ p.points }}</span>
+          <component :is="trendIcon(p.trend)" class="w-4 h-4" :style="{ color: trendColor(p.trend) }" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/ui/src/components/layout/AppHeader.vue
+++ b/ui/src/components/layout/AppHeader.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Trophy, ChevronDown, Bell } from 'lucide-vue-next'
+import { useFantasyLeagueStore } from '../../stores/fantasyLeague'
+
+const store = useFantasyLeagueStore()
+const open = ref(false)
+
+// Mock leagues until real API integration
+const mockLeagues = [
+  { id: '1', name: 'Worlds Fantasy 2024' },
+  { id: '2', name: 'LCS Spring Split' },
+  { id: '3', name: 'LEC Champions' },
+]
+
+const selectedName = ref(
+  mockLeagues.find((l) => l.id === store.selectedLeagueId)?.name ?? mockLeagues[0].name
+)
+
+function selectLeague(league: { id: string; name: string }) {
+  store.selectLeague(league.id)
+  selectedName.value = league.name
+  open.value = false
+}
+</script>
+
+<template>
+  <header
+    class="h-16 flex items-center justify-between px-6 sticky top-0 z-30 bg-surface border-b border-border-subtle"
+  >
+    <!-- League selector -->
+    <div class="relative">
+      <button
+        class="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium bg-surface-elevated border border-border-subtle text-foreground"
+        @click="open = !open"
+      >
+        <Trophy class="w-4 h-4 text-accent" />
+        <span>{{ selectedName }}</span>
+        <ChevronDown class="w-4 h-4 text-foreground-muted" />
+      </button>
+
+      <div
+        v-if="open"
+        class="absolute top-full left-0 mt-2 w-56 rounded-lg py-1 z-50 shadow-2xl bg-surface-elevated border border-border-subtle"
+      >
+        <button
+          v-for="league in mockLeagues"
+          :key="league.id"
+          class="w-full text-left px-4 py-2.5 text-sm transition-colors hover:bg-primary/8"
+          :class="league.id === store.selectedLeagueId ? 'text-primary' : 'text-foreground'"
+          @click="selectLeague(league)"
+        >
+          {{ league.name }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Right side -->
+    <div class="flex items-center gap-3">
+      <button class="relative p-2 rounded-lg text-foreground-muted hover:bg-surface-elevated">
+        <Bell class="w-5 h-5" />
+        <span
+          class="absolute top-1 right-1 w-4 h-4 rounded-full text-[10px] font-bold text-white flex items-center justify-center bg-danger"
+        >
+          3
+        </span>
+      </button>
+    </div>
+  </header>
+</template>

--- a/ui/src/components/layout/AppLayout.vue
+++ b/ui/src/components/layout/AppLayout.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import AppSidebar from './AppSidebar.vue'
+import AppHeader from './AppHeader.vue'
+import { useLayoutState } from '../../composables/useLayoutState'
+
+const { isCollapsed } = useLayoutState()
+</script>
+
+<template>
+  <div class="min-h-screen bg-background">
+    <AppSidebar />
+    <div
+      class="transition-all duration-300"
+      :style="{ marginLeft: isCollapsed ? '64px' : '240px' }"
+    >
+      <AppHeader />
+      <main class="p-6">
+        <RouterView />
+      </main>
+    </div>
+  </div>
+</template>

--- a/ui/src/components/layout/AppSidebar.vue
+++ b/ui/src/components/layout/AppSidebar.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { useRoute } from 'vue-router'
+import {
+  LayoutDashboard,
+  Trophy,
+  Users,
+  Shield,
+  Radio,
+  Settings,
+  Flame,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-vue-next'
+import { useLayoutState } from '../../composables/useLayoutState'
+
+const { isCollapsed, toggle } = useLayoutState()
+const route = useRoute()
+
+const navItems = [
+  { icon: LayoutDashboard, label: 'Dashboard', to: '/' },
+  { icon: Trophy, label: 'My Leagues', to: '/leagues' },
+  { icon: Users, label: 'Browse Players', to: '/players' },
+  { icon: Shield, label: 'Browse Teams', to: '/teams' },
+  { icon: Radio, label: 'Live Matches', to: '/matches' },
+  { icon: Settings, label: 'Settings', to: '/settings' },
+]
+
+function isActive(to: string) {
+  return route.path === to
+}
+</script>
+
+<template>
+  <aside
+    class="fixed left-0 top-0 h-full z-40 flex flex-col bg-surface transition-all duration-300 border-r border-border-subtle"
+    :style="{ width: isCollapsed ? '64px' : '240px' }"
+  >
+    <!-- Logo -->
+    <div class="h-16 flex items-center justify-between px-4 shrink-0 border-b border-border-subtle">
+      <div class="flex items-center gap-3 min-w-0">
+        <div class="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 bg-primary">
+          <Flame class="w-4 h-4 text-white" />
+        </div>
+        <span v-if="!isCollapsed" class="font-bold text-base truncate text-foreground">
+          MythicForge
+        </span>
+      </div>
+      <button
+        class="p-1.5 rounded-md text-foreground-muted hover:bg-surface-elevated shrink-0"
+        @click="toggle"
+      >
+        <ChevronLeft v-if="!isCollapsed" class="w-4 h-4" />
+        <ChevronRight v-else class="w-4 h-4" />
+      </button>
+    </div>
+
+    <!-- Nav -->
+    <nav class="flex-1 py-4 px-2 flex flex-col gap-1 overflow-hidden">
+      <RouterLink
+        v-for="item in navItems"
+        :key="item.to"
+        :to="item.to"
+        :title="isCollapsed ? item.label : undefined"
+        class="flex items-center gap-3 px-3 py-2.5 rounded-lg w-full transition-all text-left"
+        :class="
+          isActive(item.to)
+            ? 'bg-primary/12 border border-primary/25 text-primary'
+            : 'border border-transparent text-foreground-muted hover:bg-surface-elevated hover:text-foreground'
+        "
+      >
+        <component :is="item.icon" class="w-5 h-5 shrink-0" />
+        <span v-if="!isCollapsed" class="text-sm font-medium truncate">{{ item.label }}</span>
+      </RouterLink>
+    </nav>
+
+    <!-- User -->
+    <div class="p-3 shrink-0 border-t border-border-subtle">
+      <div class="flex items-center gap-3">
+        <div class="w-9 h-9 rounded-full shrink-0 flex items-center justify-center text-sm font-bold text-white bg-primary">
+          S
+        </div>
+        <p v-if="!isCollapsed" class="text-sm font-medium truncate text-foreground">Summoner42</p>
+      </div>
+    </div>
+  </aside>
+</template>

--- a/ui/src/composables/useLayoutState.ts
+++ b/ui/src/composables/useLayoutState.ts
@@ -1,0 +1,14 @@
+import { ref } from 'vue'
+
+const STORAGE_KEY = 'sidebar-collapsed'
+
+const isCollapsed = ref(localStorage.getItem(STORAGE_KEY) === 'true')
+
+export function useLayoutState() {
+  function toggle() {
+    isCollapsed.value = !isCollapsed.value
+    localStorage.setItem(STORAGE_KEY, String(isCollapsed.value))
+  }
+
+  return { isCollapsed, toggle }
+}

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
+import AppLayout from '../components/layout/AppLayout.vue'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -18,13 +19,44 @@ const router = createRouter({
     },
     {
       path: '/',
-      name: 'dashboard',
-      component: () => import('../views/DashboardView.vue'),
-    },
-    {
-      path: '/admin',
-      name: 'admin',
-      component: () => import('../views/AdminView.vue'),
+      component: AppLayout,
+      children: [
+        {
+          path: '',
+          name: 'dashboard',
+          component: () => import('../views/DashboardView.vue'),
+        },
+        {
+          path: 'leagues',
+          name: 'leagues',
+          component: () => import('../views/LeaguesView.vue'),
+        },
+        {
+          path: 'players',
+          name: 'players',
+          component: () => import('../views/PlayersView.vue'),
+        },
+        {
+          path: 'teams',
+          name: 'teams',
+          component: () => import('../views/TeamsView.vue'),
+        },
+        {
+          path: 'matches',
+          name: 'matches',
+          component: () => import('../views/MatchesView.vue'),
+        },
+        {
+          path: 'settings',
+          name: 'settings',
+          component: () => import('../views/SettingsView.vue'),
+        },
+        {
+          path: 'admin',
+          name: 'admin',
+          component: () => import('../views/AdminView.vue'),
+        },
+      ],
     },
   ],
 })

--- a/ui/src/stores/fantasyLeague.ts
+++ b/ui/src/stores/fantasyLeague.ts
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+const STORAGE_KEY = 'selected-league-id'
+
+export const useFantasyLeagueStore = defineStore('fantasyLeague', () => {
+  const selectedLeagueId = ref<string | null>(localStorage.getItem(STORAGE_KEY))
+
+  function selectLeague(id: string | null) {
+    selectedLeagueId.value = id
+    if (id) {
+      localStorage.setItem(STORAGE_KEY, id)
+    } else {
+      localStorage.removeItem(STORAGE_KEY)
+    }
+  }
+
+  return { selectedLeagueId, selectLeague }
+})

--- a/ui/src/style.css
+++ b/ui/src/style.css
@@ -1,1 +1,37 @@
 @import 'tailwindcss';
+@import '@fontsource/inter/latin.css';
+
+@theme {
+  --color-background: #0f172a;
+  --color-surface: #1e293b;
+  --color-surface-elevated: #334155;
+  --color-border-subtle: #334155;
+  --color-border: #475569;
+
+  --color-foreground: #f1f5f9;
+  --color-foreground-muted: #94a3b8;
+
+  --color-primary: #3b82f6;
+  --color-primary-hover: #2563eb;
+  --color-accent: #f59e0b;
+  --color-success: #22c55e;
+  --color-danger: #ef4444;
+  --color-live: #ef4444;
+
+  --font-sans: 'Inter', system-ui, sans-serif;
+}
+
+html {
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+  font-family: var(--font-sans);
+}
+
+@keyframes pulse-live {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.animate-pulse-live {
+  animation: pulse-live 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}

--- a/ui/src/types/fantasy.ts
+++ b/ui/src/types/fantasy.ts
@@ -1,0 +1,74 @@
+import type { PlayerRole } from './riot'
+
+export type FantasyLeagueStatus = 'pre-draft' | 'draft' | 'active' | 'completed' | 'deleted'
+
+export interface FantasyLeagueSettings {
+  name: string
+  number_of_teams: number
+  available_leagues: string[]
+}
+
+export interface FantasyLeague extends FantasyLeagueSettings {
+  id: string
+  owner_id: string
+  status: FantasyLeagueStatus
+  current_week: number | null
+  current_draft_position: number | null
+}
+
+export interface FantasyLeagueScoringSettings {
+  fantasy_league_id: string | null
+  kills: number
+  deaths: number
+  assists: number
+  creep_score: number
+  wards_placed: number
+  wards_destroyed: number
+  kill_participation: number
+  damage_percentage: number
+}
+
+export interface FantasyTeam {
+  fantasy_league_id: string
+  user_id: string
+  week: number
+  top_player_id: string | null
+  jungle_player_id: string | null
+  mid_player_id: string | null
+  adc_player_id: string | null
+  support_player_id: string | null
+}
+
+export interface RosterEntry {
+  player_id: string
+  summoner_name: string
+  role: PlayerRole
+  team_code: string
+  points: number
+  trend: 'up' | 'down' | 'neutral'
+}
+
+export interface LeaderboardEntry {
+  user_id: string
+  username: string
+  position: number
+  points: number
+  is_current_user: boolean
+}
+
+export interface LiveMatch {
+  match_id: string
+  team_1_name: string
+  team_2_name: string
+  team_1_score: number
+  team_2_score: number
+  league_slug: string
+  start_time: string
+}
+
+export interface ActivityEvent {
+  id: string
+  type: 'score' | 'trade' | 'pickup' | 'drop'
+  description: string
+  timestamp: string
+}

--- a/ui/src/types/riot.ts
+++ b/ui/src/types/riot.ts
@@ -1,0 +1,78 @@
+export interface League {
+  id: string
+  slug: string
+  name: string
+  region: string
+  image: string
+  priority: number
+  fantasy_available: boolean
+}
+
+export interface Tournament {
+  id: string
+  slug: string
+  start_date: string
+  end_date: string
+  league_id: string
+}
+
+export type MatchState = 'completed' | 'inProgress' | 'unstarted'
+
+export interface Match {
+  id: string
+  start_time: string
+  block_name: string
+  league_slug: string
+  strategy_type: string
+  strategy_count: number
+  tournament_id: string | null
+  team_1_name: string | null
+  team_2_name: string | null
+  has_games: boolean
+  state: MatchState
+  team_1_wins: number | null
+  team_2_wins: number | null
+  winning_team: string | null
+}
+
+export interface ProfessionalTeam {
+  id: string
+  slug: string
+  name: string
+  code: string
+  image: string
+  alternative_image: string | null
+  background_image: string | null
+  status: string
+  home_league_name: string | null
+  home_league_region: string | null
+}
+
+export type PlayerRole = 'top' | 'jungle' | 'mid' | 'bottom' | 'support' | 'none'
+
+export interface ProfessionalPlayer {
+  id: string
+  summoner_name: string
+  first_name: string
+  last_name: string
+  image: string
+  role: PlayerRole
+  team_id: string
+}
+
+export interface PlayerGameData {
+  game_id: string
+  player_id: string
+  participant_id: number
+  champion_id: string
+  role: PlayerRole
+  kills: number
+  deaths: number
+  assists: number
+  total_gold: number
+  creep_score: number
+  kill_participation: number
+  champion_damage_share: number
+  wards_placed: number
+  wards_destroyed: number
+}

--- a/ui/src/views/AdminView.vue
+++ b/ui/src/views/AdminView.vue
@@ -42,43 +42,37 @@ async function triggerAll() {
 </script>
 
 <template>
-  <div class="min-h-screen bg-gray-900">
-    <nav class="flex items-center justify-between border-b border-gray-700 px-6 py-4">
-      <h1 class="text-xl font-bold text-white">MythicForge Admin</h1>
-      <RouterLink to="/" class="text-sm text-gray-400 hover:text-white">← Back</RouterLink>
-    </nav>
-    <main class="mx-auto max-w-2xl p-6">
-      <h2 class="mb-6 text-lg font-semibold text-white">Scraper Job Triggers</h2>
+  <div class="mx-auto max-w-2xl">
+    <h2 class="mb-6 text-lg font-semibold text-foreground">Scraper Job Triggers</h2>
 
-      <button
-        class="mb-6 w-full rounded bg-indigo-600 px-4 py-3 font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
-        :disabled="triggeringAll"
-        @click="triggerAll"
+    <button
+      class="mb-6 w-full rounded-lg bg-primary px-4 py-3 font-semibold text-white hover:bg-primary-hover disabled:opacity-50"
+      :disabled="triggeringAll"
+      @click="triggerAll"
+    >
+      {{ triggeringAll ? 'Triggering all...' : 'Trigger All Jobs' }}
+    </button>
+
+    <div class="space-y-3">
+      <div
+        v-for="job in jobs"
+        :key="job.name"
+        class="flex items-center justify-between rounded-lg bg-surface px-4 py-3"
       >
-        {{ triggeringAll ? 'Triggering all...' : 'Trigger All Jobs' }}
-      </button>
-
-      <div class="space-y-3">
-        <div
-          v-for="job in jobs"
-          :key="job.name"
-          class="flex items-center justify-between rounded bg-gray-800 px-4 py-3"
-        >
-          <span class="text-white">{{ job.label }}</span>
-          <div class="flex items-center gap-3">
-            <span v-if="results[job.name]" class="text-sm text-gray-400">
-              {{ results[job.name] }}
-            </span>
-            <button
-              class="rounded bg-gray-700 px-3 py-1 text-sm text-gray-300 hover:bg-gray-600 disabled:opacity-50"
-              :disabled="loading[job.name]"
-              @click="triggerJob(job.name)"
-            >
-              {{ loading[job.name] ? '...' : 'Trigger' }}
-            </button>
-          </div>
+        <span class="text-foreground">{{ job.label }}</span>
+        <div class="flex items-center gap-3">
+          <span v-if="results[job.name]" class="text-sm text-foreground-muted">
+            {{ results[job.name] }}
+          </span>
+          <button
+            class="rounded-lg bg-surface-elevated px-3 py-1 text-sm text-foreground-muted hover:text-foreground disabled:opacity-50"
+            :disabled="loading[job.name]"
+            @click="triggerJob(job.name)"
+          >
+            {{ loading[job.name] ? '...' : 'Trigger' }}
+          </button>
         </div>
       </div>
-    </main>
+    </div>
   </div>
 </template>

--- a/ui/src/views/DashboardView.vue
+++ b/ui/src/views/DashboardView.vue
@@ -1,30 +1,48 @@
 <script setup lang="ts">
-import { useRouter } from 'vue-router'
-import { useAuthStore } from '../stores/auth'
+import { ref } from 'vue'
+import { Trophy } from 'lucide-vue-next'
+import LeagueCard from '../components/dashboard/LeagueCard.vue'
+import MyTeamCard from '../components/dashboard/MyTeamCard.vue'
+import LiveMatchesCard from '../components/dashboard/LiveMatchesCard.vue'
+import LeaderboardCard from '../components/dashboard/LeaderboardCard.vue'
+import ActivityCard from '../components/dashboard/ActivityCard.vue'
 
-const auth = useAuthStore()
-const router = useRouter()
-
-function handleLogout() {
-  auth.logout()
-  router.push('/login')
-}
+// Mock: set to true to see empty state
+const hasLeagues = ref(true)
 </script>
 
 <template>
-  <div class="min-h-screen bg-gray-900">
-    <nav class="flex items-center justify-between border-b border-gray-700 px-6 py-4">
-      <h1 class="text-xl font-bold text-white">MythicForge</h1>
-      <button
-        class="rounded bg-gray-700 px-4 py-2 text-sm text-gray-300 hover:bg-gray-600"
-        @click="handleLogout"
+  <div>
+    <!-- Page title -->
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold text-foreground">Dashboard</h1>
+      <p class="text-sm mt-1 text-foreground-muted">Week 8 of 12 — Worlds Fantasy 2024</p>
+    </div>
+
+    <!-- Empty state -->
+    <div v-if="!hasLeagues" class="flex flex-col items-center justify-center py-20">
+      <div class="w-16 h-16 rounded-full bg-surface-elevated flex items-center justify-center mb-4">
+        <Trophy class="w-8 h-8 text-foreground-muted" />
+      </div>
+      <h2 class="text-lg font-semibold text-foreground mb-2">No Fantasy Leagues Yet</h2>
+      <p class="text-sm text-foreground-muted mb-6 text-center max-w-md">
+        Create a new fantasy league or join an existing one to start competing with friends.
+      </p>
+      <RouterLink
+        to="/leagues"
+        class="px-6 py-2.5 rounded-lg bg-primary text-white font-semibold text-sm hover:bg-primary-hover transition-colors"
       >
-        Logout
-      </button>
-    </nav>
-    <main class="p-6">
-      <h2 class="text-lg font-semibold text-white">Dashboard</h2>
-      <p class="mt-2 text-gray-400">Welcome to MythicForge. Your fantasy leagues will appear here.</p>
-    </main>
+        Get Started
+      </RouterLink>
+    </div>
+
+    <!-- Dashboard grid -->
+    <div v-else class="grid grid-cols-3 gap-6">
+      <LeagueCard />
+      <MyTeamCard />
+      <LiveMatchesCard />
+      <LeaderboardCard />
+      <ActivityCard />
+    </div>
   </div>
 </template>

--- a/ui/src/views/LeaguesView.vue
+++ b/ui/src/views/LeaguesView.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <h2 class="text-lg font-semibold text-foreground">My Leagues</h2>
+    <p class="mt-2 text-foreground-muted">Your fantasy leagues will be listed here.</p>
+  </div>
+</template>

--- a/ui/src/views/LoginView.vue
+++ b/ui/src/views/LoginView.vue
@@ -25,28 +25,28 @@ async function handleLogin() {
 </script>
 
 <template>
-  <main class="flex min-h-screen items-center justify-center bg-gray-900">
+  <main class="flex min-h-screen items-center justify-center bg-background">
     <form
-      class="w-full max-w-sm rounded-lg bg-gray-800 p-8 shadow-lg"
+      class="w-full max-w-sm rounded-xl bg-surface p-8 shadow-lg border border-border-subtle"
       @submit.prevent="handleLogin"
     >
-      <h1 class="mb-6 text-center text-2xl font-bold text-white">MythicForge</h1>
+      <h1 class="mb-6 text-center text-2xl font-bold text-foreground">MythicForge</h1>
 
-      <p v-if="auth.error" class="mb-4 rounded bg-red-900/50 p-2 text-sm text-red-300">
+      <p v-if="auth.error" class="mb-4 rounded-lg bg-danger/10 border border-danger/25 p-2 text-sm text-danger">
         {{ auth.error }}
       </p>
 
-      <label for="username" class="mb-1 block text-sm text-gray-300">Username</label>
+      <label for="username" class="mb-1 block text-sm text-foreground-muted">Username</label>
       <input
         id="username"
         v-model="username"
         type="text"
         required
         autocomplete="username"
-        class="mb-4 w-full rounded border border-gray-600 bg-gray-700 px-3 py-2 text-white placeholder-gray-400 focus:border-indigo-500 focus:outline-none"
+        class="mb-4 w-full rounded-lg border border-border bg-surface-elevated px-3 py-2 text-foreground placeholder-foreground-muted focus:border-primary focus:outline-none"
       />
 
-      <label for="password" class="mb-1 block text-sm text-gray-300">Password</label>
+      <label for="password" class="mb-1 block text-sm text-foreground-muted">Password</label>
       <div class="mb-6">
         <PasswordInput id="password" v-model="password" autocomplete="current-password" />
       </div>
@@ -54,14 +54,14 @@ async function handleLogin() {
       <button
         type="submit"
         :disabled="loading"
-        class="w-full rounded bg-indigo-600 py-2 font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+        class="w-full rounded-lg bg-primary py-2 font-semibold text-white hover:bg-primary-hover disabled:opacity-50 transition-colors"
       >
         {{ loading ? 'Signing in...' : 'Sign In' }}
       </button>
 
-      <p class="mt-4 text-center text-sm text-gray-400">
+      <p class="mt-4 text-center text-sm text-foreground-muted">
         Don't have an account?
-        <RouterLink to="/signup" class="text-indigo-400 hover:underline">Sign up</RouterLink>
+        <RouterLink to="/signup" class="text-primary hover:underline">Sign up</RouterLink>
       </p>
     </form>
   </main>

--- a/ui/src/views/MatchesView.vue
+++ b/ui/src/views/MatchesView.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <h2 class="text-lg font-semibold text-foreground">Live Matches</h2>
+    <p class="mt-2 text-foreground-muted">Live and upcoming matches will appear here.</p>
+  </div>
+</template>

--- a/ui/src/views/PlayersView.vue
+++ b/ui/src/views/PlayersView.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <h2 class="text-lg font-semibold text-foreground">Browse Players</h2>
+    <p class="mt-2 text-foreground-muted">Search and browse professional players here.</p>
+  </div>
+</template>

--- a/ui/src/views/SettingsView.vue
+++ b/ui/src/views/SettingsView.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <h2 class="text-lg font-semibold text-foreground">Settings</h2>
+    <p class="mt-2 text-foreground-muted">Account and app settings will be available here.</p>
+  </div>
+</template>

--- a/ui/src/views/SignupView.vue
+++ b/ui/src/views/SignupView.vue
@@ -54,18 +54,18 @@ async function handleSignup() {
 </script>
 
 <template>
-  <main class="flex min-h-screen items-center justify-center bg-gray-900">
+  <main class="flex min-h-screen items-center justify-center bg-background">
     <form
-      class="w-full max-w-sm rounded-lg bg-gray-800 p-8 shadow-lg"
+      class="w-full max-w-sm rounded-xl bg-surface p-8 shadow-lg border border-border-subtle"
       @submit.prevent="handleSignup"
     >
-      <h1 class="mb-6 text-center text-2xl font-bold text-white">Create Account</h1>
+      <h1 class="mb-6 text-center text-2xl font-bold text-foreground">Create Account</h1>
 
-      <p v-if="auth.error" class="mb-4 rounded bg-red-900/50 p-2 text-sm text-red-300">
+      <p v-if="auth.error" class="mb-4 rounded-lg bg-danger/10 border border-danger/25 p-2 text-sm text-danger">
         {{ auth.error }}
       </p>
 
-      <label for="username" class="mb-1 block text-sm text-gray-300">Username</label>
+      <label for="username" class="mb-1 block text-sm text-foreground-muted">Username</label>
       <input
         id="username"
         v-model="username"
@@ -74,29 +74,29 @@ async function handleSignup() {
         minlength="3"
         maxlength="32"
         autocomplete="username"
-        class="mb-1 w-full rounded border border-gray-600 bg-gray-700 px-3 py-2 text-white placeholder-gray-400 focus:border-indigo-500 focus:outline-none"
+        class="mb-1 w-full rounded-lg border border-border bg-surface-elevated px-3 py-2 text-foreground placeholder-foreground-muted focus:border-primary focus:outline-none"
       />
-      <p v-if="usernameError" class="mb-4 text-sm text-red-400">{{ usernameError }}</p>
+      <p v-if="usernameError" class="mb-4 text-sm text-danger">{{ usernameError }}</p>
       <div v-else class="mb-4" />
 
-      <label for="email" class="mb-1 block text-sm text-gray-300">Email</label>
+      <label for="email" class="mb-1 block text-sm text-foreground-muted">Email</label>
       <input
         id="email"
         v-model="email"
         type="email"
         required
         autocomplete="email"
-        class="mb-4 w-full rounded border border-gray-600 bg-gray-700 px-3 py-2 text-white placeholder-gray-400 focus:border-indigo-500 focus:outline-none"
+        class="mb-4 w-full rounded-lg border border-border bg-surface-elevated px-3 py-2 text-foreground placeholder-foreground-muted focus:border-primary focus:outline-none"
       />
 
-      <label for="password" class="mb-1 block text-sm text-gray-300">Password</label>
+      <label for="password" class="mb-1 block text-sm text-foreground-muted">Password</label>
       <div class="mb-1">
         <PasswordInput id="password" v-model="password" autocomplete="new-password" :minlength="8" />
       </div>
-      <p v-if="passwordError" class="mb-4 text-sm text-red-400">{{ passwordError }}</p>
+      <p v-if="passwordError" class="mb-4 text-sm text-danger">{{ passwordError }}</p>
       <div v-else class="mb-4" />
 
-      <label for="confirmPassword" class="mb-1 block text-sm text-gray-300">Confirm Password</label>
+      <label for="confirmPassword" class="mb-1 block text-sm text-foreground-muted">Confirm Password</label>
       <div class="mb-1">
         <PasswordInput
           id="confirmPassword"
@@ -106,20 +106,20 @@ async function handleSignup() {
           :has-error="passwordMismatch"
         />
       </div>
-      <p v-if="passwordMismatch" class="mb-4 text-sm text-red-400">Passwords do not match</p>
+      <p v-if="passwordMismatch" class="mb-4 text-sm text-danger">Passwords do not match</p>
       <div v-else class="mb-4" />
 
       <button
         type="submit"
         :disabled="loading || !formValid"
-        class="w-full rounded bg-indigo-600 py-2 font-semibold text-white hover:bg-indigo-500 disabled:opacity-50"
+        class="w-full rounded-lg bg-primary py-2 font-semibold text-white hover:bg-primary-hover disabled:opacity-50 transition-colors"
       >
         {{ loading ? 'Creating account...' : 'Sign Up' }}
       </button>
 
-      <p class="mt-4 text-center text-sm text-gray-400">
+      <p class="mt-4 text-center text-sm text-foreground-muted">
         Already have an account?
-        <RouterLink to="/login" class="text-indigo-400 hover:underline">Sign in</RouterLink>
+        <RouterLink to="/login" class="text-primary hover:underline">Sign in</RouterLink>
       </p>
     </form>
   </main>

--- a/ui/src/views/TeamsView.vue
+++ b/ui/src/views/TeamsView.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <h2 class="text-lg font-semibold text-foreground">Browse Teams</h2>
+    <p class="mt-2 text-foreground-muted">Search and browse professional teams here.</p>
+  </div>
+</template>


### PR DESCRIPTION
UI Redesign: Design System, Layout Shell, and Dashboard

  Implements the full UI redesign specified in #422, delivering a cohesive dark esports-themed interface with navigation and a rich dashboard.

  Changes

  Design System (#423)

  - Installed @fontsource/inter and lucide-vue-next
  - Added Tailwind CSS v4 @theme block with 12 color tokens (background, surface, foreground, primary, accent, etc.)
  - Created types/riot.ts and types/fantasy.ts with TypeScript interfaces mirroring backend Pydantic schemas

  Layout Shell & Routing (#424)

  - Added AppLayout, AppSidebar, AppHeader components
  - Collapsible sidebar with 6 nav items, localStorage-persisted collapse state
  - Sticky header with league selector dropdown and notification bell
  - Restructured router to nest all authenticated routes under AppLayout
  - Added useLayoutState composable and useFantasyLeagueStore Pinia store

  Dashboard Cards (#425)

  - Built 5 card components: LeagueCard, MyTeamCard (2-col span), LiveMatchesCard, LeaderboardCard, ActivityCard
  - 3-column CSS grid layout with mock data typed against the TS interfaces
  - Empty state for users with no leagues

  Auth Page Restyling (#426)

  - Restyled Login and Signup views with design system tokens
  - Updated PasswordInput component classes to match theme

  Testing

  - vue-tsc -b && vite build passes with no errors
  - Manual verification: all routes render, sidebar navigation works, auth flow functions, collapse persists

  Out of Scope

  - Real API integration (all data is mock/hardcoded)
  - Mobile/responsive design
  - Automated tests
  - Backend changes

  Closes #422, closes #423, closes #424, closes #425, closes #426