### PR TITLE
Fix match completion flow: unneeded games, frames_status, game_wins

### DIFF
--- a/src/common/schemas/riot_data_schemas.py
+++ b/src/common/schemas/riot_data_schemas.py
@@ -420,6 +420,7 @@ class ScheduleMatch(BaseModel):
 class DetailTeam(BaseModel):
     team_id: ProTeamID
     team_code: str
+    game_wins: int | None = None
 
 
 class DetailGame(BaseModel):

--- a/src/db/riot_dao/match_dao.py
+++ b/src/db/riot_dao/match_dao.py
@@ -153,16 +153,32 @@ def save_from_details(session, details: MatchDetails) -> None:
             )
             if existing_team is not None:
                 et.team_id = team.team_id
-                session.merge(et)
+            if team.game_wins is not None:
+                et.game_wins = team.game_wins
+                # Derive outcome: team with more wins in a completed match wins
+                max_wins = max((t.game_wins or 0) for t in details.teams)
+                if max_wins > 0:
+                    et.outcome = "win" if team.game_wins == max_wins else "loss"
+            session.merge(et)
 
     for game in details.games:
-        db_game = GameModel(
-            id=game.id,
-            state=game.state,
-            number=game.number,
-            match_id=details.match_id,
-        )
-        session.merge(db_game)
+        existing_game = session.query(GameModel).filter(GameModel.id == game.id).first()
+        if existing_game is not None:
+            existing_game.state = game.state
+            existing_game.number = game.number
+            if game.state == "completed" and existing_game.frames_status is None:
+                if existing_game.details_status != "unavailable":
+                    existing_game.frames_status = "pending"
+            session.merge(existing_game)
+        else:
+            new_game = GameModel(
+                id=game.id,
+                state=game.state,
+                number=game.number,
+                match_id=details.match_id,
+                frames_status="pending" if game.state == "completed" else None,
+            )
+            session.merge(new_game)
 
     session.commit()
 

--- a/src/riot_scraper/scrapers/match_scraper.py
+++ b/src/riot_scraper/scrapers/match_scraper.py
@@ -102,7 +102,14 @@ class RiotMatchScraper:
                 self.db.update_match_has_games(match_id, False)
                 continue
             event = response.data.event
-            teams = [DetailTeam(team_id=t.id, team_code=t.code) for t in event.match.teams]
+            teams = [
+                DetailTeam(
+                    team_id=t.id,
+                    team_code=t.code,
+                    game_wins=t.result.gameWins if t.result else None,
+                )
+                for t in event.match.teams
+            ]
             games = [DetailGame(id=g.id, state=g.state, number=g.number) for g in event.match.games]
             details = MatchDetails(
                 match_id=match_id,
@@ -120,7 +127,14 @@ class RiotMatchScraper:
             if response is None:
                 continue
             event = response.data.event
-            teams = [DetailTeam(team_id=t.id, team_code=t.code) for t in event.match.teams]
+            teams = [
+                DetailTeam(
+                    team_id=t.id,
+                    team_code=t.code,
+                    game_wins=t.result.gameWins if t.result else None,
+                )
+                for t in event.match.teams
+            ]
             games = [DetailGame(id=g.id, state=g.state, number=g.number) for g in event.match.games]
             details = MatchDetails(
                 match_id=match_id,
@@ -132,5 +146,6 @@ class RiotMatchScraper:
             self.db.save_from_details(details)
 
             # Infer match state from game states
-            if games and all(g.state == GameState.COMPLETED for g in games):
+            terminal_states = {GameState.COMPLETED, GameState.UNNEEDED}
+            if games and all(g.state in terminal_states for g in games):
                 self.db.update_match_state(match_id, MatchState.COMPLETED)

--- a/tests/riot_scraper/test_match_scraper.py
+++ b/tests/riot_scraper/test_match_scraper.py
@@ -338,3 +338,342 @@ class TestRiotMatchScraper(TestBase):
         self.assertIsNotNone(result)
         ids_without_games = self.db.get_ids_without_games()
         self.assertNotIn(RiotMatchID("e2e-001"), ids_without_games)
+
+    def test_refresh_stale_events_marks_match_completed_with_unneeded_games(self):
+        """A Bo3 won 2-0 has game 3 as 'unneeded' — match should still be COMPLETED."""
+        from src.common.schemas.riot_data_schemas import ScheduleMatch, ScheduleTeam, Tournament
+        from tests.test_util import riot_fixtures
+        from src.riot_scraper.riot_api.schemas.get_event_details import (
+            EventDetailsResponse,
+            EventData,
+            Event,
+            EventTournament,
+            EventLeague,
+            EventMatch,
+            MatchStrategy,
+            MatchTeam,
+            MatchGame,
+            GameTeam,
+            TeamResult,
+        )
+
+        league = riot_fixtures.league_1_fixture.model_copy(deep=True)
+        league.id = RiotLeagueID("league-1")
+        league.slug = "test-league"
+        self.db.put_league(league)
+        tournament = Tournament(
+            id=RiotTournamentID("tourn-1"),
+            slug="t",
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+            league_id=league.id,
+        )
+        self.db.put_tournament(tournament)
+
+        self.db.save_from_schedule(
+            ScheduleMatch(
+                id=RiotMatchID("bo3-match-001"),
+                start_time="2020-01-01T12:00:00Z",
+                block_name="W1",
+                league_slug="test-league",
+                strategy_type="bestOf",
+                strategy_count=3,
+                state=MatchState.INPROGRESS,
+                teams=[
+                    ScheduleTeam(side=1, team_code="TA", team_name="Team A"),
+                    ScheduleTeam(side=2, team_code="TB", team_name="Team B"),
+                ],
+            )
+        )
+
+        # API returns 2 completed + 1 unneeded
+        self.mock_api.get_event_details.return_value = EventDetailsResponse(
+            data=EventData(
+                event=Event(
+                    id=RiotMatchID("bo3-match-001"),
+                    type="match",
+                    tournament=EventTournament(id=RiotTournamentID("tourn-1")),
+                    league=EventLeague(id=league.id, slug="test-league", image="", name="Test"),
+                    match=EventMatch(
+                        strategy=MatchStrategy(count=3),
+                        teams=[
+                            MatchTeam(
+                                id=ProTeamID("ta-id"),
+                                name="Team A",
+                                code="TA",
+                                image="",
+                                result=TeamResult(gameWins=2),
+                            ),
+                            MatchTeam(
+                                id=ProTeamID("tb-id"),
+                                name="Team B",
+                                code="TB",
+                                image="",
+                                result=TeamResult(gameWins=0),
+                            ),
+                        ],
+                        games=[
+                            MatchGame(
+                                number=1,
+                                id=RiotGameID("g1"),
+                                state=GameState.COMPLETED,
+                                teams=[
+                                    GameTeam(id=ProTeamID("ta-id"), side="blue"),
+                                    GameTeam(id=ProTeamID("tb-id"), side="red"),
+                                ],
+                            ),
+                            MatchGame(
+                                number=2,
+                                id=RiotGameID("g2"),
+                                state=GameState.COMPLETED,
+                                teams=[
+                                    GameTeam(id=ProTeamID("ta-id"), side="blue"),
+                                    GameTeam(id=ProTeamID("tb-id"), side="red"),
+                                ],
+                            ),
+                            MatchGame(
+                                number=3,
+                                id=RiotGameID("g3"),
+                                state=GameState.UNNEEDED,
+                                teams=[
+                                    GameTeam(id=ProTeamID("ta-id"), side="blue"),
+                                    GameTeam(id=ProTeamID("tb-id"), side="red"),
+                                ],
+                            ),
+                        ],
+                    ),
+                )
+            )
+        )
+
+        self.scraper.refresh_stale_events()
+
+        result = self.db.get_match_by_id(RiotMatchID("bo3-match-001"))
+        self.assertEqual(MatchState.COMPLETED, result.state)
+
+    def test_save_from_details_sets_frames_status_pending_for_completed_games(self):
+        """When save_from_details writes a game as completed, frames_status should be pending."""
+        from src.common.schemas.riot_data_schemas import ScheduleMatch, ScheduleTeam, Tournament
+        from tests.test_util import riot_fixtures
+        from src.riot_scraper.riot_api.schemas.get_event_details import (
+            EventDetailsResponse,
+            EventData,
+            Event,
+            EventTournament,
+            EventLeague,
+            EventMatch,
+            MatchStrategy,
+            MatchTeam,
+            MatchGame,
+            GameTeam,
+            TeamResult,
+        )
+        from src.db.models import GameModel
+
+        league = riot_fixtures.league_1_fixture.model_copy(deep=True)
+        league.id = RiotLeagueID("league-1")
+        league.slug = "test-league"
+        self.db.put_league(league)
+        tournament = Tournament(
+            id=RiotTournamentID("tourn-1"),
+            slug="t",
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+            league_id=league.id,
+        )
+        self.db.put_tournament(tournament)
+
+        self.db.save_from_schedule(
+            ScheduleMatch(
+                id=RiotMatchID("frames-test-001"),
+                start_time="2020-01-01T12:00:00Z",
+                block_name="W1",
+                league_slug="test-league",
+                strategy_type="bestOf",
+                strategy_count=1,
+                state=MatchState.INPROGRESS,
+                teams=[
+                    ScheduleTeam(side=1, team_code="TA", team_name="Team A"),
+                    ScheduleTeam(side=2, team_code="TB", team_name="Team B"),
+                ],
+            )
+        )
+
+        self.mock_api.get_event_details.return_value = EventDetailsResponse(
+            data=EventData(
+                event=Event(
+                    id=RiotMatchID("frames-test-001"),
+                    type="match",
+                    tournament=EventTournament(id=RiotTournamentID("tourn-1")),
+                    league=EventLeague(id=league.id, slug="test-league", image="", name="Test"),
+                    match=EventMatch(
+                        strategy=MatchStrategy(count=1),
+                        teams=[
+                            MatchTeam(
+                                id=ProTeamID("ta-id"),
+                                name="Team A",
+                                code="TA",
+                                image="",
+                                result=TeamResult(gameWins=1),
+                            ),
+                            MatchTeam(
+                                id=ProTeamID("tb-id"),
+                                name="Team B",
+                                code="TB",
+                                image="",
+                                result=TeamResult(gameWins=0),
+                            ),
+                        ],
+                        games=[
+                            MatchGame(
+                                number=1,
+                                id=RiotGameID("frames-g1"),
+                                state=GameState.COMPLETED,
+                                teams=[
+                                    GameTeam(id=ProTeamID("ta-id"), side="blue"),
+                                    GameTeam(id=ProTeamID("tb-id"), side="red"),
+                                ],
+                            ),
+                        ],
+                    ),
+                )
+            )
+        )
+
+        self.scraper.refresh_stale_events()
+
+        with self.db_provider.get_db() as session:
+            gm = session.query(GameModel).filter(GameModel.id == "frames-g1").first()
+            self.assertIsNotNone(gm)
+            self.assertEqual("pending", gm.frames_status)
+
+    def test_refresh_stale_events_updates_game_wins_and_outcome(self):
+        """After a match completes, event_teams should have game_wins and outcome updated."""
+        from src.common.schemas.riot_data_schemas import ScheduleMatch, ScheduleTeam, Tournament
+        from tests.test_util import riot_fixtures
+        from src.riot_scraper.riot_api.schemas.get_event_details import (
+            EventDetailsResponse,
+            EventData,
+            Event,
+            EventTournament,
+            EventLeague,
+            EventMatch,
+            MatchStrategy,
+            MatchTeam,
+            MatchGame,
+            GameTeam,
+            TeamResult,
+        )
+        from src.db.models import EventTeamsModel
+
+        league = riot_fixtures.league_1_fixture.model_copy(deep=True)
+        league.id = RiotLeagueID("league-1")
+        league.slug = "test-league"
+        self.db.put_league(league)
+        tournament = Tournament(
+            id=RiotTournamentID("tourn-1"),
+            slug="t",
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+            league_id=league.id,
+        )
+        self.db.put_tournament(tournament)
+
+        self.db.save_from_schedule(
+            ScheduleMatch(
+                id=RiotMatchID("wins-test-001"),
+                start_time="2020-01-01T12:00:00Z",
+                block_name="W1",
+                league_slug="test-league",
+                strategy_type="bestOf",
+                strategy_count=3,
+                state=MatchState.INPROGRESS,
+                teams=[
+                    ScheduleTeam(side=1, team_code="TA", team_name="Team A"),
+                    ScheduleTeam(side=2, team_code="TB", team_name="Team B"),
+                ],
+            )
+        )
+
+        self.mock_api.get_event_details.return_value = EventDetailsResponse(
+            data=EventData(
+                event=Event(
+                    id=RiotMatchID("wins-test-001"),
+                    type="match",
+                    tournament=EventTournament(id=RiotTournamentID("tourn-1")),
+                    league=EventLeague(id=league.id, slug="test-league", image="", name="Test"),
+                    match=EventMatch(
+                        strategy=MatchStrategy(count=3),
+                        teams=[
+                            MatchTeam(
+                                id=ProTeamID("ta-id"),
+                                name="Team A",
+                                code="TA",
+                                image="",
+                                result=TeamResult(gameWins=2),
+                            ),
+                            MatchTeam(
+                                id=ProTeamID("tb-id"),
+                                name="Team B",
+                                code="TB",
+                                image="",
+                                result=TeamResult(gameWins=1),
+                            ),
+                        ],
+                        games=[
+                            MatchGame(
+                                number=1,
+                                id=RiotGameID("wg1"),
+                                state=GameState.COMPLETED,
+                                teams=[
+                                    GameTeam(id=ProTeamID("ta-id"), side="blue"),
+                                    GameTeam(id=ProTeamID("tb-id"), side="red"),
+                                ],
+                            ),
+                            MatchGame(
+                                number=2,
+                                id=RiotGameID("wg2"),
+                                state=GameState.COMPLETED,
+                                teams=[
+                                    GameTeam(id=ProTeamID("ta-id"), side="blue"),
+                                    GameTeam(id=ProTeamID("tb-id"), side="red"),
+                                ],
+                            ),
+                            MatchGame(
+                                number=3,
+                                id=RiotGameID("wg3"),
+                                state=GameState.COMPLETED,
+                                teams=[
+                                    GameTeam(id=ProTeamID("ta-id"), side="blue"),
+                                    GameTeam(id=ProTeamID("tb-id"), side="red"),
+                                ],
+                            ),
+                        ],
+                    ),
+                )
+            )
+        )
+
+        self.scraper.refresh_stale_events()
+
+        with self.db_provider.get_db() as session:
+            ta = (
+                session.query(EventTeamsModel)
+                .filter(
+                    EventTeamsModel.match_id == "wins-test-001",
+                    EventTeamsModel.team_code == "TA",
+                )
+                .first()
+            )
+            tb = (
+                session.query(EventTeamsModel)
+                .filter(
+                    EventTeamsModel.match_id == "wins-test-001",
+                    EventTeamsModel.team_code == "TB",
+                )
+                .first()
+            )
+            self.assertEqual(2, ta.game_wins)
+            self.assertEqual("win", ta.outcome)
+            self.assertEqual(1, tb.game_wins)
+            self.assertEqual("loss", tb.outcome)


### PR DESCRIPTION
## Summary

Fixes three related bugs in the `refresh_stale_events` → `save_from_details` path that prevented matches from completing properly.

## Bug Fixes

### #443 — Match state never marked COMPLETED for Bo3/Bo5 won early

The completion check required ALL games to be `completed`. In a 2-0 Bo3, game 3 is `unneeded` — so the check always failed.

**Fix:** Treat `{COMPLETED, UNNEEDED}` as terminal states.

### #444 — Games set to completed via match scraper skip frame analysis

`save_from_details` wrote `state=completed` without setting `frames_status=pending`. The game analysis job never picked them up.

**Fix:** When `save_from_details` transitions a game to completed, set `frames_status=pending` (unless `details_status=unavailable`).

### #442 — `event_teams` never gets `game_wins`/`outcome` updated

`refresh_stale_events` built `DetailTeam` without result data. `save_from_details` had no game_wins to write.

**Fix:** Pass `game_wins` from the API response through `DetailTeam`. `save_from_details` now writes `game_wins` and derives `outcome` (win/loss).

## Tests

3 new integration tests covering each fix:
- Match marked COMPLETED with unneeded games
- `frames_status` set to pending via save_from_details path
- `game_wins` and `outcome` updated on event_teams

Closes #442, closes #443, closes #444