### PR TITLE
Fix round_to_10_seconds overflow when seconds >= 55

### DIFF
--- a/src/riot_scraper/timestamp_util.py
+++ b/src/riot_scraper/timestamp_util.py
@@ -14,7 +14,7 @@ class TimestampUtil:
     @staticmethod
     def round_to_10_seconds(timestamp):
         dt = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
-        rounded_seconds = round(dt.second / 10) * 10
+        rounded_seconds = (dt.second // 10) * 10
         rounded_dt = dt.replace(second=rounded_seconds, microsecond=0)
         return rounded_dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 

--- a/tests/riot_scraper/test_timestamp_util.py
+++ b/tests/riot_scraper/test_timestamp_util.py
@@ -27,3 +27,13 @@ class TestTimestampUtil:
         result = TimestampUtil.round_current_time_to_10_seconds()
         parsed = datetime.strptime(result, "%Y-%m-%dT%H:%M:%S.%fZ")
         assert parsed.microsecond == 0
+
+    def test_round_to_10_seconds_with_seconds_above_55(self):
+        """Seconds >= 55 should floor to 50, not round up to 60."""
+        result = TimestampUtil.round_to_10_seconds("2024-01-01T00:00:57.123456Z")
+        assert result == "2024-01-01T00:00:50.000000Z"
+
+    def test_round_to_10_seconds_result_is_valid(self):
+        result = TimestampUtil.round_to_10_seconds("2024-01-01T12:34:59.999999Z")
+        parsed = datetime.strptime(result, "%Y-%m-%dT%H:%M:%S.%fZ")
+        assert 0 <= parsed.second <= 59


### PR DESCRIPTION
## Problem

`TimestampUtil.round_to_10_seconds` uses `round(dt.second / 10) * 10` which produces 60 when seconds >= 55 (e.g. `round(57/10) * 10 = 60`). This crashes with `ValueError: second must be in 0..59`.

Discovered in production when the game analysis job hit a frame timestamp with seconds = 57.

## Fix

Use floor division (`//`) instead of `round()`: `(dt.second // 10) * 10` always produces 0-50.

## Test

Added regression tests for seconds >= 55.