### PR TITLE
Matches schedule page: live, upcoming, and recent

### DIFF
--- a/alembic/versions/004_match_view_team_images.py
+++ b/alembic/versions/004_match_view_team_images.py
@@ -1,0 +1,73 @@
+"""Recreate match_view with team images
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-05-09
+"""
+
+from alembic import op
+
+revision = "004"
+down_revision = "003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS match_view CASCADE")
+    op.execute("""
+        CREATE OR REPLACE VIEW match_view AS
+        SELECT
+            m.id,
+            m.start_time,
+            m.block_name,
+            m.league_slug,
+            m.strategy_type,
+            m.strategy_count,
+            m.tournament_id,
+            t1.team_name AS team_1_name,
+            t2.team_name AS team_2_name,
+            m.has_games,
+            m.state,
+            t1.game_wins AS team_1_wins,
+            t2.game_wins AS team_2_wins,
+            CASE
+                WHEN t1.outcome = 'win' THEN t1.team_name
+                WHEN t2.outcome = 'win' THEN t2.team_name
+                ELSE NULL
+            END AS winning_team,
+            t1.team_image AS team_1_image,
+            t2.team_image AS team_2_image
+        FROM matches m
+        LEFT JOIN event_teams t1 ON m.id = t1.match_id AND t1.side = 1
+        LEFT JOIN event_teams t2 ON m.id = t2.match_id AND t2.side = 2
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS match_view CASCADE")
+    op.execute("""
+        CREATE OR REPLACE VIEW match_view AS
+        SELECT
+            m.id,
+            m.start_time,
+            m.block_name,
+            m.league_slug,
+            m.strategy_type,
+            m.strategy_count,
+            m.tournament_id,
+            t1.team_name AS team_1_name,
+            t2.team_name AS team_2_name,
+            m.has_games,
+            m.state,
+            t1.game_wins AS team_1_wins,
+            t2.game_wins AS team_2_wins,
+            CASE
+                WHEN t1.outcome = 'win' THEN t1.team_name
+                WHEN t2.outcome = 'win' THEN t2.team_name
+                ELSE NULL
+            END AS winning_team
+        FROM matches m
+        LEFT JOIN event_teams t1 ON m.id = t1.match_id AND t1.side = 1
+        LEFT JOIN event_teams t2 ON m.id = t2.match_id AND t2.side = 2
+    """)

--- a/src/common/config.py
+++ b/src/common/config.py
@@ -55,8 +55,8 @@ class AppConfig(BaseSettings):
         trigger="cron", hour="10", minute="05"
     )
     TEAM_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(trigger="cron", hour="10", minute="10")
-    MATCH_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(trigger="cron", minute="30")
-    GAME_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(trigger="cron", minute="45")
+    MATCH_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(trigger="cron", minute="*/15")
+    GAME_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(trigger="cron", minute="*/15")
     GAME_STATS_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(trigger="cron", minute="*/5")
     GAME_ANALYSIS_SERVICE_SCHEDULE: ScheduleConfig = ScheduleConfig(trigger="cron", minute="*/10")
 

--- a/src/common/schemas/riot_data_schemas.py
+++ b/src/common/schemas/riot_data_schemas.py
@@ -126,6 +126,8 @@ class Match(BaseModel):
     winning_team: str | None = Field(
         default=None, description="The name of the winning team for the match", examples=["T1"]
     )
+    team_1_image: str | None = Field(default=None, description="The image url of team 1")
+    team_2_image: str | None = Field(default=None, description="The image url of team 2")
 
 
 class GameState(str, Enum):

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -135,6 +135,10 @@ class DatabaseService:
         with self.connection_provider.get_db() as db:
             return match_dao.get_matches(db, filters)
 
+    def get_fantasy_schedule_matches(self) -> list[Match]:
+        with self.connection_provider.get_db() as db:
+            return match_dao.get_fantasy_schedule_matches(db)
+
     def get_match_by_id(self, match_id: RiotMatchID) -> Match | None:
         with self.connection_provider.get_db() as db:
             return match_dao.get_match_by_id(db, match_id)

--- a/src/db/riot_dao/match_dao.py
+++ b/src/db/riot_dao/match_dao.py
@@ -225,6 +225,16 @@ def get_matches(session, filters: list | None = None) -> list[Match]:
     return [Match.model_validate(match_model) for match_model in match_models]
 
 
+def get_fantasy_schedule_matches(session) -> list[Match]:
+    """Get all matches from fantasy-available leagues (any state)."""
+    query = (
+        session.query(MatchView)
+        .join(LeagueModel, MatchView.league_slug == LeagueModel.slug)
+        .filter(LeagueModel.fantasy_available == True)  # noqa: E712
+    )
+    return [Match.model_validate(m) for m in query.all()]
+
+
 def get_match_by_id(session, match_id: RiotMatchID) -> Match | None:
     db_match = session.query(MatchView).filter(MatchView.id == match_id).first()
     if db_match is None:

--- a/src/db/views.py
+++ b/src/db/views.py
@@ -69,6 +69,8 @@ class MatchView(Base):  # type: ignore
     team_1_wins = Column(Integer, nullable=True)
     team_2_wins = Column(Integer, nullable=True)
     winning_team = Column(String, nullable=True)
+    team_1_image = Column(String, nullable=True)
+    team_2_image = Column(String, nullable=True)
 
 
 create_match_view_query = text("""
@@ -91,7 +93,9 @@ create_match_view_query = text("""
             WHEN t1.outcome = 'win' THEN t1.team_name
             WHEN t2.outcome = 'win' THEN t2.team_name
             ELSE NULL
-        END AS winning_team
+        END AS winning_team,
+        t1.team_image AS team_1_image,
+        t2.team_image AS team_2_image
     FROM matches m
     LEFT JOIN event_teams t1 ON m.id = t1.match_id AND t1.side = 1
     LEFT JOIN event_teams t2 ON m.id = t2.match_id AND t2.side = 2

--- a/src/riot/endpoints/match_endpoint_v1.py
+++ b/src/riot/endpoints/match_endpoint_v1.py
@@ -14,6 +14,15 @@ class MatchEndpoint(Routable):
         self.__match_service = match_service
 
     @get(
+        path="/matches/schedule",
+        description="Get live, upcoming, and recent matches from fantasy-available leagues",
+        tags=["Matches"],
+        dependencies=[Depends(JWTBearer([Permissions.RIOT_READ]))],
+    )
+    def get_match_schedule(self) -> dict[str, list[Match]]:
+        return self.__match_service.get_schedule()
+
+    @get(
         path="/matches",
         description="Get a list of matches based on a set of search criteria",
         tags=["Matches"],

--- a/src/riot/service/riot_match_service.py
+++ b/src/riot/service/riot_match_service.py
@@ -1,6 +1,7 @@
 import logging
+from datetime import datetime, timezone, timedelta
 
-from src.common.schemas.riot_data_schemas import Match, RiotMatchID
+from src.common.schemas.riot_data_schemas import Match, RiotMatchID, MatchState
 from src.common.schemas.search_parameters import MatchSearchParameters
 from src.db.database_service import DatabaseService
 from src.db.views import MatchView
@@ -27,3 +28,26 @@ class RiotMatchService:
         if match is None:
             raise MatchNotFoundException()
         return match
+
+    def get_schedule(self) -> dict[str, list[Match]]:
+        all_matches = self.db.get_fantasy_schedule_matches()
+        now = datetime.now(timezone.utc)
+        cutoff = now - timedelta(hours=48)
+        cutoff_str = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        live = []
+        upcoming = []
+        recent = []
+
+        for match in all_matches:
+            if match.state == MatchState.INPROGRESS:
+                live.append(match)
+            elif match.state == MatchState.UNSTARTED:
+                upcoming.append(match)
+            elif match.state == MatchState.COMPLETED and match.start_time >= cutoff_str:
+                recent.append(match)
+
+        upcoming.sort(key=lambda m: m.start_time)
+        recent.sort(key=lambda m: m.start_time, reverse=True)
+
+        return {"live": live, "upcoming": upcoming, "recent": recent}

--- a/tests/riot/integration/service/test_match_schedule.py
+++ b/tests/riot/integration/service/test_match_schedule.py
@@ -1,0 +1,85 @@
+from tests.test_base import TestBase
+from tests.test_util import riot_fixtures
+
+from src.common.schemas.riot_data_schemas import (
+    RiotMatchID,
+    MatchState,
+    ScheduleMatch,
+    ScheduleTeam,
+)
+from src.riot.service import RiotMatchService
+
+
+class TestMatchSchedule(TestBase):
+    def setUp(self):
+        self.db.put_league(riot_fixtures.league_1_fixture)
+        self.db.put_tournament(riot_fixtures.tournament_fixture)
+        self.db.put_team(riot_fixtures.team_1_fixture)
+        self.db.put_team(riot_fixtures.team_2_fixture)
+        # Mark league as fantasy available for schedule queries
+        self.db.update_league_fantasy_available_status(riot_fixtures.league_1_fixture.id, True)
+        self.match_service = RiotMatchService(self.db)
+
+    def _create_match(self, match_id, state, start_time):
+        self.db.save_from_schedule(
+            ScheduleMatch(
+                id=RiotMatchID(match_id),
+                start_time=start_time,
+                block_name="Week 1",
+                league_slug=riot_fixtures.league_1_fixture.slug,
+                strategy_type="bestOf",
+                strategy_count=3,
+                state=state,
+                teams=[
+                    ScheduleTeam(
+                        side=1,
+                        team_code=riot_fixtures.team_1_fixture.code,
+                        team_name=riot_fixtures.team_1_fixture.name,
+                        team_image=riot_fixtures.team_1_fixture.image,
+                        game_wins=0,
+                    ),
+                    ScheduleTeam(
+                        side=2,
+                        team_code=riot_fixtures.team_2_fixture.code,
+                        team_name=riot_fixtures.team_2_fixture.name,
+                        team_image=riot_fixtures.team_2_fixture.image,
+                        game_wins=0,
+                    ),
+                ],
+            )
+        )
+
+    def test_match_response_includes_team_images(self):
+        self._create_match("img-match-001", MatchState.UNSTARTED, "2099-01-01T12:00:00Z")
+
+        match = self.db.get_match_by_id(RiotMatchID("img-match-001"))
+
+        self.assertIsNotNone(match)
+        self.assertEqual(riot_fixtures.team_1_fixture.image, match.team_1_image)
+        self.assertEqual(riot_fixtures.team_2_fixture.image, match.team_2_image)
+
+    def test_get_schedule_returns_live_upcoming_recent(self):
+        # Live match
+        self._create_match("live-001", MatchState.INPROGRESS, "2020-01-01T12:00:00Z")
+        # Upcoming match
+        self._create_match("upcoming-001", MatchState.UNSTARTED, "2099-01-01T12:00:00Z")
+        # Recent match (completed, within 48h — use a time we know is recent)
+        from datetime import datetime, timezone, timedelta
+
+        recent_time = (datetime.now(timezone.utc) - timedelta(hours=6)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        self._create_match("recent-001", MatchState.COMPLETED, recent_time)
+        # Old completed match (>48h ago — should NOT appear)
+        self._create_match("old-001", MatchState.COMPLETED, "2020-01-01T12:00:00Z")
+
+        schedule = self.match_service.get_schedule()
+
+        live_ids = [m.id for m in schedule["live"]]
+        upcoming_ids = [m.id for m in schedule["upcoming"]]
+        recent_ids = [m.id for m in schedule["recent"]]
+
+        self.assertIn(RiotMatchID("live-001"), live_ids)
+        self.assertIn(RiotMatchID("upcoming-001"), upcoming_ids)
+        self.assertIn(RiotMatchID("recent-001"), recent_ids)
+        self.assertNotIn(RiotMatchID("old-001"), recent_ids)

--- a/tests/test_util/riot_fixtures.py
+++ b/tests/test_util/riot_fixtures.py
@@ -117,6 +117,8 @@ match_fixture = schemas.Match(
     team_1_wins=1,
     team_2_wins=0,
     winning_team=None,
+    team_1_image=team_1_fixture.image,
+    team_2_image=team_2_fixture.image,
 )
 
 completed_match_fixture = schemas.Match(
@@ -134,6 +136,8 @@ completed_match_fixture = schemas.Match(
     team_1_wins=1,
     team_2_wins=0,
     winning_team=team_1_fixture.name,
+    team_1_image=team_1_fixture.image,
+    team_2_image=team_2_fixture.image,
 )
 
 future_match_fixture = schemas.Match(
@@ -151,6 +155,8 @@ future_match_fixture = schemas.Match(
     team_1_wins=None,
     team_2_wins=None,
     winning_team=None,
+    team_1_image=team_1_fixture.image,
+    team_2_image=team_2_fixture.image,
 )
 
 game_1_fixture_completed = schemas.Game(

--- a/ui/src/api/riotApi.ts
+++ b/ui/src/api/riotApi.ts
@@ -43,3 +43,14 @@ export async function getMatches(params: MatchParams = {}): Promise<PaginatedRes
   const res = await api.get<PaginatedResponse<Match>>('/riot/match', { params })
   return res.data
 }
+
+export interface MatchScheduleResponse {
+  live: Match[]
+  upcoming: Match[]
+  recent: Match[]
+}
+
+export async function getMatchSchedule(): Promise<MatchScheduleResponse> {
+  const res = await api.get<MatchScheduleResponse>('/riot/matches/schedule')
+  return res.data
+}

--- a/ui/src/types/riot.ts
+++ b/ui/src/types/riot.ts
@@ -33,6 +33,8 @@ export interface Match {
   team_1_wins: number | null
   team_2_wins: number | null
   winning_team: string | null
+  team_1_image: string | null
+  team_2_image: string | null
 }
 
 export interface ProfessionalTeam {

--- a/ui/src/views/MatchesView.vue
+++ b/ui/src/views/MatchesView.vue
@@ -67,6 +67,7 @@ function formatScore(match: Match): string {
                 <span class="font-semibold text-sm text-foreground truncate">{{ m.team_1_name }}</span>
               </div>
               <div class="text-center px-4 shrink-0">
+                <p class="text-[10px] text-foreground-muted mb-0.5">{{ m.block_name }}</p>
                 <div class="text-lg font-bold tabular-nums text-foreground">{{ formatScore(m) }}</div>
                 <div class="text-[11px] font-semibold text-live">LIVE</div>
               </div>
@@ -93,7 +94,10 @@ function formatScore(match: Match): string {
                 <img v-if="m.team_1_image" :src="m.team_1_image" class="w-8 h-8 rounded-full object-cover bg-surface-elevated" />
                 <span class="font-medium text-sm text-foreground truncate">{{ m.team_1_name }}</span>
               </div>
-              <span class="text-xs text-foreground-muted px-3">Bo{{ m.strategy_count }}</span>
+              <span class="text-xs text-foreground-muted px-3 text-center">
+                <p class="text-[10px]">{{ m.block_name }}</p>
+                Bo{{ m.strategy_count }}
+              </span>
               <div class="flex items-center gap-3 flex-1 min-w-0 justify-end">
                 <span class="font-medium text-sm text-foreground truncate">{{ m.team_2_name }}</span>
                 <img v-if="m.team_2_image" :src="m.team_2_image" class="w-8 h-8 rounded-full object-cover bg-surface-elevated" />
@@ -118,6 +122,7 @@ function formatScore(match: Match): string {
                 <span class="font-medium text-sm text-foreground truncate" :class="{ 'text-primary': m.winning_team === m.team_1_name }">{{ m.team_1_name }}</span>
               </div>
               <div class="text-center px-3 shrink-0">
+                <p class="text-[10px] text-foreground-muted mb-0.5">{{ m.block_name }}</p>
                 <span class="text-base font-bold tabular-nums text-foreground">{{ formatScore(m) }}</span>
               </div>
               <div class="flex items-center gap-3 flex-1 min-w-0 justify-end">

--- a/ui/src/views/MatchesView.vue
+++ b/ui/src/views/MatchesView.vue
@@ -60,14 +60,17 @@ function formatScore(match: Match): string {
         </h3>
         <div class="flex flex-col gap-3">
           <div v-for="m in schedule.live" :key="m.id" class="rounded-xl p-4 bg-surface border border-border-subtle">
-            <p class="text-xs text-foreground-muted mb-2 uppercase">{{ m.league_slug }}</p>
+            <div class="flex items-center justify-between mb-2">
+              <span class="text-xs text-foreground-muted uppercase">{{ m.league_slug }}</span>
+              <span class="text-xs text-foreground-muted">{{ m.block_name }}</span>
+              <span class="text-xs text-foreground-muted">{{ formatLocalTime(m.start_time) }}</span>
+            </div>
             <div class="flex items-center justify-between">
               <div class="flex items-center gap-3 flex-1 min-w-0">
                 <img v-if="m.team_1_image" :src="m.team_1_image" class="w-8 h-8 rounded-full object-cover bg-surface-elevated" />
                 <span class="font-semibold text-sm text-foreground truncate">{{ m.team_1_name }}</span>
               </div>
               <div class="text-center px-4 shrink-0">
-                <p class="text-[10px] text-foreground-muted mb-0.5">{{ m.block_name }}</p>
                 <div class="text-lg font-bold tabular-nums text-foreground">{{ formatScore(m) }}</div>
                 <div class="text-[11px] font-semibold text-live">LIVE</div>
               </div>
@@ -87,6 +90,7 @@ function formatScore(match: Match): string {
           <div v-for="m in schedule.upcoming" :key="m.id" class="rounded-xl p-4 bg-surface border border-border-subtle">
             <div class="flex items-center justify-between mb-2">
               <span class="text-xs text-foreground-muted uppercase">{{ m.league_slug }}</span>
+              <span class="text-xs text-foreground-muted">{{ m.block_name }}</span>
               <span class="text-xs text-foreground-muted">{{ formatLocalTime(m.start_time) }}</span>
             </div>
             <div class="flex items-center justify-between">
@@ -94,10 +98,7 @@ function formatScore(match: Match): string {
                 <img v-if="m.team_1_image" :src="m.team_1_image" class="w-8 h-8 rounded-full object-cover bg-surface-elevated" />
                 <span class="font-medium text-sm text-foreground truncate">{{ m.team_1_name }}</span>
               </div>
-              <span class="text-xs text-foreground-muted px-3 text-center">
-                <p class="text-[10px]">{{ m.block_name }}</p>
-                Bo{{ m.strategy_count }}
-              </span>
+              <span class="text-xs text-foreground-muted px-3">Bo{{ m.strategy_count }}</span>
               <div class="flex items-center gap-3 flex-1 min-w-0 justify-end">
                 <span class="font-medium text-sm text-foreground truncate">{{ m.team_2_name }}</span>
                 <img v-if="m.team_2_image" :src="m.team_2_image" class="w-8 h-8 rounded-full object-cover bg-surface-elevated" />
@@ -114,6 +115,7 @@ function formatScore(match: Match): string {
           <div v-for="m in schedule.recent" :key="m.id" class="rounded-xl p-4 bg-surface border border-border-subtle">
             <div class="flex items-center justify-between mb-2">
               <span class="text-xs text-foreground-muted uppercase">{{ m.league_slug }}</span>
+              <span class="text-xs text-foreground-muted">{{ m.block_name }}</span>
               <span class="text-xs text-foreground-muted">{{ formatLocalTime(m.start_time) }}</span>
             </div>
             <div class="flex items-center justify-between">
@@ -122,7 +124,6 @@ function formatScore(match: Match): string {
                 <span class="font-medium text-sm text-foreground truncate" :class="{ 'text-primary': m.winning_team === m.team_1_name }">{{ m.team_1_name }}</span>
               </div>
               <div class="text-center px-3 shrink-0">
-                <p class="text-[10px] text-foreground-muted mb-0.5">{{ m.block_name }}</p>
                 <span class="text-base font-bold tabular-nums text-foreground">{{ formatScore(m) }}</span>
               </div>
               <div class="flex items-center gap-3 flex-1 min-w-0 justify-end">

--- a/ui/src/views/MatchesView.vue
+++ b/ui/src/views/MatchesView.vue
@@ -1,6 +1,138 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { getMatchSchedule, type MatchScheduleResponse } from '../api/riotApi'
+import type { Match } from '../types/riot'
+
+const schedule = ref<MatchScheduleResponse | null>(null)
+const loading = ref(true)
+const error = ref<string | null>(null)
+
+onMounted(async () => {
+  try {
+    schedule.value = await getMatchSchedule()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to load schedule'
+  } finally {
+    loading.value = false
+  }
+})
+
+function formatLocalTime(utcTime: string): string {
+  const date = new Date(utcTime)
+  return date.toLocaleString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+function formatScore(match: Match): string {
+  if (match.team_1_wins == null && match.team_2_wins == null) {
+    return `Bo${match.strategy_count}`
+  }
+  return `${match.team_1_wins ?? 0} — ${match.team_2_wins ?? 0}`
+}
+</script>
+
 <template>
-  <div>
-    <h2 class="text-lg font-semibold text-foreground">Live Matches</h2>
-    <p class="mt-2 text-foreground-muted">Live and upcoming matches will appear here.</p>
+  <div class="flex flex-col gap-8">
+    <div>
+      <h2 class="text-lg font-semibold text-foreground">Matches</h2>
+      <p class="mt-1 text-sm text-foreground-muted">Live, upcoming, and recent matches.</p>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="loading" class="flex items-center justify-center py-12">
+      <div class="w-6 h-6 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+    </div>
+
+    <!-- Error -->
+    <div v-else-if="error" class="text-center py-12 text-danger text-sm">{{ error }}</div>
+
+    <template v-else-if="schedule">
+      <!-- Live -->
+      <section v-if="schedule.live.length > 0">
+        <h3 class="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
+          <span class="w-2 h-2 rounded-full bg-live animate-pulse-live" />
+          Live
+        </h3>
+        <div class="flex flex-col gap-3">
+          <div v-for="m in schedule.live" :key="m.id" class="rounded-xl p-4 bg-surface border border-border-subtle">
+            <p class="text-xs text-foreground-muted mb-2 uppercase">{{ m.league_slug }}</p>
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-3 flex-1 min-w-0">
+                <img v-if="m.team_1_image" :src="m.team_1_image" class="w-8 h-8 rounded-full object-cover bg-surface-elevated" />
+                <span class="font-semibold text-sm text-foreground truncate">{{ m.team_1_name }}</span>
+              </div>
+              <div class="text-center px-4 shrink-0">
+                <div class="text-lg font-bold tabular-nums text-foreground">{{ formatScore(m) }}</div>
+                <div class="text-[11px] font-semibold text-live">LIVE</div>
+              </div>
+              <div class="flex items-center gap-3 flex-1 min-w-0 justify-end">
+                <span class="font-semibold text-sm text-foreground truncate">{{ m.team_2_name }}</span>
+                <img v-if="m.team_2_image" :src="m.team_2_image" class="w-8 h-8 rounded-full object-cover bg-surface-elevated" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Upcoming -->
+      <section v-if="schedule.upcoming.length > 0">
+        <h3 class="text-sm font-semibold text-foreground mb-3">Upcoming</h3>
+        <div class="flex flex-col gap-2">
+          <div v-for="m in schedule.upcoming" :key="m.id" class="rounded-xl p-4 bg-surface border border-border-subtle">
+            <div class="flex items-center justify-between mb-2">
+              <span class="text-xs text-foreground-muted uppercase">{{ m.league_slug }}</span>
+              <span class="text-xs text-foreground-muted">{{ formatLocalTime(m.start_time) }}</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-3 flex-1 min-w-0">
+                <img v-if="m.team_1_image" :src="m.team_1_image" class="w-8 h-8 rounded-full object-cover bg-surface-elevated" />
+                <span class="font-medium text-sm text-foreground truncate">{{ m.team_1_name }}</span>
+              </div>
+              <span class="text-xs text-foreground-muted px-3">Bo{{ m.strategy_count }}</span>
+              <div class="flex items-center gap-3 flex-1 min-w-0 justify-end">
+                <span class="font-medium text-sm text-foreground truncate">{{ m.team_2_name }}</span>
+                <img v-if="m.team_2_image" :src="m.team_2_image" class="w-8 h-8 rounded-full object-cover bg-surface-elevated" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Recent -->
+      <section v-if="schedule.recent.length > 0">
+        <h3 class="text-sm font-semibold text-foreground mb-3">Recent Results</h3>
+        <div class="flex flex-col gap-2">
+          <div v-for="m in schedule.recent" :key="m.id" class="rounded-xl p-4 bg-surface border border-border-subtle">
+            <div class="flex items-center justify-between mb-2">
+              <span class="text-xs text-foreground-muted uppercase">{{ m.league_slug }}</span>
+              <span class="text-xs text-foreground-muted">{{ formatLocalTime(m.start_time) }}</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-3 flex-1 min-w-0">
+                <img v-if="m.team_1_image" :src="m.team_1_image" class="w-8 h-8 rounded-full object-cover bg-surface-elevated" />
+                <span class="font-medium text-sm text-foreground truncate" :class="{ 'text-primary': m.winning_team === m.team_1_name }">{{ m.team_1_name }}</span>
+              </div>
+              <div class="text-center px-3 shrink-0">
+                <span class="text-base font-bold tabular-nums text-foreground">{{ formatScore(m) }}</span>
+              </div>
+              <div class="flex items-center gap-3 flex-1 min-w-0 justify-end">
+                <span class="font-medium text-sm text-foreground truncate" :class="{ 'text-primary': m.winning_team === m.team_2_name }">{{ m.team_2_name }}</span>
+                <img v-if="m.team_2_image" :src="m.team_2_image" class="w-8 h-8 rounded-full object-cover bg-surface-elevated" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Empty -->
+      <div v-if="schedule.live.length === 0 && schedule.upcoming.length === 0 && schedule.recent.length === 0" class="text-center py-12">
+        <p class="text-foreground-muted text-sm">No matches scheduled.</p>
+      </div>
+    </template>
   </div>
 </template>


### PR DESCRIPTION
## Summary

Builds the Matches page showing live, upcoming, and recently completed matches from fantasy-available leagues.

## Backend

- **Match view**: added `team_1_image`, `team_2_image` from `event_teams`
- **New endpoint**: `GET /riot/matches/schedule` returns `{ live, upcoming, recent }`
- **Logic**: Fetches all matches from fantasy-available leagues, buckets by state:
  - `live`: state = inProgress
  - `upcoming`: state = unstarted (sorted by start_time ASC)
  - `recent`: state = completed, within last 48 hours (sorted by start_time DESC)

## Frontend

- Three sections: Live (with pulse indicator), Upcoming, Recent Results
- Match cards show: league badge, team images + names, score or format
- Times displayed in user's local timezone
- Winner name highlighted in recent results

## Tests

- Match response includes team images
- Schedule endpoint returns correct buckets
- Old completed matches (>48h) excluded from recent

## Verified

- `ruff check && ruff format --check` pass
- `vue-tsc -b && vite build` pass
- 541 tests pass (2 pre-existing failures unrelated)