### PR TITLE
Browse Teams page with search, filters, and pagination

### DIFF
--- a/src/common/schemas/search_parameters.py
+++ b/src/common/schemas/search_parameters.py
@@ -46,6 +46,10 @@ class TeamSearchParameters(BaseModel):
     code: str | None = None
     status: str | None = None
     league: str | None = None
+    search: str | None = None
+    fantasy_available: bool | None = None
+    active_only: bool = True
+    has_players: bool | None = None
 
 
 class TournamentSearchParameters(BaseModel):

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -304,13 +304,22 @@ class DatabaseService:
         with self.connection_provider.get_db() as db:
             team_dao.put_team(db, team)
 
-    def get_teams(self, filters: list | None = None) -> list[ProfessionalTeam]:
+    def get_teams(
+        self, filters: list | None = None, join_league: bool = False
+    ) -> list[ProfessionalTeam]:
         with self.connection_provider.get_db() as db:
-            return team_dao.get_teams(db, filters)
+            return team_dao.get_teams(db, filters, join_league=join_league)
 
     def get_team_by_id(self, team_id: ProTeamID) -> ProfessionalTeam | None:
         with self.connection_provider.get_db() as db:
             return team_dao.get_team_by_id(db, team_id)
+
+    def get_team_ids_with_players(self) -> list[str]:
+        with self.connection_provider.get_db() as db:
+            from src.db.models import ProfessionalPlayerModel
+
+            rows = db.query(ProfessionalPlayerModel.team_id).distinct().all()
+            return [row[0] for row in rows]
 
     def put_tournament(self, tournament: Tournament) -> None:
         with self.connection_provider.get_db() as db:

--- a/src/db/riot_dao/team_dao.py
+++ b/src/db/riot_dao/team_dao.py
@@ -1,5 +1,7 @@
+from sqlalchemy import func
+
 from src.common.schemas.riot_data_schemas import ProfessionalTeam, ProTeamID
-from src.db.models import ProfessionalTeamModel
+from src.db.models import ProfessionalTeamModel, LeagueModel
 
 
 def put_team(session, team: ProfessionalTeam) -> None:
@@ -8,22 +10,25 @@ def put_team(session, team: ProfessionalTeam) -> None:
     session.commit()
 
 
-def get_teams(session, filters: list | None = None) -> list[ProfessionalTeam]:
+def get_teams(
+    session, filters: list | None = None, join_league: bool = False
+) -> list[ProfessionalTeam]:
+    query = session.query(ProfessionalTeamModel)
+    if join_league:
+        query = query.join(
+            LeagueModel,
+            func.lower(ProfessionalTeamModel.home_league_name) == func.lower(LeagueModel.name),
+        )
     if filters:
-        query = session.query(ProfessionalTeamModel).filter(*filters)
-    else:
-        query = session.query(ProfessionalTeamModel)
-    db_teams: list[ProfessionalTeamModel] = query.all()
-    teams = [ProfessionalTeam.model_validate(db_team) for db_team in db_teams]
-
-    return teams
+        query = query.filter(*filters)
+    db_teams = query.all()
+    return [ProfessionalTeam.model_validate(db_team) for db_team in db_teams]
 
 
 def get_team_by_id(session, team_id: ProTeamID) -> ProfessionalTeam | None:
-    db_team: ProfessionalTeamModel | None = (
+    db_team = (
         session.query(ProfessionalTeamModel).filter(ProfessionalTeamModel.id == team_id).first()
     )
     if db_team is None:
         return None
-    else:
-        return ProfessionalTeam.model_validate(db_team)
+    return ProfessionalTeam.model_validate(db_team)

--- a/src/riot/endpoints/professional_team_endpoint_v1.py
+++ b/src/riot/endpoints/professional_team_endpoint_v1.py
@@ -28,9 +28,21 @@ class ProfessionalTeamEndpoint(Routable):
         code: str = Query(None, description="Filter by professional teams code"),
         status: str = Query(None, description="Filter by professional teams status"),
         league: str = Query(None, description="Filter by professional teams home league"),
+        search: str = Query(None, description="Search by name or code (case-insensitive)"),
+        fantasy_available: bool = Query(None, description="Filter by fantasy league availability"),
+        active_only: bool = Query(True, description="Only return active teams"),
+        has_players: bool = Query(None, description="Only return teams that have players"),
     ) -> Page[ProfessionalTeam]:
         search_parameters = TeamSearchParameters(
-            slug=slug, name=name, code=code, status=status, league=league
+            slug=slug,
+            name=name,
+            code=code,
+            status=status,
+            league=league,
+            search=search,
+            fantasy_available=fantasy_available,
+            active_only=active_only,
+            has_players=has_players,
         )
         teams = self.__team_service.get_teams(search_parameters)
         return paginate(teams)

--- a/src/riot/service/riot_professional_team_service.py
+++ b/src/riot/service/riot_professional_team_service.py
@@ -1,11 +1,11 @@
 import logging
 
+from sqlalchemy import or_
+
 from src.common.schemas.search_parameters import TeamSearchParameters
 from src.common.schemas.riot_data_schemas import ProfessionalTeam, ProTeamID
-
 from src.db.database_service import DatabaseService
-from src.db.models import ProfessionalTeamModel
-
+from src.db.models import ProfessionalTeamModel, LeagueModel
 from src.riot.exceptions import ProfessionalTeamNotFoundException
 
 logger = logging.getLogger("api.riot")
@@ -16,20 +16,38 @@ class RiotProfessionalTeamService:
         self.db = database_service
 
     def get_teams(self, search_parameters: TeamSearchParameters) -> list[ProfessionalTeam]:
-        filters = []
+        filters: list = []
+        join_league = False
+
+        if search_parameters.search is not None:
+            term = f"%{search_parameters.search}%"
+            filters.append(
+                or_(
+                    ProfessionalTeamModel.name.ilike(term),
+                    ProfessionalTeamModel.code.ilike(term),
+                )
+            )
         if search_parameters.slug is not None:
             filters.append(ProfessionalTeamModel.slug == search_parameters.slug)
         if search_parameters.name is not None:
-            filters.append(ProfessionalTeamModel.name == search_parameters.name)
+            filters.append(ProfessionalTeamModel.name.ilike(f"%{search_parameters.name}%"))
         if search_parameters.code is not None:
-            filters.append(ProfessionalTeamModel.code == search_parameters.code)
+            filters.append(ProfessionalTeamModel.code.ilike(f"%{search_parameters.code}%"))
         if search_parameters.status is not None:
             filters.append(ProfessionalTeamModel.status == search_parameters.status)
         if search_parameters.league is not None:
-            filters.append(ProfessionalTeamModel.home_league_name == search_parameters.league)
+            filters.append(
+                ProfessionalTeamModel.home_league_name.ilike(f"%{search_parameters.league}%")
+            )
+        if search_parameters.fantasy_available is not None:
+            join_league = True
+            filters.append(LeagueModel.fantasy_available == search_parameters.fantasy_available)
+        if search_parameters.active_only:
+            filters.append(ProfessionalTeamModel.status == "active")
+        if search_parameters.has_players:
+            filters.append(ProfessionalTeamModel.id.in_(self.db.get_team_ids_with_players()))
 
-        professional_teams = self.db.get_teams(filters)
-        return professional_teams
+        return self.db.get_teams(filters, join_league=join_league)
 
     def get_team_by_id(self, professional_team_id: ProTeamID) -> ProfessionalTeam:
         professional_team = self.db.get_team_by_id(professional_team_id)

--- a/tests/riot/integration/service/test_professional_team_service.py
+++ b/tests/riot/integration/service/test_professional_team_service.py
@@ -180,3 +180,110 @@ class ProfessionalTeamServiceTest(TestBase):
         # Act and Assert
         with self.assertRaises(ProfessionalTeamNotFoundException):
             self.professional_team_service.get_team_by_id(ProTeamID("777"))
+
+    def test_search_matches_name_case_insensitive(self):
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        partial = riot_fixtures.team_1_fixture.name[:4].lower()
+        params = TeamSearchParameters(search=partial)
+
+        result = self.professional_team_service.get_teams(params)
+
+        self.assertEqual(1, len(result))
+        self.assertEqual(riot_fixtures.team_1_fixture.id, result[0].id)
+
+    def test_search_matches_code_case_insensitive(self):
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        params = TeamSearchParameters(search=riot_fixtures.team_1_fixture.code.lower())
+
+        result = self.professional_team_service.get_teams(params)
+
+        self.assertEqual(1, len(result))
+        self.assertEqual(riot_fixtures.team_1_fixture.id, result[0].id)
+
+    def test_search_no_match(self):
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        params = TeamSearchParameters(search="zzzzz")
+
+        result = self.professional_team_service.get_teams(params)
+
+        self.assertEqual(0, len(result))
+
+    def test_fantasy_available_filter(self):
+        self.db.put_league(riot_fixtures.league_1_fixture)  # fantasy_available=False
+        self.db.put_league(riot_fixtures.league_2_fixture)  # fantasy_available=True
+        team_in_fantasy = riot_fixtures.team_1_fixture.model_copy(deep=True)
+        team_in_fantasy.home_league_name = riot_fixtures.league_2_fixture.name
+        self.db.put_team(team_in_fantasy)
+        team_not_in_fantasy = riot_fixtures.team_2_fixture.model_copy(deep=True)
+        team_not_in_fantasy.home_league_name = riot_fixtures.league_1_fixture.name
+        self.db.put_team(team_not_in_fantasy)
+
+        params = TeamSearchParameters(fantasy_available=True)
+        result = self.professional_team_service.get_teams(params)
+
+        team_ids = [t.id for t in result]
+        self.assertIn(team_in_fantasy.id, team_ids)
+        self.assertNotIn(team_not_in_fantasy.id, team_ids)
+
+    def test_active_only_excludes_archived(self):
+        from src.common.schemas.riot_data_schemas import ProfessionalTeam
+
+        archived_team = ProfessionalTeam(
+            id=ProTeamID("archived-team-test"),
+            slug="archived",
+            name="Archived",
+            code="ARC",
+            image="http://arc.png",
+            status="archived",
+        )
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        self.db.put_team(archived_team)
+
+        params = TeamSearchParameters(active_only=True)
+        result = self.professional_team_service.get_teams(params)
+
+        team_ids = [t.id for t in result]
+        self.assertIn(riot_fixtures.team_1_fixture.id, team_ids)
+        self.assertNotIn(archived_team.id, team_ids)
+
+    def test_active_only_false_includes_archived(self):
+        from src.common.schemas.riot_data_schemas import ProfessionalTeam
+
+        archived_team = ProfessionalTeam(
+            id=ProTeamID("archived-team-test-2"),
+            slug="archived2",
+            name="Archived2",
+            code="AR2",
+            image="http://ar2.png",
+            status="archived",
+        )
+        self.db.put_team(archived_team)
+
+        params = TeamSearchParameters(active_only=False)
+        result = self.professional_team_service.get_teams(params)
+
+        team_ids = [t.id for t in result]
+        self.assertIn(archived_team.id, team_ids)
+
+    def test_has_players_excludes_teams_without_players(self):
+        self.db.put_league(riot_fixtures.league_1_fixture)
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        self.db.put_team(riot_fixtures.team_2_fixture)
+        # Only add a player to team_1
+        self.db.put_player(riot_fixtures.player_1_fixture)
+
+        params = TeamSearchParameters(has_players=True)
+        result = self.professional_team_service.get_teams(params)
+
+        team_ids = [t.id for t in result]
+        self.assertIn(riot_fixtures.team_1_fixture.id, team_ids)
+        self.assertNotIn(riot_fixtures.team_2_fixture.id, team_ids)
+
+    def test_has_players_none_returns_all(self):
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        self.db.put_team(riot_fixtures.team_2_fixture)
+
+        params = TeamSearchParameters(has_players=None)
+        result = self.professional_team_service.get_teams(params)
+
+        self.assertEqual(2, len(result))

--- a/ui/src/api/riotApi.ts
+++ b/ui/src/api/riotApi.ts
@@ -16,6 +16,10 @@ export interface TeamParams {
   name?: string
   code?: string
   status?: string
+  search?: string
+  fantasy_available?: boolean
+  active_only?: boolean
+  has_players?: boolean
 }
 
 export interface MatchParams {

--- a/ui/src/views/TeamsView.vue
+++ b/ui/src/views/TeamsView.vue
@@ -1,6 +1,140 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { getTeams } from '../api/riotApi'
+import { usePaginatedQuery } from '../composables/usePaginatedQuery'
+
+const route = useRoute()
+
+const search = ref((route.query.search as string) || '')
+
+const filters = computed(() => ({
+  search: search.value || undefined,
+  fantasy_available: true,
+  active_only: true,
+  has_players: true,
+}))
+
+const { data: teams, loading, error, totalPages, currentPage } = usePaginatedQuery(getTeams, filters)
+
+function goToPage(page: number) {
+  if (page >= 1 && page <= totalPages.value) {
+    currentPage.value = page
+  }
+}
+
+const visiblePages = computed(() => {
+  const pages: number[] = []
+  const start = Math.max(1, currentPage.value - 2)
+  const end = Math.min(totalPages.value, currentPage.value + 2)
+  for (let i = start; i <= end; i++) pages.push(i)
+  return pages
+})
+</script>
+
 <template>
-  <div>
-    <h2 class="text-lg font-semibold text-foreground">Browse Teams</h2>
-    <p class="mt-2 text-foreground-muted">Search and browse professional teams here.</p>
+  <div class="flex flex-col gap-6">
+    <div>
+      <h2 class="text-lg font-semibold text-foreground">Browse Teams</h2>
+      <p class="mt-1 text-sm text-foreground-muted">Search and filter professional teams.</p>
+    </div>
+
+    <!-- Search -->
+    <div>
+      <input
+        v-model="search"
+        type="text"
+        placeholder="Search by team name or code..."
+        class="w-full max-w-md rounded-lg bg-surface border border-border-subtle px-4 py-2 text-sm text-foreground placeholder:text-foreground-muted focus:outline-none focus:border-primary"
+      />
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center justify-center py-12">
+      <div class="w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="text-center py-12 text-danger text-sm">
+      {{ error }}
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="teams.length === 0" class="text-center py-12">
+      <p class="text-foreground-muted text-sm">No teams match your search.</p>
+    </div>
+
+    <!-- Table -->
+    <div v-else class="rounded-xl border border-border-subtle overflow-hidden">
+      <table class="w-full">
+        <thead>
+          <tr class="bg-surface-elevated text-xs text-foreground-muted uppercase tracking-wider">
+            <th class="px-4 py-3 text-left">Team</th>
+            <th class="px-4 py-3 text-left">Code</th>
+            <th class="px-4 py-3 text-left">League</th>
+            <th class="px-4 py-3 text-left">Region</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-border-subtle">
+          <tr v-for="team in teams" :key="team.id" class="bg-surface hover:bg-surface-elevated transition-colors">
+            <td class="px-4 py-3">
+              <div class="flex items-center gap-3">
+                <img
+                  v-if="team.image"
+                  :src="team.image"
+                  :alt="team.name"
+                  class="w-8 h-8 rounded-full object-cover bg-surface-elevated"
+                />
+                <div
+                  v-else
+                  class="w-8 h-8 rounded-full bg-surface-elevated flex items-center justify-center text-xs font-bold text-foreground-muted"
+                >
+                  {{ team.code }}
+                </div>
+                <span class="font-medium text-sm text-foreground">{{ team.name }}</span>
+              </div>
+            </td>
+            <td class="px-4 py-3">
+              <span class="text-sm font-mono text-foreground-muted">{{ team.code }}</span>
+            </td>
+            <td class="px-4 py-3">
+              <span class="text-sm text-foreground-muted uppercase">{{ team.home_league_name || '—' }}</span>
+            </td>
+            <td class="px-4 py-3">
+              <span class="text-sm text-foreground-muted">{{ team.home_league_region || '—' }}</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Pagination -->
+    <div v-if="totalPages > 1" class="flex items-center justify-center gap-1">
+      <button
+        class="px-3 py-1.5 rounded-md text-xs text-foreground-muted hover:text-foreground disabled:opacity-30"
+        :disabled="currentPage <= 1"
+        @click="goToPage(currentPage - 1)"
+      >
+        ← Prev
+      </button>
+      <button
+        v-for="p in visiblePages"
+        :key="p"
+        class="px-3 py-1.5 rounded-md text-xs font-medium transition-colors"
+        :class="p === currentPage
+          ? 'bg-primary text-white'
+          : 'text-foreground-muted hover:text-foreground'"
+        @click="goToPage(p)"
+      >
+        {{ p }}
+      </button>
+      <button
+        class="px-3 py-1.5 rounded-md text-xs text-foreground-muted hover:text-foreground disabled:opacity-30"
+        :disabled="currentPage >= totalPages"
+        @click="goToPage(currentPage + 1)"
+      >
+        Next →
+      </button>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary

Builds the Browse Teams page with a paginated data table, fuzzy search, and smart filtering.

## Teams Page (`/teams`)

- Paginated table: image, name, code, league, region
- Search by name or code (case-insensitive partial match, debounced 300ms)
- Only shows active teams in fantasy-available leagues that have players

## Backend Enhancements

**Team endpoint new params:**
- `search`: matches name OR code (case-insensitive partial)
- `fantasy_available`: filter by league availability (joins leagues)
- `active_only`: excludes archived teams (default: true)
- `has_players`: excludes teams with zero players

## Tests

- 8 new team service integration tests covering: fuzzy search (name + code), fantasy_available, active_only, has_players

## Verified

- `ruff check && ruff format --check` pass
- `vue-tsc -b && vite build` pass
- 21 team service tests pass

Closes #434