### PR TITLE
feat: League detail pre-draft page with tabs (#456)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -17,7 +17,8 @@
         "primevue": "^4.5.5",
         "tailwindcss": "^4.2.4",
         "vue": "^3.5.32",
-        "vue-router": "^4.6.4"
+        "vue-router": "^4.6.4",
+        "vuedraggable": "^4.1.0"
       },
       "devDependencies": {
         "@types/node": "^24.12.2",
@@ -1912,6 +1913,12 @@
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "license": "MIT"
     },
+    "node_modules/sortablejs": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+      "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2146,6 +2153,18 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/vuedraggable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
+      "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
+      "license": "MIT",
+      "dependencies": {
+        "sortablejs": "1.14.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.1"
       }
     }
   }

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,7 +18,8 @@
     "primevue": "^4.5.5",
     "tailwindcss": "^4.2.4",
     "vue": "^3.5.32",
-    "vue-router": "^4.6.4"
+    "vue-router": "^4.6.4",
+    "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.2",

--- a/ui/src/api/fantasyApi.ts
+++ b/ui/src/api/fantasyApi.ts
@@ -1,9 +1,21 @@
 import { api } from './client'
-import type { FantasyLeague, FantasyLeagueSettings } from '../types/fantasy'
+import type { FantasyLeague, FantasyLeagueSettings, FantasyLeagueScoringSettings } from '../types/fantasy'
 
 export interface MyLeaguesResponse {
   pending: FantasyLeague[]
   accepted: FantasyLeague[]
+}
+
+export interface LeagueMember {
+  user_id: string
+  username: string
+  status: 'accepted' | 'pending'
+}
+
+export interface DraftOrderEntry {
+  user_id: string
+  username: string
+  position: number
 }
 
 export async function getMyLeagues(): Promise<MyLeaguesResponse> {
@@ -22,4 +34,41 @@ export async function joinLeague(leagueId: string): Promise<void> {
 
 export async function leaveLeague(leagueId: string): Promise<void> {
   await api.post(`/fantasy/leagues/${leagueId}/leave`)
+}
+
+export async function getLeagueById(leagueId: string): Promise<FantasyLeague> {
+  const res = await api.get<FantasyLeague>(`/fantasy/leagues/${leagueId}`)
+  return res.data
+}
+
+export async function getLeagueMembers(leagueId: string): Promise<LeagueMember[]> {
+  const res = await api.get<LeagueMember[]>(`/fantasy/leagues/${leagueId}/members`)
+  return res.data
+}
+
+export async function getLeagueSettings(leagueId: string): Promise<FantasyLeagueSettings> {
+  const res = await api.get<FantasyLeagueSettings>(`/fantasy/leagues/${leagueId}/settings`)
+  return res.data
+}
+
+export async function getLeagueScoringSettings(leagueId: string): Promise<FantasyLeagueScoringSettings> {
+  const res = await api.get<FantasyLeagueScoringSettings>(`/fantasy/leagues/${leagueId}/scoring`)
+  return res.data
+}
+
+export async function getDraftOrder(leagueId: string): Promise<DraftOrderEntry[]> {
+  const res = await api.get<DraftOrderEntry[]>(`/fantasy/leagues/${leagueId}/draft-order`)
+  return res.data
+}
+
+export async function updateDraftOrder(leagueId: string, order: DraftOrderEntry[]): Promise<void> {
+  await api.put(`/fantasy/leagues/${leagueId}/draft-order`, order)
+}
+
+export async function inviteToLeague(leagueId: string, username: string): Promise<void> {
+  await api.post(`/fantasy/leagues/${leagueId}/invite/${username}`)
+}
+
+export async function startDraft(leagueId: string): Promise<void> {
+  await api.post(`/fantasy/leagues/${leagueId}/start-draft`)
 }

--- a/ui/src/components/leagues/DraftOrderTab.vue
+++ b/ui/src/components/leagues/DraftOrderTab.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import draggable from 'vuedraggable'
+import { updateDraftOrder } from '../../api/fantasyApi'
+import type { DraftOrderEntry } from '../../api/fantasyApi'
+import { GripVertical } from 'lucide-vue-next'
+
+const props = defineProps<{
+  leagueId: string
+  draftOrder: DraftOrderEntry[]
+  isOwner: boolean
+  loading: boolean
+  error: string
+}>()
+
+const localOrder = ref<DraftOrderEntry[]>([])
+const saving = ref(false)
+const saveError = ref('')
+const saved = ref(false)
+
+watch(() => props.draftOrder, (val) => {
+  localOrder.value = val.map(e => ({ ...e }))
+}, { immediate: true })
+
+async function save() {
+  saving.value = true
+  saveError.value = ''
+  saved.value = false
+  try {
+    const updated = localOrder.value.map((e, i) => ({ ...e, position: i + 1 }))
+    await updateDraftOrder(props.leagueId, updated)
+    saved.value = true
+    setTimeout(() => { saved.value = false }, 2000)
+  } catch {
+    saveError.value = 'Failed to save draft order.'
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-4">
+    <div v-if="loading" class="flex justify-center py-8">
+      <div class="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+    </div>
+    <div v-else-if="error" class="text-sm text-danger">{{ error }}</div>
+
+    <template v-else>
+      <!-- Owner: draggable -->
+      <draggable
+        v-if="isOwner"
+        v-model="localOrder"
+        item-key="user_id"
+        handle=".drag-handle"
+        class="flex flex-col gap-2"
+      >
+        <template #item="{ element, index }">
+          <div class="flex items-center gap-3 px-4 py-3 rounded-xl border border-border-subtle bg-surface">
+            <span class="drag-handle cursor-grab active:cursor-grabbing text-foreground-muted">
+              <GripVertical class="w-4 h-4" />
+            </span>
+            <span class="text-xs font-bold text-foreground-muted w-5">{{ index + 1 }}</span>
+            <div class="w-7 h-7 rounded-full bg-surface-elevated flex items-center justify-center text-xs font-bold text-foreground-muted">
+              {{ element.username.slice(0, 2).toUpperCase() }}
+            </div>
+            <span class="text-sm text-foreground">{{ element.username }}</span>
+          </div>
+        </template>
+      </draggable>
+
+      <!-- Non-owner: static list -->
+      <div v-else class="flex flex-col gap-2">
+        <div
+          v-for="(entry, index) in draftOrder"
+          :key="entry.user_id"
+          class="flex items-center gap-3 px-4 py-3 rounded-xl border border-border-subtle bg-surface"
+        >
+          <span class="text-xs font-bold text-foreground-muted w-5">{{ index + 1 }}</span>
+          <div class="w-7 h-7 rounded-full bg-surface-elevated flex items-center justify-center text-xs font-bold text-foreground-muted">
+            {{ entry.username.slice(0, 2).toUpperCase() }}
+          </div>
+          <span class="text-sm text-foreground">{{ entry.username }}</span>
+        </div>
+      </div>
+
+      <!-- Save button (owner only) -->
+      <div v-if="isOwner" class="flex items-center gap-3">
+        <button
+          class="px-4 py-2 rounded-lg bg-primary text-white text-sm font-semibold hover:bg-primary-hover transition-colors disabled:opacity-50"
+          :disabled="saving"
+          @click="save"
+        >
+          {{ saving ? 'Saving…' : 'Save Order' }}
+        </button>
+        <span v-if="saved" class="text-xs text-success">Saved!</span>
+        <span v-if="saveError" class="text-xs text-danger">{{ saveError }}</span>
+      </div>
+    </template>
+  </div>
+</template>

--- a/ui/src/components/leagues/MembersTab.vue
+++ b/ui/src/components/leagues/MembersTab.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { inviteToLeague } from '../../api/fantasyApi'
+import type { LeagueMember } from '../../api/fantasyApi'
+
+const props = defineProps<{
+  leagueId: string
+  members: LeagueMember[]
+  isOwner: boolean
+  ownerId: string
+  loading: boolean
+  error: string
+}>()
+
+const emit = defineEmits<{
+  invited: [username: string]
+}>()
+
+const inviteUsername = ref('')
+const inviteError = ref('')
+const inviting = ref(false)
+
+async function sendInvite() {
+  if (!inviteUsername.value.trim()) return
+  inviting.value = true
+  inviteError.value = ''
+  try {
+    await inviteToLeague(props.leagueId, inviteUsername.value.trim())
+    emit('invited', inviteUsername.value.trim())
+    inviteUsername.value = ''
+  } catch (e: unknown) {
+    const status = (e as { response?: { status: number } })?.response?.status
+    if (status === 404) inviteError.value = 'User not found.'
+    else if (status === 409) inviteError.value = 'User already invited or league is full.'
+    else inviteError.value = 'Failed to send invite.'
+  } finally {
+    inviting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-6">
+    <!-- Loading / Error -->
+    <div v-if="loading" class="flex justify-center py-8">
+      <div class="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+    </div>
+    <div v-else-if="error" class="text-sm text-danger">{{ error }}</div>
+
+    <template v-else>
+      <!-- Accepted -->
+      <div>
+        <h3 class="text-xs font-semibold text-foreground-muted uppercase tracking-wider mb-2">Members</h3>
+        <div class="flex flex-col divide-y divide-border-subtle rounded-xl border border-border-subtle overflow-hidden">
+          <div
+            v-for="m in members.filter(m => m.status === 'accepted')"
+            :key="m.user_id"
+            class="flex items-center gap-3 px-4 py-3 bg-surface"
+          >
+            <div class="w-7 h-7 rounded-full bg-surface-elevated flex items-center justify-center text-xs font-bold text-foreground-muted">
+              {{ m.username.slice(0, 2).toUpperCase() }}
+            </div>
+            <span class="text-sm text-foreground">{{ m.username }}</span>
+            <span v-if="m.user_id === ownerId" class="ml-auto text-xs text-foreground-muted">owner</span>
+          </div>
+          <div v-if="members.filter(m => m.status === 'accepted').length === 0" class="px-4 py-3 text-sm text-foreground-muted bg-surface">
+            No members yet.
+          </div>
+        </div>
+      </div>
+
+      <!-- Pending -->
+      <div v-if="members.filter(m => m.status === 'pending').length > 0">
+        <h3 class="text-xs font-semibold text-foreground-muted uppercase tracking-wider mb-2">Pending Invites</h3>
+        <div class="flex flex-col divide-y divide-border-subtle rounded-xl border border-border-subtle overflow-hidden">
+          <div
+            v-for="m in members.filter(m => m.status === 'pending')"
+            :key="m.user_id"
+            class="flex items-center gap-3 px-4 py-3 bg-surface"
+          >
+            <div class="w-7 h-7 rounded-full bg-surface-elevated flex items-center justify-center text-xs font-bold text-foreground-muted">
+              {{ m.username.slice(0, 2).toUpperCase() }}
+            </div>
+            <span class="text-sm text-foreground">{{ m.username }}</span>
+            <span class="ml-auto text-xs text-foreground-muted">pending</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Invite (owner only) -->
+      <div v-if="isOwner">
+        <h3 class="text-xs font-semibold text-foreground-muted uppercase tracking-wider mb-2">Invite Player</h3>
+        <div class="flex gap-2">
+          <input
+            v-model="inviteUsername"
+            type="text"
+            placeholder="Enter username..."
+            class="flex-1 rounded-lg bg-surface border border-border-subtle px-4 py-2 text-sm text-foreground placeholder:text-foreground-muted focus:outline-none focus:border-primary"
+            @keydown.enter="sendInvite"
+          />
+          <button
+            class="px-4 py-2 rounded-lg bg-primary text-white text-sm font-semibold hover:bg-primary-hover transition-colors disabled:opacity-50"
+            :disabled="!inviteUsername.trim() || inviting"
+            @click="sendInvite"
+          >
+            {{ inviting ? 'Sending…' : 'Send Invite' }}
+          </button>
+        </div>
+        <p v-if="inviteError" class="mt-1.5 text-xs text-danger">{{ inviteError }}</p>
+      </div>
+    </template>
+  </div>
+</template>

--- a/ui/src/components/leagues/ScoringTab.vue
+++ b/ui/src/components/leagues/ScoringTab.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import type { FantasyLeagueScoringSettings } from '../../types/fantasy'
+
+defineProps<{
+  scoring: FantasyLeagueScoringSettings | null
+  loading: boolean
+  error: string
+}>()
+
+const labels: { key: keyof FantasyLeagueScoringSettings; label: string }[] = [
+  { key: 'kills', label: 'Kills' },
+  { key: 'deaths', label: 'Deaths' },
+  { key: 'assists', label: 'Assists' },
+  { key: 'creep_score', label: 'Creep Score' },
+  { key: 'wards_placed', label: 'Wards Placed' },
+  { key: 'wards_destroyed', label: 'Wards Destroyed' },
+  { key: 'kill_participation', label: 'Kill Participation' },
+  { key: 'damage_percentage', label: 'Damage %' },
+]
+</script>
+
+<template>
+  <div>
+    <div v-if="loading" class="flex justify-center py-8">
+      <div class="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+    </div>
+    <div v-else-if="error" class="text-sm text-danger">{{ error }}</div>
+    <div v-else-if="scoring" class="rounded-xl border border-border-subtle overflow-hidden">
+      <table class="w-full">
+        <thead>
+          <tr class="bg-surface-elevated text-xs text-foreground-muted uppercase tracking-wider">
+            <th class="px-4 py-3 text-left">Stat</th>
+            <th class="px-4 py-3 text-right">Points</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-border-subtle">
+          <tr v-for="row in labels" :key="row.key" class="bg-surface">
+            <td class="px-4 py-3 text-sm text-foreground">{{ row.label }}</td>
+            <td class="px-4 py-3 text-sm text-foreground text-right font-mono">
+              {{ scoring[row.key] }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/ui/src/components/leagues/SettingsTab.vue
+++ b/ui/src/components/leagues/SettingsTab.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { FantasyLeagueSettings } from '../../types/fantasy'
+
+defineProps<{
+  settings: FantasyLeagueSettings | null
+  loading: boolean
+  error: string
+}>()
+</script>
+
+<template>
+  <div>
+    <div v-if="loading" class="flex justify-center py-8">
+      <div class="w-5 h-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+    </div>
+    <div v-else-if="error" class="text-sm text-danger">{{ error }}</div>
+    <div v-else-if="settings" class="flex flex-col gap-4">
+      <div class="rounded-xl border border-border-subtle overflow-hidden">
+        <table class="w-full">
+          <tbody class="divide-y divide-border-subtle">
+            <tr class="bg-surface">
+              <td class="px-4 py-3 text-xs font-medium text-foreground-muted w-40">League Name</td>
+              <td class="px-4 py-3 text-sm text-foreground">{{ settings.name }}</td>
+            </tr>
+            <tr class="bg-surface">
+              <td class="px-4 py-3 text-xs font-medium text-foreground-muted">Number of Teams</td>
+              <td class="px-4 py-3 text-sm text-foreground">{{ settings.number_of_teams }}</td>
+            </tr>
+            <tr class="bg-surface">
+              <td class="px-4 py-3 text-xs font-medium text-foreground-muted">Available Leagues</td>
+              <td class="px-4 py-3 text-sm text-foreground">{{ settings.available_leagues.join(', ') || '—' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -37,6 +37,11 @@ const router = createRouter({
           component: () => import('../views/LeagueDetailView.vue'),
         },
         {
+          path: 'leagues/:id/draft',
+          name: 'league-draft',
+          component: () => import('../views/DraftView.vue'),
+        },
+        {
           path: 'players',
           name: 'players',
           component: () => import('../views/PlayersView.vue'),

--- a/ui/src/stores/auth.ts
+++ b/ui/src/stores/auth.ts
@@ -2,11 +2,11 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { login as apiLogin, signup as apiSignup } from '../api/authApi'
 
-function parseJwtUsername(token: string | null): string | null {
+function parseJwtField(token: string | null, field: string): string | null {
   if (!token) return null
   try {
     const payload = JSON.parse(atob(token.split('.')[1]))
-    return payload.username || null
+    return payload[field] || null
   } catch {
     return null
   }
@@ -24,7 +24,8 @@ function isTokenExpired(token: string | null): boolean {
 
 export const useAuthStore = defineStore('auth', () => {
   const token = ref<string | null>(localStorage.getItem('token'))
-  const username = computed(() => parseJwtUsername(token.value))
+  const username = computed(() => parseJwtField(token.value, 'username'))
+  const userId = computed(() => parseJwtField(token.value, 'user_id'))
   const error = ref<string | null>(null)
 
   const isAuthenticated = computed(() => !!token.value && !isTokenExpired(token.value))
@@ -56,5 +57,5 @@ export const useAuthStore = defineStore('auth', () => {
     localStorage.removeItem('token')
   }
 
-  return { token, username, error, isAuthenticated, login, signup, logout }
+  return { token, username, userId, error, isAuthenticated, login, signup, logout }
 })

--- a/ui/src/views/DraftView.vue
+++ b/ui/src/views/DraftView.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { useRoute } from 'vue-router'
+const route = useRoute()
+const leagueId = route.params.id as string
+</script>
+
+<template>
+  <div class="flex flex-col gap-6">
+    <div>
+      <h2 class="text-lg font-semibold text-foreground">Draft</h2>
+      <p class="mt-1 text-sm text-foreground-muted">League ID: {{ leagueId }}</p>
+    </div>
+    <div class="rounded-xl border border-border-subtle bg-surface px-6 py-10 text-center">
+      <p class="text-foreground-muted text-sm">Draft board coming soon.</p>
+    </div>
+  </div>
+</template>

--- a/ui/src/views/LeagueDetailView.vue
+++ b/ui/src/views/LeagueDetailView.vue
@@ -1,18 +1,215 @@
 <script setup lang="ts">
-import { useRoute } from 'vue-router'
+import { ref, computed, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAuthStore } from '../stores/auth'
+import {
+  getLeagueMembers,
+  getLeagueSettings,
+  getLeagueScoringSettings,
+  getDraftOrder,
+  leaveLeague,
+  startDraft,
+} from '../api/fantasyApi'
+import type {
+  LeagueMember,
+  DraftOrderEntry,
+} from '../api/fantasyApi'
+import type { FantasyLeague, FantasyLeagueSettings, FantasyLeagueScoringSettings } from '../types/fantasy'
+import MembersTab from '../components/leagues/MembersTab.vue'
+import SettingsTab from '../components/leagues/SettingsTab.vue'
+import ScoringTab from '../components/leagues/ScoringTab.vue'
+import DraftOrderTab from '../components/leagues/DraftOrderTab.vue'
 
 const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+
 const leagueId = route.params.id as string
+
+// We get the league object from the router state (passed from LeaguesView) or fetch it
+const league = ref<FantasyLeague | null>((history.state?.league as FantasyLeague) ?? null)
+
+const isOwner = computed(() => !!auth.userId && league.value?.owner_id === auth.userId)
+const acceptedCount = computed(() => members.value.filter(m => m.status === 'accepted').length)
+const isFull = computed(() => !!league.value && acceptedCount.value >= league.value.number_of_teams)
+
+type Tab = 'members' | 'settings' | 'scoring' | 'draft-order'
+const activeTab = ref<Tab>('members')
+const tabs: { key: Tab; label: string }[] = [
+  { key: 'members', label: 'Members' },
+  { key: 'settings', label: 'Settings' },
+  { key: 'scoring', label: 'Scoring' },
+  { key: 'draft-order', label: 'Draft Order' },
+]
+
+// Per-tab data
+const members = ref<LeagueMember[]>([])
+const membersLoading = ref(false)
+const membersError = ref('')
+
+const settings = ref<FantasyLeagueSettings | null>(null)
+const settingsLoading = ref(false)
+const settingsError = ref('')
+
+const scoring = ref<FantasyLeagueScoringSettings | null>(null)
+const scoringLoading = ref(false)
+const scoringError = ref('')
+
+const draftOrder = ref<DraftOrderEntry[]>([])
+const draftOrderLoading = ref(false)
+const draftOrderError = ref('')
+
+const startingDraft = ref(false)
+const startDraftError = ref('')
+const leavingLeague = ref(false)
+
+async function fetchAll() {
+  membersLoading.value = true
+  settingsLoading.value = true
+  scoringLoading.value = true
+  draftOrderLoading.value = true
+
+  await Promise.allSettled([
+    getLeagueMembers(leagueId).then(d => { members.value = d }).catch(() => { membersError.value = 'Unable to load members.' }).finally(() => { membersLoading.value = false }),
+    getLeagueSettings(leagueId).then(d => { settings.value = d }).catch(() => { settingsError.value = 'Unable to load settings.' }).finally(() => { settingsLoading.value = false }),
+    getLeagueScoringSettings(leagueId).then(d => { scoring.value = d }).catch(() => { scoringError.value = 'Unable to load scoring.' }).finally(() => { scoringLoading.value = false }),
+    getDraftOrder(leagueId).then(d => { draftOrder.value = d }).catch(() => { draftOrderError.value = 'Unable to load draft order.' }).finally(() => { draftOrderLoading.value = false }),
+  ])
+}
+
+onMounted(fetchAll)
+
+function onInvited(username: string) {
+  members.value.push({ user_id: username, username, status: 'pending' })
+}
+
+async function onLeave() {
+  leavingLeague.value = true
+  try {
+    await leaveLeague(leagueId)
+    router.push({ name: 'leagues' })
+  } catch {
+    leavingLeague.value = false
+  }
+}
+
+async function onStartDraft() {
+  startingDraft.value = true
+  startDraftError.value = ''
+  try {
+    await startDraft(leagueId)
+    router.push({ name: 'league-draft', params: { id: leagueId } })
+  } catch {
+    startDraftError.value = 'Failed to start draft.'
+    startingDraft.value = false
+  }
+}
+
+const statusColors: Record<string, string> = {
+  'pre-draft': '#f59e0b',
+  draft: '#3b82f6',
+  active: '#22c55e',
+  completed: '#64748b',
+}
 </script>
 
 <template>
   <div class="flex flex-col gap-6">
-    <div>
-      <h2 class="text-lg font-semibold text-foreground">League Details</h2>
-      <p class="mt-1 text-sm text-foreground-muted">League ID: {{ leagueId }}</p>
+    <!-- Header -->
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <h2 class="text-lg font-semibold text-foreground">{{ league?.name ?? 'League' }}</h2>
+        <div class="flex items-center gap-3 mt-1">
+          <span
+            v-if="league"
+            class="text-xs font-bold px-2 py-0.5 rounded-md capitalize"
+            :style="{
+              background: `${statusColors[league.status] ?? '#64748b'}1a`,
+              color: statusColors[league.status] ?? '#64748b',
+            }"
+          >
+            {{ league.status }}
+          </span>
+          <span class="text-sm text-foreground-muted">
+            {{ acceptedCount }}/{{ league?.number_of_teams ?? '?' }} members
+          </span>
+        </div>
+      </div>
+
+      <div class="flex flex-col items-end gap-1">
+        <!-- Owner: Start Draft -->
+        <button
+          v-if="isOwner"
+          class="px-4 py-2 rounded-lg text-sm font-semibold transition-colors"
+          :class="isFull
+            ? 'bg-primary text-white hover:bg-primary-hover'
+            : 'bg-surface border border-border-subtle text-foreground-muted cursor-not-allowed'"
+          :disabled="!isFull || startingDraft"
+          @click="onStartDraft"
+        >
+          {{ startingDraft ? 'Starting…' : 'Start Draft' }}
+        </button>
+        <!-- Non-owner: Leave -->
+        <button
+          v-else
+          class="px-4 py-2 rounded-lg border border-border-subtle text-sm text-foreground-muted hover:text-foreground transition-colors"
+          :disabled="leavingLeague"
+          @click="onLeave"
+        >
+          {{ leavingLeague ? 'Leaving…' : 'Leave League' }}
+        </button>
+        <p v-if="startDraftError" class="text-xs text-danger">{{ startDraftError }}</p>
+        <p v-if="!isFull && isOwner" class="text-xs text-foreground-muted">
+          Need {{ (league?.number_of_teams ?? 0) - acceptedCount }} more member(s) to start
+        </p>
+      </div>
     </div>
-    <div class="rounded-xl border border-border-subtle bg-surface px-6 py-10 text-center">
-      <p class="text-foreground-muted text-sm">League details coming soon.</p>
+
+    <!-- Tabs -->
+    <div class="flex gap-1 p-1 rounded-lg bg-surface border border-border-subtle w-fit">
+      <button
+        v-for="tab in tabs"
+        :key="tab.key"
+        class="px-4 py-1.5 rounded-md text-xs font-medium transition-colors"
+        :class="activeTab === tab.key
+          ? 'bg-primary text-white'
+          : 'text-foreground-muted hover:text-foreground'"
+        @click="activeTab = tab.key"
+      >
+        {{ tab.label }}
+      </button>
     </div>
+
+    <!-- Tab content -->
+    <MembersTab
+      v-if="activeTab === 'members'"
+      :league-id="leagueId"
+      :members="members"
+      :is-owner="isOwner"
+      :owner-id="league?.owner_id ?? ''"
+      :loading="membersLoading"
+      :error="membersError"
+      @invited="onInvited"
+    />
+    <SettingsTab
+      v-else-if="activeTab === 'settings'"
+      :settings="settings"
+      :loading="settingsLoading"
+      :error="settingsError"
+    />
+    <ScoringTab
+      v-else-if="activeTab === 'scoring'"
+      :scoring="scoring"
+      :loading="scoringLoading"
+      :error="scoringError"
+    />
+    <DraftOrderTab
+      v-else-if="activeTab === 'draft-order'"
+      :league-id="leagueId"
+      :draft-order="draftOrder"
+      :is-owner="isOwner"
+      :loading="draftOrderLoading"
+      :error="draftOrderError"
+    />
   </div>
 </template>


### PR DESCRIPTION
- Add userId computed to auth store (parsed from JWT)
- Expand fantasyApi with getLeagueMembers, getLeagueSettings, getLeagueScoringSettings, getDraftOrder, updateDraftOrder, inviteToLeague, startDraft
- Rewrite LeagueDetailView with header (Start Draft / Leave League), tab bar, and per-tab components
- MembersTab: accepted/pending list + owner invite with inline errors
- SettingsTab: read-only league settings table
- ScoringTab: read-only scoring weights table
- DraftOrderTab: owner drag-and-drop reorder (vuedraggable) + Save; non-owner static list
- Add DraftView placeholder at /leagues/:id/draft
- Add league-draft route to router
- Install vuedraggable@4.1.0

closes #456 