### PR TITLE
Fix frame walker infinite loop on incomplete API data

### DIFF
--- a/src/riot_scraper/scrapers/game_analysis_scraper.py
+++ b/src/riot_scraper/scrapers/game_analysis_scraper.py
@@ -78,18 +78,24 @@ class GameAnalysisScraper:
         start_time = TimestampUtil.round_to_10_seconds(initial_window.frames[0].rfc460Timestamp)
         current_time = start_time
         finished = False
+        last_timestamp = None
 
         while not finished:
             window = self.api.get_game_window(game_id, current_time)
             if window is None:
                 break
 
+            # Detect stale data: if the API keeps returning the same frames, stop
+            newest_timestamp = window.frames[-1].rfc460Timestamp
+            if newest_timestamp == last_timestamp:
+                logger.warning(f"Game {game_id}: API stopped advancing at {newest_timestamp}")
+                return None
+            last_timestamp = newest_timestamp
+
             for frame in window.frames:
                 all_frames.append(frame)
                 if frame.gameState == LiveGameState.FINISHED:
                     finished = True
-
-            current_time = TimestampUtil.add_10_seconds(current_time)
 
             current_time = TimestampUtil.add_10_seconds(current_time)
 

--- a/src/riot_scraper/scrapers/game_analysis_scraper.py
+++ b/src/riot_scraper/scrapers/game_analysis_scraper.py
@@ -69,6 +69,16 @@ class GameAnalysisScraper:
         logger.info(f"Game {game_id} analysis complete")
 
     def _fetch_all_frames(self, game_id: RiotGameID) -> list[WindowFrame] | None:
+        # Check the latest available frames first — if no FINISHED frame exists, bail early
+        latest_time = TimestampUtil.round_current_time_to_10_seconds()
+        latest_window = self.api.get_game_window(game_id, latest_time)
+        if latest_window is None:
+            return None
+        has_finished = any(f.gameState == LiveGameState.FINISHED for f in latest_window.frames)
+        if not has_finished:
+            logger.warning(f"Game {game_id}: no FINISHED frame in latest window, skipping")
+            return None
+
         initial_window = self.api.get_game_window(game_id)
         if initial_window is None:
             return None
@@ -78,19 +88,11 @@ class GameAnalysisScraper:
         start_time = TimestampUtil.round_to_10_seconds(initial_window.frames[0].rfc460Timestamp)
         current_time = start_time
         finished = False
-        last_timestamp = None
 
         while not finished:
             window = self.api.get_game_window(game_id, current_time)
             if window is None:
                 break
-
-            # Detect stale data: if the API keeps returning the same frames, stop
-            newest_timestamp = window.frames[-1].rfc460Timestamp
-            if newest_timestamp == last_timestamp:
-                logger.warning(f"Game {game_id}: API stopped advancing at {newest_timestamp}")
-                return None
-            last_timestamp = newest_timestamp
 
             for frame in window.frames:
                 all_frames.append(frame)

--- a/tests/riot_scraper/test_game_analysis_scraper.py
+++ b/tests/riot_scraper/test_game_analysis_scraper.py
@@ -152,6 +152,7 @@ class TestGameAnalysisScraper(TestBase):
 
         # API returns all frames in one window call, then None for subsequent
         self.mock_api.get_game_window.side_effect = [
+            _make_window_response(game_id, frames),  # latest window check (has FINISHED)
             _make_window_response(game_id, frames),  # initial call (no timestamp)
             _make_window_response(game_id, frames),  # call with rounded timestamp
             None,  # subsequent call returns None
@@ -186,6 +187,26 @@ class TestGameAnalysisScraper(TestBase):
         game_id = self._create_pending_game("game-no-data-001")
 
         self.mock_api.get_game_window.return_value = None
+
+        self.scraper.analyze_games()
+
+        from src.db.models import GameModel
+
+        with self.db_provider.get_db() as session:
+            gm = session.query(GameModel).filter(GameModel.id == game_id).first()
+            self.assertEqual("unavailable", gm.frames_status)
+
+    def test_marks_unavailable_when_latest_window_has_no_finished_frame(self):
+        """If the latest window has no FINISHED frame, the game data is incomplete."""
+        game_id = self._create_pending_game("game-no-finished-001")
+
+        # Latest window returns frames but none are FINISHED
+        incomplete_frames = [
+            _make_frame("2024-01-01T00:30:00.000Z", blue_kills=[5, 3, 2, 1, 0]),
+        ]
+        self.mock_api.get_game_window.return_value = _make_window_response(
+            game_id, incomplete_frames
+        )
 
         self.scraper.analyze_games()
 


### PR DESCRIPTION
## Problem

Game `113475798006664624` caused the analysis job to loop for 3+ hours, exhausting server resources (SSH unresponsive, Cloudflare 1033). The Riot API has incomplete data for this game — it never returns a FINISHED frame.

## Fix

Before walking all frames from start to finish, fetch the latest available window (using `round_current_time_to_10_seconds`, same pattern as the player stats scraper) and check if it contains a FINISHED frame. If not, the game data is incomplete — mark `frames_status = 'unavailable'` immediately without walking.

Also fixes a duplicate `add_10_seconds` call that was advancing 20s per iteration instead of 10.

## After merging

```sql
UPDATE games SET frames_status = 'unavailable'
WHERE id = '113475798006664624';
```