### PR TITLE
Improve docker_server.sh script

### DIFF
--- a/scripts/docker_server.sh
+++ b/scripts/docker_server.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+set -e
 
-cd docker-files || exit 1
-docker compose -p fantasy_lol -f docker-compose.server.yml --env-file ../.env up -d --build
+COMPOSE="docker compose -p fantasy_lol -f docker-files/docker-compose.server.yml --env-file .env"
+
+case "${1:-up}" in
+  up)
+    $COMPOSE up -d --build
+    ;;
+  down)
+    $COMPOSE down
+    ;;
+  restart)
+    $COMPOSE down
+    $COMPOSE up -d --build
+    ;;
+  *)
+    echo "Usage: $0 {up|down|restart}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Simplifies deploying by letting you run `./scripts/docker_server.sh {up|down|restart}` from the repo root instead of manually cd-ing into docker-files and typing the full compose command.