### PR TITLE
Add username to JWT and client-side token expiry check

### DIFF
--- a/src/auth/auth_handler.py
+++ b/src/auth/auth_handler.py
@@ -14,9 +14,10 @@ def token_response(token: str):
     return {"access_token": token}
 
 
-def sign_jwt(user_id: str, permissions: list[str]) -> dict[str, str]:
+def sign_jwt(user_id: str, permissions: list[str], username: str = "") -> dict[str, str]:
     payload = {
         "user_id": user_id,
+        "username": username,
         "permissions": permissions,
         "exp": time.time() + 86400,  # Token is valid for 24 hours
         "iat": time.time(),

--- a/src/fantasy/service/fantasy_user_service.py
+++ b/src/fantasy/service/fantasy_user_service.py
@@ -115,7 +115,7 @@ class UserService:
             time.sleep(2)
             raise InvalidUsernameOrPasswordException()
 
-        return sign_jwt(user.id, user.get_permissions())
+        return sign_jwt(user.id, user.get_permissions(), user.username)
 
     def delete_user(self, user_id: UserID) -> None:
         self.db.update_user_account_status(user_id, UserAccountStatus.DELETED)

--- a/tests/auth/test_auth_handler.py
+++ b/tests/auth/test_auth_handler.py
@@ -11,21 +11,22 @@ class TestAuthHandler(TestBase):
     def test_sign_jwt(self):
         user_id = "123"
         with patch("time.time", return_value=0):  # Mocking time to ensure a fixed expiration time
-            result = sign_jwt(user_id, self.permissions)
+            result = sign_jwt(user_id, self.permissions, "testuser")
         self.assertTrue("access_token" in result)
         self.assertIsNotNone(result["access_token"])
 
     def test_decode_valid_jwt(self):
         user_id = "123"
-        token = sign_jwt(user_id, self.permissions)["access_token"]
+        token = sign_jwt(user_id, self.permissions, "testuser")["access_token"]
         result = decode_jwt(token)
         self.assertEqual(result["user_id"], user_id)
         self.assertEqual(result["permissions"], self.permissions)
+        self.assertEqual(result["username"], "testuser")
 
     def test_decode_expired_jwt(self):
         user_id = "123"
         with patch("time.time", return_value=86401):  # Mocking time to create an expired token
-            token = sign_jwt(user_id, self.permissions)["access_token"]
+            token = sign_jwt(user_id, self.permissions, "testuser")["access_token"]
         result = decode_jwt(token)
         self.assertEqual(result, {})
 

--- a/tests/fantasy/unit/service/test_fantasy_user_service.py
+++ b/tests/fantasy/unit/service/test_fantasy_user_service.py
@@ -175,7 +175,7 @@ class UserServiceTest(TestBase):
 
         # Assert
         self.mock_db_service.get_user_by_username.assert_called_once_with(user.username)
-        mock_sign_jwt.assert_called_once_with(user.id, user.get_permissions())
+        mock_sign_jwt.assert_called_once_with(user.id, user.get_permissions(), user.username)
         self.assertEqual(mock_token_response, token)
 
     def test_user_login_invalid_username(self):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -21,7 +21,7 @@ def make_client():
             if isinstance(dep.dependency, JWTBearer):
                 app.dependency_overrides[dep.dependency] = lambda: test_principal
     # Also override for parameter-level Depends
-    token_data = sign_jwt(TEST_USER_ID, ALL_PERMISSIONS)
+    token_data = sign_jwt(TEST_USER_ID, ALL_PERMISSIONS, "test-user")
     auth_header = {"Authorization": f"Bearer {token_data['access_token']}"}
     return TestClient(app), mock_db, auth_header
 

--- a/ui/src/components/layout/AppSidebar.vue
+++ b/ui/src/components/layout/AppSidebar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import {
   LayoutDashboard,
   Trophy,
@@ -10,8 +10,13 @@ import {
   Flame,
   ChevronLeft,
   ChevronRight,
+  LogOut,
 } from 'lucide-vue-next'
 import { useLayoutState } from '../../composables/useLayoutState'
+import { useAuthStore } from '../../stores/auth'
+
+const auth = useAuthStore()
+const router = useRouter()
 
 const { isCollapsed, toggle } = useLayoutState()
 const route = useRoute()
@@ -77,9 +82,16 @@ function isActive(to: string) {
     <div class="p-3 shrink-0 border-t border-border-subtle">
       <div class="flex items-center gap-3">
         <div class="w-9 h-9 rounded-full shrink-0 flex items-center justify-center text-sm font-bold text-white bg-primary">
-          S
+          {{ auth.username?.charAt(0).toUpperCase() ?? '?' }}
         </div>
-        <p v-if="!isCollapsed" class="text-sm font-medium truncate text-foreground">Summoner42</p>
+        <p v-if="!isCollapsed" class="text-sm font-medium truncate text-foreground flex-1 min-w-0">{{ auth.username }}</p>
+        <button
+          :title="isCollapsed ? 'Logout' : undefined"
+          class="p-1.5 rounded-md text-foreground-muted hover:bg-surface-elevated hover:text-foreground shrink-0"
+          @click="auth.logout(); router.push('/login')"
+        >
+          <LogOut class="w-4 h-4" />
+        </button>
       </div>
     </div>
   </aside>

--- a/ui/src/stores/auth.ts
+++ b/ui/src/stores/auth.ts
@@ -2,16 +2,37 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { login as apiLogin, signup as apiSignup } from '../api/authApi'
 
+function parseJwtUsername(token: string | null): string | null {
+  if (!token) return null
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]))
+    return payload.username || null
+  } catch {
+    return null
+  }
+}
+
+function isTokenExpired(token: string | null): boolean {
+  if (!token) return true
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]))
+    return payload.exp * 1000 < Date.now()
+  } catch {
+    return true
+  }
+}
+
 export const useAuthStore = defineStore('auth', () => {
   const token = ref<string | null>(localStorage.getItem('token'))
+  const username = computed(() => parseJwtUsername(token.value))
   const error = ref<string | null>(null)
 
-  const isAuthenticated = computed(() => !!token.value)
+  const isAuthenticated = computed(() => !!token.value && !isTokenExpired(token.value))
 
-  async function login(username: string, password: string) {
+  async function login(user: string, password: string) {
     error.value = null
     try {
-      const accessToken = await apiLogin({ username, password })
+      const accessToken = await apiLogin({ username: user, password })
       token.value = accessToken
       localStorage.setItem('token', accessToken)
     } catch (e: unknown) {
@@ -20,10 +41,10 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-  async function signup(username: string, email: string, password: string) {
+  async function signup(user: string, email: string, password: string) {
     error.value = null
     try {
-      await apiSignup({ username, email, password })
+      await apiSignup({ username: user, email, password })
     } catch (e: unknown) {
       error.value = 'Signup failed. Please try again.'
       throw e
@@ -35,5 +56,5 @@ export const useAuthStore = defineStore('auth', () => {
     localStorage.removeItem('token')
   }
 
-  return { token, error, isAuthenticated, login, signup, logout }
+  return { token, username, error, isAuthenticated, login, signup, logout }
 })


### PR DESCRIPTION
## Summary

Adds the username to the JWT payload so the UI can display it without an extra API call, and fixes the UX issue where expired tokens kept users appearing "logged in" until an API call failed.

### Changes

**Backend:**
- `sign_jwt` now accepts a `username` parameter and includes it in the JWT payload
- `login_user` passes `user.username` to `sign_jwt`

**UI:**
- Auth store decodes `username` from the JWT payload (computed property)
- `isAuthenticated` now checks the token's `exp` claim — expired tokens immediately redirect to login
- Sidebar shows the real username with first-letter avatar
- Logout button added to sidebar

### Testing

- All existing auth and user service tests updated and passing
- `vue-tsc -b && vite build` passes