### PR TITLE
Fix frame walker: walk until FINISHED or 2.5h with last-frame fallback

### DIFF
--- a/src/riot_scraper/game_analysis.py
+++ b/src/riot_scraper/game_analysis.py
@@ -192,6 +192,10 @@ def compute_duration(frames: list[WindowFrame]) -> int:
             end_time = frame.rfc460Timestamp
             break
 
+    # Fall back to last frame if no FINISHED frame exists
+    if end_time is None and frames:
+        end_time = frames[-1].rfc460Timestamp
+
     if start_time is None or end_time is None:
         return 0
 

--- a/src/riot_scraper/scrapers/game_analysis_scraper.py
+++ b/src/riot_scraper/scrapers/game_analysis_scraper.py
@@ -44,6 +44,8 @@ class GameAnalysisScraper:
         # Compute duration
         duration = compute_duration(frames)
         if duration > 0:
+            if duration < 900:
+                logger.error(f"Game {game_id}: duration is only {duration}s — suspiciously short")
             self.db.update_game_duration(game_id, duration)
 
         # Detect multi-kills
@@ -79,7 +81,7 @@ class GameAnalysisScraper:
         start_time = TimestampUtil.round_to_10_seconds(initial_window.frames[0].rfc460Timestamp)
         current_time = start_time
 
-        # Hard limit: 2.5 hours from first frame. If no FINISHED by then, give up.
+        # Hard limit: 2.5 hours from first frame
         start_dt = TimestampUtil.parse_rfc3339(start_time)
         max_dt = start_dt + timedelta(hours=2, minutes=30)
         max_timestamp = max_dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
@@ -90,9 +92,10 @@ class GameAnalysisScraper:
             # Check if we've exceeded the time limit
             if current_time >= max_timestamp:
                 logger.error(
-                    f"Game {game_id}: no FINISHED frame found within 2.5h, marking unavailable"
+                    f"Game {game_id}: no FINISHED frame found within 2.5h, "
+                    f"using last available frame as end"
                 )
-                return None
+                break
 
             window = self.api.get_game_window(game_id, current_time)
             if window is None:

--- a/tests/riot_scraper/test_game_analysis_scraper.py
+++ b/tests/riot_scraper/test_game_analysis_scraper.py
@@ -196,7 +196,7 @@ class TestGameAnalysisScraper(TestBase):
             self.assertEqual("unavailable", gm.frames_status)
 
     def test_marks_unavailable_when_no_finished_after_2_5_hours(self):
-        """If no FINISHED frame is found within 2.5h of start, mark unavailable."""
+        """If no FINISHED frame within 2.5h, fall back to last frame and still complete."""
         game_id = self._create_pending_game("game-timeout-001")
 
         # Frame that never has FINISHED — timestamp advances but no end
@@ -208,7 +208,6 @@ class TestGameAnalysisScraper(TestBase):
             if timestamp is None:
                 return _make_window_response(game_id, [_make_frame("2024-01-01T00:00:00.000Z")])
             # Return frames that keep advancing but never FINISHED
-            # Each call advances 10s, so 2.5h = 900 calls
             return _make_window_response(
                 game_id, [_make_frame(timestamp, blue_kills=[1, 0, 0, 0, 0])]
             )
@@ -221,10 +220,9 @@ class TestGameAnalysisScraper(TestBase):
 
         with self.db_provider.get_db() as session:
             gm = session.query(GameModel).filter(GameModel.id == game_id).first()
-            self.assertEqual("unavailable", gm.frames_status)
+            self.assertEqual("completed", gm.frames_status)
 
         # Should have stopped at 2.5h worth of 10s increments (900) + 1 initial call
-        # Allow some tolerance for the exact count
         self.assertLessEqual(call_count[0], 910)
 
     def test_does_not_terminate_early_during_pause(self):


### PR DESCRIPTION
## Problem

Previous approaches all had issues:
- Wall-clock 'latest window' check returned garbage for older games
- Stale detection terminated early during pauses
- Hard timeout marking unavailable lost data for games without FINISHED frames

## Fix

Simple, predictable frame walker:
1. Walk from game start, advancing 10s per request
2. Stop on FINISHED frame → use as end time
3. Stop at 2.5h timeout → log error, use last frame as end time
4. Stop if API returns None → use last frame as end time

`compute_duration` falls back to last frame timestamp when no FINISHED exists.

Additional: logs error if duration < 900s (suspiciously short) but still saves.

## Result

- Games WITH FINISHED: exact duration ✓
- Games WITHOUT FINISHED (truncated API): ~30s inaccuracy, still get multi-kills/dragons ✓
- Paused games: walker keeps advancing request time, no early termination ✓
- No infinite loops: hard cap at 2.5h = ~901 API calls max ✓

## Test on server

```sql
UPDATE games SET frames_status = 'pending', duration_seconds = NULL
WHERE id IN ('115564793879403677', '115564793879469271', '115564689066907657');
```