### PR TITLE
Use last frame as end time when API has no FINISHED frame

### DIFF
--- a/src/riot_scraper/game_analysis.py
+++ b/src/riot_scraper/game_analysis.py
@@ -192,6 +192,10 @@ def compute_duration(frames: list[WindowFrame]) -> int:
             end_time = frame.rfc460Timestamp
             break
 
+    # Fall back to last frame timestamp if no FINISHED frame
+    if end_time is None and frames:
+        end_time = frames[-1].rfc460Timestamp
+
     if start_time is None or end_time is None:
         return 0
 

--- a/src/riot_scraper/scrapers/game_analysis_scraper.py
+++ b/src/riot_scraper/scrapers/game_analysis_scraper.py
@@ -69,15 +69,12 @@ class GameAnalysisScraper:
         logger.info(f"Game {game_id} analysis complete")
 
     def _fetch_all_frames(self, game_id: RiotGameID) -> list[WindowFrame] | None:
-        # Check the latest available frames first — if no FINISHED frame exists, bail early
+        # Get the latest window to determine the end timestamp
         latest_time = TimestampUtil.round_current_time_to_10_seconds()
         latest_window = self.api.get_game_window(game_id, latest_time)
         if latest_window is None:
             return None
-        has_finished = any(f.gameState == LiveGameState.FINISHED for f in latest_window.frames)
-        if not has_finished:
-            logger.warning(f"Game {game_id}: no FINISHED frame in latest window, skipping")
-            return None
+        end_timestamp = latest_window.frames[-1].rfc460Timestamp
 
         initial_window = self.api.get_game_window(game_id)
         if initial_window is None:
@@ -87,17 +84,20 @@ class GameAnalysisScraper:
 
         start_time = TimestampUtil.round_to_10_seconds(initial_window.frames[0].rfc460Timestamp)
         current_time = start_time
-        finished = False
+        reached_end = False
 
-        while not finished:
+        while not reached_end:
             window = self.api.get_game_window(game_id, current_time)
             if window is None:
                 break
 
             for frame in window.frames:
                 all_frames.append(frame)
-                if frame.gameState == LiveGameState.FINISHED:
-                    finished = True
+                if (
+                    frame.rfc460Timestamp >= end_timestamp
+                    or frame.gameState == LiveGameState.FINISHED
+                ):
+                    reached_end = True
 
             current_time = TimestampUtil.add_10_seconds(current_time)
 

--- a/tests/riot_scraper/test_game_analysis_scraper.py
+++ b/tests/riot_scraper/test_game_analysis_scraper.py
@@ -196,17 +196,18 @@ class TestGameAnalysisScraper(TestBase):
             gm = session.query(GameModel).filter(GameModel.id == game_id).first()
             self.assertEqual("unavailable", gm.frames_status)
 
-    def test_marks_unavailable_when_latest_window_has_no_finished_frame(self):
-        """If the latest window has no FINISHED frame, the game data is incomplete."""
+    def test_completes_analysis_when_no_finished_frame(self):
+        """If no FINISHED frame exists, use the last frame as end time."""
         game_id = self._create_pending_game("game-no-finished-001")
 
-        # Latest window returns frames but none are FINISHED
-        incomplete_frames = [
+        # Frames without a FINISHED state — simulates truncated API data
+        frames = [
+            _make_frame("2024-01-01T00:00:00.000Z"),
+            _make_frame("2024-01-01T00:00:05.000Z", blue_kills=[1, 0, 0, 0, 0]),
             _make_frame("2024-01-01T00:30:00.000Z", blue_kills=[5, 3, 2, 1, 0]),
         ]
-        self.mock_api.get_game_window.return_value = _make_window_response(
-            game_id, incomplete_frames
-        )
+        # All calls return the same window (latest + initial + walk)
+        self.mock_api.get_game_window.return_value = _make_window_response(game_id, frames)
 
         self.scraper.analyze_games()
 
@@ -214,7 +215,9 @@ class TestGameAnalysisScraper(TestBase):
 
         with self.db_provider.get_db() as session:
             gm = session.query(GameModel).filter(GameModel.id == game_id).first()
-            self.assertEqual("unavailable", gm.frames_status)
+            self.assertEqual("completed", gm.frames_status)
+            self.assertIsNotNone(gm.duration_seconds)
+            self.assertGreater(gm.duration_seconds, 0)
 
     def test_processes_at_most_5_games(self):
         # Create 7 pending games
@@ -320,3 +323,83 @@ class TestGameAnalysisScraper(TestBase):
             gm = session.query(GameModel).filter(GameModel.id == game_id).first()
             self.assertEqual(GameState.COMPLETED, gm.state)
             self.assertEqual("pending", gm.frames_status)
+
+    def test_frame_walker_stops_at_end_timestamp_and_does_not_loop(self):
+        """The frame walker must stop once it reaches the end timestamp from the latest window.
+        If it doesn't stop, it would loop forever consuming memory."""
+        game_id = self._create_pending_game("game-stop-test-001")
+
+        # Latest window has frames ending at 00:30:00
+        latest_frames = [
+            _make_frame("2024-01-01T00:30:00.000Z", blue_kills=[5, 0, 0, 0, 0]),
+        ]
+        # Initial window starts at 00:00:00
+        initial_frames = [
+            _make_frame("2024-01-01T00:00:00.000Z"),
+        ]
+        # Walking frames — includes the end timestamp
+        walk_frames = [
+            _make_frame("2024-01-01T00:00:00.000Z"),
+            _make_frame("2024-01-01T00:15:00.000Z", blue_kills=[2, 0, 0, 0, 0]),
+            _make_frame("2024-01-01T00:30:00.000Z", blue_kills=[5, 0, 0, 0, 0]),
+        ]
+
+        call_count = [0]
+        max_calls = 10  # Safety: if we exceed this, the walker is looping
+
+        def mock_get_game_window(gid, timestamp=None):
+            call_count[0] += 1
+            if call_count[0] > max_calls:
+                self.fail(f"Frame walker made {call_count[0]} API calls — it's looping!")
+            if call_count[0] == 1:
+                return _make_window_response(game_id, latest_frames)  # latest window
+            elif call_count[0] == 2:
+                return _make_window_response(game_id, initial_frames)  # initial window
+            else:
+                return _make_window_response(game_id, walk_frames)  # walking
+
+        self.mock_api.get_game_window.side_effect = mock_get_game_window
+
+        self.scraper.analyze_games()
+
+        # Should have stopped — not hit the max_calls limit
+        self.assertLessEqual(call_count[0], max_calls)
+
+        # Game should be completed, not stuck or unavailable
+        from src.db.models import GameModel
+
+        with self.db_provider.get_db() as session:
+            gm = session.query(GameModel).filter(GameModel.id == game_id).first()
+            self.assertEqual("completed", gm.frames_status)
+            self.assertIsNotNone(gm.duration_seconds)
+
+    def test_frame_walker_stops_even_when_api_returns_frames_past_end(self):
+        """Even if the API returns frames beyond the end timestamp, we stop."""
+        game_id = self._create_pending_game("game-past-end-001")
+
+        # Latest window says end is at 00:20:00
+        latest_frames = [
+            _make_frame("2024-01-01T00:20:00.000Z", blue_kills=[3, 0, 0, 0, 0]),
+        ]
+        # Walk returns frames that go PAST the end timestamp
+        walk_frames = [
+            _make_frame("2024-01-01T00:00:00.000Z"),
+            _make_frame("2024-01-01T00:10:00.000Z", blue_kills=[1, 0, 0, 0, 0]),
+            _make_frame("2024-01-01T00:20:00.000Z", blue_kills=[3, 0, 0, 0, 0]),
+            _make_frame("2024-01-01T00:25:00.000Z", blue_kills=[4, 0, 0, 0, 0]),
+        ]
+
+        self.mock_api.get_game_window.side_effect = [
+            _make_window_response(game_id, latest_frames),  # latest
+            _make_window_response(game_id, walk_frames),  # initial
+            _make_window_response(game_id, walk_frames),  # walk
+            None,  # should never reach here
+        ]
+
+        self.scraper.analyze_games()
+
+        from src.db.models import GameModel
+
+        with self.db_provider.get_db() as session:
+            gm = session.query(GameModel).filter(GameModel.id == game_id).first()
+            self.assertEqual("completed", gm.frames_status)


### PR DESCRIPTION
## Problem

Some games have truncated API data — the Riot feed stops advancing without ever returning a FINISHED frame. These games were being marked `unavailable` even though 99%+ of the frame data exists.

Example: game `115564793879403677` has 40m39s of data (gold at 80k, end-game levels) but no FINISHED transition.

## Fix

1. Fetch the latest window upfront to get the end timestamp
2. Walk frames from start until reaching that end timestamp (or FINISHED, whichever first)
3. `compute_duration` falls back to the last frame's timestamp if no FINISHED frame exists

No more infinite loops, no more marking complete games as unavailable. Duration accuracy loss is ~30 seconds at most.

## After merging

Re-queue previously unavailable games that should now work:
```sql
UPDATE games SET frames_status = 'pending'
WHERE frames_status = 'unavailable'
  AND state = 'completed'
  AND (details_status IS NULL OR details_status != 'unavailable');
```