### PR TITLE
Fix null duration: remove frame dedup that drops FINISHED

### DIFF
--- a/src/riot_scraper/scrapers/game_analysis_scraper.py
+++ b/src/riot_scraper/scrapers/game_analysis_scraper.py
@@ -1,6 +1,6 @@
 import logging
 
-from src.common.schemas.riot_data_schemas import RiotGameID, GameDragons, ProTeamID
+from src.common.schemas.riot_data_schemas import RiotGameID, GameDragons, ProTeamID, LiveGameState
 from src.db.database_service import DatabaseService
 from src.riot_scraper.game_analysis import (
     detect_multi_kills,
@@ -74,7 +74,6 @@ class GameAnalysisScraper:
             return None
 
         all_frames: list[WindowFrame] = []
-        seen_timestamps: set[str] = set()
 
         start_time = TimestampUtil.round_to_10_seconds(initial_window.frames[0].rfc460Timestamp)
         current_time = start_time
@@ -86,13 +85,11 @@ class GameAnalysisScraper:
                 break
 
             for frame in window.frames:
-                if frame.rfc460Timestamp not in seen_timestamps:
-                    seen_timestamps.add(frame.rfc460Timestamp)
-                    all_frames.append(frame)
-                from src.common.schemas.riot_data_schemas import LiveGameState
-
+                all_frames.append(frame)
                 if frame.gameState == LiveGameState.FINISHED:
                     finished = True
+
+            current_time = TimestampUtil.add_10_seconds(current_time)
 
             current_time = TimestampUtil.add_10_seconds(current_time)
 


### PR DESCRIPTION
## Problem

Game analysis produces `duration_seconds = NULL` for some games. Root cause: the Riot API returns two frames with identical timestamps but different states:

```
ts=2024-10-11T12:40:33.873Z, state=IN_GAME
ts=2024-10-11T12:40:33.873Z, state=FINISHED
```

The frame deduplication (by timestamp) kept the first and dropped the FINISHED frame. Without a FINISHED frame, `compute_duration` returns 0 and duration is never persisted.

## Fix

Remove deduplication entirely. The analysis functions diff state transitions between consecutive frames — duplicate frames with the same data produce no spurious diffs, so they're harmless.

## Affected games

Any game where `frames_status = 'completed'` but `duration_seconds IS NULL` needs to be re-analyzed:

```sql
UPDATE games SET frames_status = 'pending'
WHERE frames_status = 'completed' AND duration_seconds IS NULL;
```