### PR TITLE
Riot Browsing: API infrastructure & player response enrichment

### DIFF
--- a/src/common/schemas/riot_data_schemas.py
+++ b/src/common/schemas/riot_data_schemas.py
@@ -255,6 +255,8 @@ class ProfessionalPlayer(BaseModel):
         description="The id of the team that the player is on",
         examples=["98767991853197861"],
     )
+    team_name: str | None = Field(default=None, description="The name of the team", examples=["T1"])
+    team_code: str | None = Field(default=None, description="The code of the team", examples=["T1"])
 
 
 class PlayerGameMetadata(BaseModel):

--- a/src/common/schemas/search_parameters.py
+++ b/src/common/schemas/search_parameters.py
@@ -6,7 +6,6 @@ from .riot_data_schemas import (
     RiotMatchID,
     RiotTournamentID,
     ProPlayerID,
-    ProTeamID,
     PlayerRole,
     TournamentStatus,
 )
@@ -15,7 +14,8 @@ from .riot_data_schemas import (
 class PlayerSearchParameters(BaseModel):
     summoner_name: str | None = None
     role: PlayerRole | None = None
-    team_id: ProTeamID | None = None
+    team_name: str | None = None
+    fantasy_available: bool | None = None
 
 
 class GameSearchParameters(BaseModel):

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -155,9 +155,11 @@ class DatabaseService:
         with self.connection_provider.get_db() as db:
             player_dao.put_player(db, player)
 
-    def get_players(self, filters: list | None = None) -> list[ProfessionalPlayer]:
+    def get_players(
+        self, filters: list | None = None, join_league: bool = False
+    ) -> list[ProfessionalPlayer]:
         with self.connection_provider.get_db() as db:
-            return player_dao.get_players(db, filters)
+            return player_dao.get_players(db, filters, join_league=join_league)
 
     def get_player_by_id(self, player_id: ProPlayerID) -> ProfessionalPlayer | None:
         with self.connection_provider.get_db() as db:

--- a/src/db/riot_dao/player_dao.py
+++ b/src/db/riot_dao/player_dao.py
@@ -1,30 +1,52 @@
+from sqlalchemy import label
+
 from src.common.schemas.riot_data_schemas import ProfessionalPlayer, ProPlayerID
-from src.db.models import ProfessionalPlayerModel
+from src.db.models import ProfessionalPlayerModel, ProfessionalTeamModel, LeagueModel
+
+
+def _player_query(session, join_league=False):
+    query = session.query(
+        ProfessionalPlayerModel.id,
+        ProfessionalPlayerModel.team_id,
+        ProfessionalPlayerModel.summoner_name,
+        ProfessionalPlayerModel.first_name,
+        ProfessionalPlayerModel.last_name,
+        ProfessionalPlayerModel.image,
+        ProfessionalPlayerModel.role,
+        label("team_name", ProfessionalTeamModel.name),
+        label("team_code", ProfessionalTeamModel.code),
+    ).join(ProfessionalTeamModel, ProfessionalPlayerModel.team_id == ProfessionalTeamModel.id)
+    if join_league:
+        query = query.join(LeagueModel, ProfessionalTeamModel.home_league_name == LeagueModel.name)
+    return query
 
 
 def put_player(session, player: ProfessionalPlayer) -> None:
-    db_player = ProfessionalPlayerModel(**player.model_dump())
+    db_player = ProfessionalPlayerModel(
+        id=player.id,
+        team_id=player.team_id,
+        summoner_name=player.summoner_name,
+        first_name=player.first_name,
+        last_name=player.last_name,
+        image=player.image,
+        role=player.role,
+    )
     session.merge(db_player)
     session.commit()
 
 
-def get_players(session, filters: list | None = None) -> list[ProfessionalPlayer]:
+def get_players(
+    session, filters: list | None = None, join_league: bool = False
+) -> list[ProfessionalPlayer]:
+    query = _player_query(session, join_league=join_league)
     if filters:
-        query = session.query(ProfessionalPlayerModel).filter(*filters)
-    else:
-        query = session.query(ProfessionalPlayerModel)
-    db_players: list[ProfessionalPlayer] = query.all()
-    players = [ProfessionalPlayer.model_validate(player_model) for player_model in db_players]
-    return players
+        query = query.filter(*filters)
+    rows = query.all()
+    return [ProfessionalPlayer.model_validate(row) for row in rows]
 
 
 def get_player_by_id(session, player_id: ProPlayerID) -> ProfessionalPlayer | None:
-    db_player: ProfessionalPlayerModel | None = (
-        session.query(ProfessionalPlayerModel)
-        .filter(ProfessionalPlayerModel.id == player_id)
-        .first()
-    )
-    if db_player is None:
+    row = _player_query(session).filter(ProfessionalPlayerModel.id == player_id).first()
+    if row is None:
         return None
-    else:
-        return ProfessionalPlayer.model_validate(db_player)
+    return ProfessionalPlayer.model_validate(row)

--- a/src/riot/endpoints/professional_player_endpoint_v1.py
+++ b/src/riot/endpoints/professional_player_endpoint_v1.py
@@ -7,7 +7,6 @@ from src.common.schemas.riot_data_schemas import (
     ProfessionalPlayer,
     PlayerRole,
     ProPlayerID,
-    ProTeamID,
 )
 from src.common.schemas.search_parameters import PlayerSearchParameters
 from src.riot.service import RiotProfessionalPlayerService
@@ -36,10 +35,14 @@ class ProfessionalPlayerEndpoint(Routable):
         self,
         summoner_name: str = Query(None, description="Filter by players summoner name"),
         role: PlayerRole = Depends(validate_role_parameter),
-        team_id: ProTeamID = Query(None, description="Filter by players team id"),
+        team_name: str = Query(None, description="Filter by team name (partial, case-insensitive)"),
+        fantasy_available: bool = Query(None, description="Filter by fantasy league availability"),
     ) -> Page[ProfessionalPlayer]:
         search_params = PlayerSearchParameters(
-            summoner_name=summoner_name, role=role, team_id=team_id
+            summoner_name=summoner_name,
+            role=role,
+            team_name=team_name,
+            fantasy_available=fantasy_available,
         )
         players = self.__player_service.get_players(search_params)
         return paginate(players)

--- a/src/riot/service/riot_professional_player_service.py
+++ b/src/riot/service/riot_professional_player_service.py
@@ -15,14 +15,22 @@ class RiotProfessionalPlayerService:
 
     def get_players(self, search_parameters: PlayerSearchParameters) -> list[ProfessionalPlayer]:
         filters = []
+        join_league = False
         if search_parameters.summoner_name is not None:
             filters.append(ProfessionalPlayerModel.summoner_name == search_parameters.summoner_name)
-        if search_parameters.team_id is not None:
-            filters.append(ProfessionalPlayerModel.team_id == search_parameters.team_id)
+        if search_parameters.team_name is not None:
+            from src.db.models import ProfessionalTeamModel
+
+            filters.append(ProfessionalTeamModel.name.ilike(f"%{search_parameters.team_name}%"))
         if search_parameters.role is not None:
             filters.append(ProfessionalPlayerModel.role == search_parameters.role)
+        if search_parameters.fantasy_available is not None:
+            from src.db.models import LeagueModel
 
-        professional_players = self.db.get_players(filters)
+            join_league = True
+            filters.append(LeagueModel.fantasy_available == search_parameters.fantasy_available)
+
+        professional_players = self.db.get_players(filters, join_league=join_league)
         return professional_players
 
     def get_player_by_id(self, professional_player_id: ProPlayerID) -> ProfessionalPlayer:

--- a/tests/riot/integration/service/test_professional_player_service.py
+++ b/tests/riot/integration/service/test_professional_player_service.py
@@ -28,6 +28,21 @@ class ProfessionalPlayerServiceTest(TestBase):
         self.assertEqual(1, len(players_from_db))
         self.assertEqual(expected_player, players_from_db[0])
 
+    def test_player_response_includes_team_name_and_code(self):
+        # Arrange
+        expected_player = riot_fixtures.player_1_fixture
+        self.db.put_player(expected_player)
+        search_parameters = PlayerSearchParameters()
+
+        # Act
+        players_from_db = self.professional_player_service.get_players(search_parameters)
+
+        # Assert
+        self.assertEqual(1, len(players_from_db))
+        player = players_from_db[0]
+        self.assertEqual(riot_fixtures.team_1_fixture.name, player.team_name)
+        self.assertEqual(riot_fixtures.team_1_fixture.code, player.team_code)
+
     def test_get_no_existing_professional_players_by_summoner_name(self):
         # Arrange
         expected_player = riot_fixtures.player_1_fixture
@@ -72,7 +87,7 @@ class ProfessionalPlayerServiceTest(TestBase):
         # Arrange
         expected_player = riot_fixtures.player_1_fixture
         self.db.put_player(expected_player)
-        search_parameters = PlayerSearchParameters(team_id=expected_player.team_id)
+        search_parameters = PlayerSearchParameters(team_name=riot_fixtures.team_1_fixture.name)
 
         # Act
         players_from_db = self.professional_player_service.get_players(search_parameters)
@@ -80,13 +95,13 @@ class ProfessionalPlayerServiceTest(TestBase):
         # Assert
         self.assertIsInstance(players_from_db, list)
         self.assertEqual(1, len(players_from_db))
-        self.assertEqual(expected_player, players_from_db[0])
+        self.assertEqual(expected_player.id, players_from_db[0].id)
 
     def test_get_no_existing_professional_players_by_team_id(self):
         # Arrange
         expected_player = riot_fixtures.player_1_fixture
         self.db.put_player(expected_player)
-        search_parameters = PlayerSearchParameters(team_id="777")
+        search_parameters = PlayerSearchParameters(team_name="Nonexistent Team")
 
         # Act
         players_from_db = self.professional_player_service.get_players(search_parameters)
@@ -94,6 +109,47 @@ class ProfessionalPlayerServiceTest(TestBase):
         # Assert
         self.assertIsInstance(players_from_db, list)
         self.assertEqual(0, len(players_from_db))
+
+    def test_team_name_filter_is_case_insensitive_partial_match(self):
+        # Arrange
+        expected_player = riot_fixtures.player_1_fixture
+        self.db.put_player(expected_player)
+        # Use lowercase partial match of team name
+        partial = riot_fixtures.team_1_fixture.name[:4].lower()
+        search_parameters = PlayerSearchParameters(team_name=partial)
+
+        # Act
+        players_from_db = self.professional_player_service.get_players(search_parameters)
+
+        # Assert
+        self.assertEqual(1, len(players_from_db))
+        self.assertEqual(expected_player.id, players_from_db[0].id)
+
+    def test_fantasy_available_filter_returns_only_players_in_fantasy_leagues(self):
+        # Arrange
+        # league_1 has fantasy_available=False, league_2 has fantasy_available=True
+        league_2 = riot_fixtures.league_2_fixture
+        self.db.put_league(league_2)
+
+        # team_1 is in league_1 (not fantasy), team_2's home_league matches league_2
+        team_2 = riot_fixtures.team_2_fixture.model_copy(deep=True)
+        team_2.home_league_name = league_2.name
+        self.db.put_team(team_2)
+
+        player_in_fantasy = riot_fixtures.player_6_fixture
+        self.db.put_player(player_in_fantasy)
+
+        player_not_in_fantasy = riot_fixtures.player_1_fixture
+        self.db.put_player(player_not_in_fantasy)
+
+        search_parameters = PlayerSearchParameters(fantasy_available=True)
+
+        # Act
+        players_from_db = self.professional_player_service.get_players(search_parameters)
+
+        # Assert
+        self.assertEqual(1, len(players_from_db))
+        self.assertEqual(player_in_fantasy.id, players_from_db[0].id)
 
     def test_get_professional_player_by_id(self):
         # Arrange

--- a/tests/riot/unit/riot_endpoints/test_professional_player_endpoint_v1.py
+++ b/tests/riot/unit/riot_endpoints/test_professional_player_endpoint_v1.py
@@ -16,9 +16,9 @@ class TestProfessionalPlayerEndpointV1:
         [
             ("summoner_name", lambda p: p.summoner_name),
             ("role", lambda p: p.role.value),
-            ("team_id", lambda p: p.team_id),
+            ("team_name", lambda p: p.team_name),
         ],
-        ids=["summoner_name", "role", "team_id"],
+        ids=["summoner_name", "role", "team_name"],
     )
     def test_get_players_by_filter(self, create_endpoint_client, param, value_fn):
         client, mock = create_endpoint_client(ProfessionalPlayerEndpoint)

--- a/tests/test_util/riot_fixtures.py
+++ b/tests/test_util/riot_fixtures.py
@@ -211,6 +211,8 @@ player_1_fixture = schemas.ProfessionalPlayer(
     image="http://mocked-player-1.png",
     role=PlayerRole.TOP,
     team_id=team_1_fixture.id,
+    team_name=team_1_fixture.name,
+    team_code=team_1_fixture.code,
 )
 
 player_2_fixture = schemas.ProfessionalPlayer(
@@ -219,6 +221,8 @@ player_2_fixture = schemas.ProfessionalPlayer(
     image="http://mocked-player-2.png",
     role=PlayerRole.JUNGLE,
     team_id=team_1_fixture.id,
+    team_name=team_1_fixture.name,
+    team_code=team_1_fixture.code,
 )
 
 player_3_fixture = schemas.ProfessionalPlayer(
@@ -227,6 +231,8 @@ player_3_fixture = schemas.ProfessionalPlayer(
     image="http://mocked-player-3.png",
     role=PlayerRole.MID,
     team_id=team_1_fixture.id,
+    team_name=team_1_fixture.name,
+    team_code=team_1_fixture.code,
 )
 
 player_4_fixture = schemas.ProfessionalPlayer(
@@ -235,6 +241,8 @@ player_4_fixture = schemas.ProfessionalPlayer(
     image="http://mocked-player-4.png",
     role=PlayerRole.BOTTOM,
     team_id=team_1_fixture.id,
+    team_name=team_1_fixture.name,
+    team_code=team_1_fixture.code,
 )
 
 player_5_fixture = schemas.ProfessionalPlayer(
@@ -243,6 +251,8 @@ player_5_fixture = schemas.ProfessionalPlayer(
     image="http://mocked-player-5.png",
     role=PlayerRole.SUPPORT,
     team_id=team_1_fixture.id,
+    team_name=team_1_fixture.name,
+    team_code=team_1_fixture.code,
 )
 
 player_6_fixture = schemas.ProfessionalPlayer(
@@ -251,6 +261,8 @@ player_6_fixture = schemas.ProfessionalPlayer(
     image="http://mocked-player-6.png",
     role=PlayerRole.TOP,
     team_id=team_2_fixture.id,
+    team_name=team_2_fixture.name,
+    team_code=team_2_fixture.code,
 )
 
 player_7_fixture = schemas.ProfessionalPlayer(
@@ -259,6 +271,8 @@ player_7_fixture = schemas.ProfessionalPlayer(
     image="http://mocked-player-7.png",
     role=PlayerRole.JUNGLE,
     team_id=team_2_fixture.id,
+    team_name=team_2_fixture.name,
+    team_code=team_2_fixture.code,
 )
 
 player_8_fixture = schemas.ProfessionalPlayer(
@@ -267,6 +281,8 @@ player_8_fixture = schemas.ProfessionalPlayer(
     image="http://mocked-player-8.png",
     role=PlayerRole.MID,
     team_id=team_2_fixture.id,
+    team_name=team_2_fixture.name,
+    team_code=team_2_fixture.code,
 )
 
 player_9_fixture = schemas.ProfessionalPlayer(
@@ -275,6 +291,8 @@ player_9_fixture = schemas.ProfessionalPlayer(
     image="http://mocked-player-9.png",
     role=PlayerRole.BOTTOM,
     team_id=team_2_fixture.id,
+    team_name=team_2_fixture.name,
+    team_code=team_2_fixture.code,
 )
 
 player_10_fixture = schemas.ProfessionalPlayer(
@@ -283,6 +301,8 @@ player_10_fixture = schemas.ProfessionalPlayer(
     image="http://mocked-player-10.png",
     role=PlayerRole.SUPPORT,
     team_id=team_2_fixture.id,
+    team_name=team_2_fixture.name,
+    team_code=team_2_fixture.code,
 )
 
 player_1_game_metadata_fixture = schemas.PlayerGameMetadata(

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -1,5 +1,13 @@
 import axios from 'axios'
 
+export interface PaginatedResponse<T> {
+  items: T[]
+  total: number
+  page: number
+  size: number
+  pages: number
+}
+
 export const api = axios.create({
   baseURL: '/api/v1',
 })

--- a/ui/src/api/riotApi.ts
+++ b/ui/src/api/riotApi.ts
@@ -1,0 +1,41 @@
+import { api, type PaginatedResponse } from './client'
+import type { ProfessionalPlayer, ProfessionalTeam, Match } from '../types/riot'
+
+export interface PlayerParams {
+  page?: number
+  size?: number
+  summoner_name?: string
+  role?: string
+  team_name?: string
+  fantasy_available?: boolean
+}
+
+export interface TeamParams {
+  page?: number
+  size?: number
+  name?: string
+  code?: string
+  status?: string
+}
+
+export interface MatchParams {
+  page?: number
+  size?: number
+  league_slug?: string
+  tournament_id?: string
+}
+
+export async function getPlayers(params: PlayerParams = {}): Promise<PaginatedResponse<ProfessionalPlayer>> {
+  const res = await api.get<PaginatedResponse<ProfessionalPlayer>>('/professional-player', { params })
+  return res.data
+}
+
+export async function getTeams(params: TeamParams = {}): Promise<PaginatedResponse<ProfessionalTeam>> {
+  const res = await api.get<PaginatedResponse<ProfessionalTeam>>('/professional-team', { params })
+  return res.data
+}
+
+export async function getMatches(params: MatchParams = {}): Promise<PaginatedResponse<Match>> {
+  const res = await api.get<PaginatedResponse<Match>>('/match', { params })
+  return res.data
+}

--- a/ui/src/composables/usePaginatedQuery.ts
+++ b/ui/src/composables/usePaginatedQuery.ts
@@ -1,0 +1,67 @@
+import { ref, watch, type Ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import type { PaginatedResponse } from '../api/client'
+
+type ApiFn<T> = (params: Record<string, unknown>) => Promise<PaginatedResponse<T>>
+
+export function usePaginatedQuery<T>(apiFn: ApiFn<T>, filters: Ref<Record<string, string | undefined>>) {
+  const route = useRoute()
+  const router = useRouter()
+
+  const data = ref<T[]>([]) as Ref<T[]>
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const totalPages = ref(0)
+  const currentPage = ref(Number(route.query.page) || 1)
+  const pageSize = ref(Number(route.query.size) || 20)
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+  async function fetch() {
+    loading.value = true
+    error.value = null
+    try {
+      const params: Record<string, unknown> = {
+        page: currentPage.value,
+        size: pageSize.value,
+      }
+      for (const [key, val] of Object.entries(filters.value)) {
+        if (val) params[key] = val
+      }
+      const result = await apiFn(params)
+      data.value = result.items
+      totalPages.value = result.pages
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Request failed'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function syncToUrl() {
+    const query: Record<string, string> = { page: String(currentPage.value), size: String(pageSize.value) }
+    for (const [key, val] of Object.entries(filters.value)) {
+      if (val) query[key] = val
+    }
+    router.replace({ query })
+  }
+
+  watch([currentPage, pageSize], () => {
+    syncToUrl()
+    fetch()
+  })
+
+  watch(filters, () => {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => {
+      currentPage.value = 1
+      syncToUrl()
+      fetch()
+    }, 300)
+  }, { deep: true })
+
+  // Initial fetch
+  fetch()
+
+  return { data, loading, error, totalPages, currentPage, pageSize }
+}

--- a/ui/src/types/riot.ts
+++ b/ui/src/types/riot.ts
@@ -58,6 +58,8 @@ export interface ProfessionalPlayer {
   image: string
   role: PlayerRole
   team_id: string
+  team_name: string | null
+  team_code: string | null
 }
 
 export interface PlayerGameData {


### PR DESCRIPTION
## Summary

Builds the shared frontend API infrastructure and enriches the backend player endpoint with team name/code. Part of #432.

## Backend Changes

- **ProfessionalPlayer schema**: added `team_name` and `team_code` fields
- **Player DAO**: joins with `professional_teams` table to populate team fields
- **Player endpoint**: replaced `team_id` query param with `team_name` (case-insensitive partial match via `ilike`)
- **Search params**: `team_id` removed, `team_name` added

## Frontend Changes

- **`api/client.ts`**: `PaginatedResponse<T>` type
- **`api/riotApi.ts`**: typed functions for `getPlayers`, `getTeams`, `getMatches`
- **`composables/usePaginatedQuery.ts`**: syncs page/size/filters to URL query params, 300ms debounce on filter changes
- **`types/riot.ts`**: added `team_name`, `team_code` to `ProfessionalPlayer`

## Verified

- `ruff check` + `ruff format --check` pass
- `vue-tsc -b && vite build` pass
- 523 tests pass (2 pre-existing failures unrelated)

Closes #433