### PR TITLE
fix: League detail bugs and re-invite 500 error

### DIFF
--- a/src/common/schemas/fantasy_schemas.py
+++ b/src/common/schemas/fantasy_schemas.py
@@ -174,6 +174,12 @@ class FantasyLeagueMembership(BaseModel):
     status: FantasyLeagueMembershipStatus
 
 
+class FantasyLeagueMemberResponse(BaseModel):
+    user_id: UserID
+    username: str
+    status: FantasyLeagueMembershipStatus
+
+
 class UsersFantasyLeagues(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/src/fantasy/endpoints/fantasy_league_endpoint_v1.py
+++ b/src/fantasy/endpoints/fantasy_league_endpoint_v1.py
@@ -6,6 +6,7 @@ from src.auth.auth_principal import AuthPrincipal
 from src.common.schemas.fantasy_schemas import (
     FantasyLeague,
     FantasyLeagueID,
+    FantasyLeagueMemberResponse,
     FantasyLeagueSettings,
     FantasyLeagueScoringSettings,
     UsersFantasyLeagues,
@@ -50,9 +51,39 @@ class FantasyLeagueEndpoint(Routable):
         )
 
     @get(
+        path="/leagues/{fantasy_league_id}",
+        description="Get a Fantasy League by ID. The caller must be an accepted member.",
+        tags=["Fantasy Leagues"],
+        response_model=FantasyLeague,
+    )
+    def get_fantasy_league_by_id(
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_READ])),
+    ) -> FantasyLeague:
+        return self.__fantasy_league_service.get_fantasy_league_by_id(
+            principal.user_id, fantasy_league_id
+        )
+
+    @get(
+        path="/leagues/{fantasy_league_id}/members",
+        description="Get members of a Fantasy League. The caller must be an accepted member.",
+        tags=["Fantasy Leagues"],
+        response_model=list[FantasyLeagueMemberResponse],
+    )
+    def get_fantasy_league_members(
+        self,
+        fantasy_league_id: FantasyLeagueID,
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_READ])),
+    ) -> list[FantasyLeagueMemberResponse]:
+        return self.__fantasy_league_service.get_league_members(
+            principal.user_id, fantasy_league_id
+        )
+
+    @get(
         path="/leagues/{fantasy_league_id}/settings",
         description="Get the settings for a given Fantasy League. "
-        "The caller must be the owner of the Fantasy League.",
+        "The caller must be an accepted member of the Fantasy League.",
         tags=["Fantasy Leagues"],
         response_model=FantasyLeagueSettings,
     )
@@ -85,7 +116,7 @@ class FantasyLeagueEndpoint(Routable):
     @get(
         path="/leagues/{fantasy_league_id}/scoring",
         description="Get the scoring settings for a given Fantasy League. "
-        "The caller must be the owner of the Fantasy League.",
+        "The caller must be an accepted member of the Fantasy League.",
         tags=["Fantasy Leagues"],
         response_model=FantasyLeagueScoringSettings,
     )
@@ -175,7 +206,7 @@ class FantasyLeagueEndpoint(Routable):
     @get(
         path="/leagues/{fantasy_league_id}/draft-order",
         description="Get draft order of the Fantasy League. "
-        "The caller must be the owner of the Fantasy League.",
+        "The caller must be an accepted member of the Fantasy League.",
         tags=["Fantasy Leagues"],
         response_model=list[FantasyLeagueDraftOrderResponse],
     )

--- a/src/fantasy/service/fantasy_league_service.py
+++ b/src/fantasy/service/fantasy_league_service.py
@@ -90,11 +90,13 @@ class FantasyLeagueService:
             user = self.db.get_user_by_id(membership.user_id)
             if user is None:
                 raise UserNotFoundException()
-            result.append(FantasyLeagueMemberResponse(
-                user_id=user.id,
-                username=user.username,
-                status=membership.status,
-            ))
+            result.append(
+                FantasyLeagueMemberResponse(
+                    user_id=user.id,
+                    username=user.username,
+                    status=membership.status,
+                )
+            )
         return result
 
     def get_fantasy_league_settings(

--- a/src/fantasy/service/fantasy_league_service.py
+++ b/src/fantasy/service/fantasy_league_service.py
@@ -9,6 +9,7 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueStatus,
     FantasyLeagueMembership,
     FantasyLeagueMembershipStatus,
+    FantasyLeagueMemberResponse,
     UsersFantasyLeagues,
     FantasyLeagueScoringSettings,
     FantasyLeagueDraftOrderResponse,
@@ -71,19 +72,41 @@ class FantasyLeagueService:
                 break
         return new_id
 
+    def get_fantasy_league_by_id(
+        self, user_id: UserID, league_id: FantasyLeagueID
+    ) -> FantasyLeague:
+        fantasy_league = self.fantasy_league_util.validate_league(league_id)
+        self.fantasy_league_util.validate_membership(user_id, league_id)
+        return fantasy_league
+
+    def get_league_members(
+        self, user_id: UserID, league_id: FantasyLeagueID
+    ) -> list[FantasyLeagueMemberResponse]:
+        self.fantasy_league_util.validate_league(league_id)
+        self.fantasy_league_util.validate_membership(user_id, league_id)
+        memberships = self.db.get_pending_and_accepted_members_for_league(league_id)
+        result = []
+        for membership in memberships:
+            user = self.db.get_user_by_id(membership.user_id)
+            if user is None:
+                raise UserNotFoundException()
+            result.append(FantasyLeagueMemberResponse(
+                user_id=user.id,
+                username=user.username,
+                status=membership.status,
+            ))
+        return result
+
     def get_fantasy_league_settings(
-        self, owner_id: UserID, league_id: FantasyLeagueID
+        self, user_id: UserID, league_id: FantasyLeagueID
     ) -> FantasyLeagueSettings:
         fantasy_league_model = self.fantasy_league_util.validate_league(league_id)
-        if fantasy_league_model.owner_id != owner_id:
-            raise ForbiddenException()
-
-        league_settings = FantasyLeagueSettings(
+        self.fantasy_league_util.validate_membership(user_id, league_id)
+        return FantasyLeagueSettings(
             name=fantasy_league_model.name,
             number_of_teams=fantasy_league_model.number_of_teams,
             available_leagues=fantasy_league_model.available_leagues,
         )
-        return league_settings
 
     def update_fantasy_league_settings(
         self,
@@ -124,11 +147,10 @@ class FantasyLeagueService:
         return updated_fantasy_league_settings
 
     def get_scoring_settings(
-        self, owner_id: UserID, league_id: FantasyLeagueID
+        self, user_id: UserID, league_id: FantasyLeagueID
     ) -> FantasyLeagueScoringSettings:
-        fantasy_league_model = self.fantasy_league_util.validate_league(league_id)
-        if fantasy_league_model.owner_id != owner_id:
-            raise ForbiddenException()
+        self.fantasy_league_util.validate_league(league_id)
+        self.fantasy_league_util.validate_membership(user_id, league_id)
         scoring_settings = self.db.get_fantasy_league_scoring_settings_by_id(league_id)
         assert scoring_settings is not None
         return scoring_settings
@@ -272,9 +294,8 @@ class FantasyLeagueService:
     def get_fantasy_league_draft_order(
         self, user_id: UserID, league_id: FantasyLeagueID
     ) -> list[FantasyLeagueDraftOrderResponse]:
-        fantasy_league_model = self.fantasy_league_util.validate_league(league_id)
-        if fantasy_league_model.owner_id != user_id:
-            raise ForbiddenException()
+        self.fantasy_league_util.validate_league(league_id)
+        self.fantasy_league_util.validate_membership(user_id, league_id)
 
         draft_order_response = []
         current_draft_order = self.db.get_fantasy_league_draft_order(league_id)

--- a/src/fantasy/service/fantasy_league_service.py
+++ b/src/fantasy/service/fantasy_league_service.py
@@ -204,9 +204,22 @@ class FantasyLeagueService:
         if user is None or user.account_status != UserAccountStatus.ACTIVE:
             raise UserNotFoundException()
 
-        self.create_fantasy_league_membership(
-            league_id, user.id, FantasyLeagueMembershipStatus.PENDING
-        )
+        existing_membership = self.db.get_user_membership_for_fantasy_league(user.id, league_id)
+        if existing_membership is not None:
+            if existing_membership.status in (
+                FantasyLeagueMembershipStatus.PENDING,
+                FantasyLeagueMembershipStatus.ACCEPTED,
+            ):
+                raise FantasyLeagueInviteException(
+                    f"User {username} is already a pending or accepted member of the league"
+                )
+            self.db.update_fantasy_league_membership_status(
+                existing_membership, FantasyLeagueMembershipStatus.PENDING
+            )
+        else:
+            self.create_fantasy_league_membership(
+                league_id, user.id, FantasyLeagueMembershipStatus.PENDING
+            )
 
     def join_fantasy_league(self, user_id: UserID, league_id: FantasyLeagueID) -> None:
         logger.info("User=%s joining league=%s", user_id, league_id)

--- a/src/fantasy/util/fantasy_league_util.py
+++ b/src/fantasy/util/fantasy_league_util.py
@@ -7,6 +7,7 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueDraftOrder,
     FantasyLeagueDraftOrderResponse,
     FantasyLeagueID,
+    FantasyLeagueMembershipStatus,
     FantasyLeagueStatus,
     UserID,
 )
@@ -19,6 +20,7 @@ from src.fantasy.exceptions import (
     FantasyLeagueInvalidRequiredStateException,
     FantasyUnavailableException,
     DraftOrderException,
+    ForbiddenException,
 )
 
 
@@ -40,6 +42,11 @@ class FantasyLeagueUtil:
             )
 
         return fantasy_league
+
+    def validate_membership(self, user_id: UserID, league_id: FantasyLeagueID) -> None:
+        membership = self.db.get_user_membership_for_fantasy_league(user_id, league_id)
+        if membership is None or membership.status != FantasyLeagueMembershipStatus.ACCEPTED:
+            raise ForbiddenException()
 
     def validate_available_leagues(self, selected_league_ids: list[RiotLeagueID]) -> None:
         riot_leagues = self.db.get_leagues()

--- a/tests/fantasy/integration/service/test_fantasy_league_service.py
+++ b/tests/fantasy/integration/service/test_fantasy_league_service.py
@@ -695,7 +695,7 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
     def test_send_fantasy_league_invite_to_deleted_user(self):
         # Arrange
         user = fantasy_fixtures.user_fixture
-        deleted_user = fantasy_fixtures.user_2_fixture
+        deleted_user = deepcopy(fantasy_fixtures.user_2_fixture)
         deleted_user.account_status = UserAccountStatus.DELETED
         fantasy_league = fantasy_fixtures.fantasy_league_fixture
         self.db.create_user(user)

--- a/tests/fantasy/integration/service/test_fantasy_league_service.py
+++ b/tests/fantasy/integration/service/test_fantasy_league_service.py
@@ -166,6 +166,11 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         # Arrange
         self.db.create_fantasy_league(fantasy_fixtures.fantasy_league_fixture)
         self.db.create_user(fantasy_fixtures.user_fixture)
+        self.create_fantasy_league_membership_for_league(
+            fantasy_fixtures.fantasy_league_fixture.id,
+            fantasy_fixtures.user_fixture.id,
+            FantasyLeagueMembershipStatus.ACCEPTED,
+        )
         expected_fantasy_league_settings = fantasy_fixtures.fantasy_league_settings_fixture
 
         # Act
@@ -354,6 +359,9 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         self.db.create_user(user)
         self.db.create_fantasy_league(fantasy_league)
         self.db.put_fantasy_league_scoring_settings(expected_scoring_settings)
+        self.create_fantasy_league_membership_for_league(
+            fantasy_league.id, user.id, FantasyLeagueMembershipStatus.ACCEPTED
+        )
 
         # Act
         returned_scoring_settings = self.fantasy_league_service.get_scoring_settings(
@@ -1164,6 +1172,9 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
         fantasy_league = fantasy_fixtures.fantasy_league_fixture
         self.db.create_fantasy_league(fantasy_league)
         self.db.create_user(user_1)
+        self.create_fantasy_league_membership_for_league(
+            fantasy_league.id, user_1.id, FantasyLeagueMembershipStatus.ACCEPTED
+        )
         user_1_draft_order = self.create_draft_order_for_fantasy_league(
             fantasy_league.id, user_1.id, 1
         )

--- a/tests/fantasy/unit/service/test_fantasy_league_service.py
+++ b/tests/fantasy/unit/service/test_fantasy_league_service.py
@@ -8,6 +8,9 @@ from tests.test_util import fantasy_fixtures
 from src.common.schemas.fantasy_schemas import (
     FantasyLeague,
     FantasyLeagueID,
+    FantasyLeagueMembership,
+    FantasyLeagueMembershipStatus,
+    FantasyLeagueMemberResponse,
     FantasyLeagueSettings,
     FantasyLeagueStatus,
     UserID,
@@ -72,20 +75,22 @@ class TestFantasyLeagueService(TestBase):
         # Arrange
         expected_fantasy_league_settings = fantasy_fixtures.fantasy_league_settings_fixture
         fantasy_league = fantasy_fixtures.fantasy_league_fixture
-
+        member = fantasy_fixtures.user_2_fixture  # non-owner accepted member
+        accepted_membership = FantasyLeagueMembership(
+            league_id=fantasy_league.id,
+            user_id=member.id,
+            status=FantasyLeagueMembershipStatus.ACCEPTED,
+        )
         self.mock_db_service.get_fantasy_league_by_id.return_value = fantasy_league
-
-        owner_id = fantasy_league.owner_id
-        league_id = fantasy_league.id
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = accepted_membership
 
         # Act
         fantasy_league_settings = self.fantasy_league_service.get_fantasy_league_settings(
-            owner_id, league_id
+            member.id, fantasy_league.id
         )
 
         # Assert
         self.assertEqual(expected_fantasy_league_settings, fantasy_league_settings)
-        self.mock_db_service.get_fantasy_league_by_id.assert_called_once_with(fantasy_league.id)
 
     def test_get_fantasy_league_settings_no_league_found_exception(self):
         # Arrange
@@ -97,20 +102,19 @@ class TestFantasyLeagueService(TestBase):
             self.fantasy_league_service.get_fantasy_league_settings(
                 fantasy_league.owner_id, fantasy_league.id
             )
-        self.mock_db_service.get_fantasy_league_by_id.assert_called_once_with(fantasy_league.id)
 
-    def test_get_fantasy_league_settings_forbidden_exception(self):
+    def test_get_fantasy_league_settings_non_member_raises_forbidden(self):
         # Arrange
         fantasy_league = fantasy_fixtures.fantasy_league_fixture
-        owner_id = UserID(str(uuid.uuid4()))
-        league_id = fantasy_league.id
-
+        non_member_id = UserID(str(uuid.uuid4()))
         self.mock_db_service.get_fantasy_league_by_id.return_value = fantasy_league
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = None
 
         # Act and Assert
         with self.assertRaises(ForbiddenException):
-            self.fantasy_league_service.get_fantasy_league_settings(owner_id, league_id)
-        self.mock_db_service.get_fantasy_league_by_id.assert_called_once_with(league_id)
+            self.fantasy_league_service.get_fantasy_league_settings(
+                non_member_id, fantasy_league.id
+            )
 
     def test_update_fantasy_league_settings_successful(self):
         # Arrange
@@ -178,3 +182,158 @@ class TestFantasyLeagueService(TestBase):
             )
         self.mock_db_service.get_fantasy_league_by_id.assert_called_once_with(league_id)
         self.mock_db_service.update_fantasy_league_settings.assert_not_called()
+
+    # --- get_scoring_settings ---
+
+    def test_get_scoring_settings_accepted_member_successful(self):
+        # Arrange
+        league = fantasy_fixtures.fantasy_league_fixture
+        member = fantasy_fixtures.user_2_fixture
+        expected_scoring = fantasy_fixtures.fantasy_league_scoring_settings_fixture
+        self.mock_db_service.get_fantasy_league_by_id.return_value = league
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = (
+            FantasyLeagueMembership(
+                league_id=league.id,
+                user_id=member.id,
+                status=FantasyLeagueMembershipStatus.ACCEPTED,
+            )
+        )
+        self.mock_db_service.get_fantasy_league_scoring_settings_by_id.return_value = (
+            expected_scoring
+        )
+
+        result = self.fantasy_league_service.get_scoring_settings(member.id, league.id)
+
+        self.assertEqual(expected_scoring, result)
+
+    def test_get_scoring_settings_non_member_raises_forbidden(self):
+        # Arrange
+        league = fantasy_fixtures.fantasy_league_fixture
+        self.mock_db_service.get_fantasy_league_by_id.return_value = league
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = None
+
+        with self.assertRaises(ForbiddenException):
+            self.fantasy_league_service.get_scoring_settings(
+                UserID(str(uuid.uuid4())), league.id
+            )
+
+    # --- get_fantasy_league_by_id ---
+
+    def test_get_fantasy_league_by_id_accepted_member_successful(self):
+        # Arrange
+        league = fantasy_fixtures.fantasy_league_fixture
+        member = fantasy_fixtures.user_2_fixture
+        self.mock_db_service.get_fantasy_league_by_id.return_value = league
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = (
+            FantasyLeagueMembership(
+                league_id=league.id,
+                user_id=member.id,
+                status=FantasyLeagueMembershipStatus.ACCEPTED,
+            )
+        )
+
+        result = self.fantasy_league_service.get_fantasy_league_by_id(member.id, league.id)
+
+        self.assertEqual(league, result)
+
+    def test_get_fantasy_league_by_id_league_not_found_raises_exception(self):
+        self.mock_db_service.get_fantasy_league_by_id.return_value = None
+
+        with self.assertRaises(FantasyLeagueNotFoundException):
+            self.fantasy_league_service.get_fantasy_league_by_id(
+                UserID(str(uuid.uuid4())), FantasyLeagueID(str(uuid.uuid4()))
+            )
+
+    def test_get_fantasy_league_by_id_non_member_raises_forbidden(self):
+        league = fantasy_fixtures.fantasy_league_fixture
+        self.mock_db_service.get_fantasy_league_by_id.return_value = league
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = None
+
+        with self.assertRaises(ForbiddenException):
+            self.fantasy_league_service.get_fantasy_league_by_id(
+                UserID(str(uuid.uuid4())), league.id
+            )
+
+    # --- get_league_members ---
+
+    def test_get_league_members_returns_members_with_usernames(self):
+        # Arrange
+        league = fantasy_fixtures.fantasy_league_fixture
+        user1 = fantasy_fixtures.user_fixture
+        user2 = fantasy_fixtures.user_2_fixture
+        memberships = [
+            FantasyLeagueMembership(
+                league_id=league.id,
+                user_id=user1.id,
+                status=FantasyLeagueMembershipStatus.ACCEPTED,
+            ),
+            FantasyLeagueMembership(
+                league_id=league.id,
+                user_id=user2.id,
+                status=FantasyLeagueMembershipStatus.PENDING,
+            ),
+        ]
+        self.mock_db_service.get_fantasy_league_by_id.return_value = league
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = memberships[0]
+        self.mock_db_service.get_pending_and_accepted_members_for_league.return_value = memberships
+        self.mock_db_service.get_user_by_id.side_effect = [user1, user2]
+
+        result = self.fantasy_league_service.get_league_members(user1.id, league.id)
+
+        self.assertEqual(2, len(result))
+        self.assertEqual(
+            FantasyLeagueMemberResponse(
+                user_id=user1.id,
+                username=user1.username,
+                status=FantasyLeagueMembershipStatus.ACCEPTED,
+            ),
+            result[0],
+        )
+        self.assertEqual(
+            FantasyLeagueMemberResponse(
+                user_id=user2.id,
+                username=user2.username,
+                status=FantasyLeagueMembershipStatus.PENDING,
+            ),
+            result[1],
+        )
+
+    def test_get_league_members_non_member_raises_forbidden(self):
+        league = fantasy_fixtures.fantasy_league_fixture
+        self.mock_db_service.get_fantasy_league_by_id.return_value = league
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = None
+
+        with self.assertRaises(ForbiddenException):
+            self.fantasy_league_service.get_league_members(
+                UserID(str(uuid.uuid4())), league.id
+            )
+
+    # --- get_fantasy_league_draft_order ---
+
+    def test_get_fantasy_league_draft_order_accepted_member_successful(self):
+        # Arrange
+        league = fantasy_fixtures.fantasy_league_fixture
+        member = fantasy_fixtures.user_2_fixture
+        self.mock_db_service.get_fantasy_league_by_id.return_value = league
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = (
+            FantasyLeagueMembership(
+                league_id=league.id,
+                user_id=member.id,
+                status=FantasyLeagueMembershipStatus.ACCEPTED,
+            )
+        )
+        self.mock_db_service.get_fantasy_league_draft_order.return_value = []
+
+        result = self.fantasy_league_service.get_fantasy_league_draft_order(member.id, league.id)
+
+        self.assertEqual([], result)
+
+    def test_get_fantasy_league_draft_order_non_member_raises_forbidden(self):
+        league = fantasy_fixtures.fantasy_league_fixture
+        self.mock_db_service.get_fantasy_league_by_id.return_value = league
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = None
+
+        with self.assertRaises(ForbiddenException):
+            self.fantasy_league_service.get_fantasy_league_draft_order(
+                UserID(str(uuid.uuid4())), league.id
+            )

--- a/tests/fantasy/unit/service/test_fantasy_league_service.py
+++ b/tests/fantasy/unit/service/test_fantasy_league_service.py
@@ -15,7 +15,7 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueStatus,
     UserID,
 )
-from src.fantasy.exceptions import FantasyLeagueNotFoundException, ForbiddenException
+from src.fantasy.exceptions import FantasyLeagueNotFoundException, ForbiddenException, FantasyLeagueInviteException
 from src.fantasy.service import FantasyLeagueService
 
 FANTASY_LEAGUE_SERV_PATH = "src.fantasy.service.fantasy_league_service.FantasyLeagueService"
@@ -336,4 +336,69 @@ class TestFantasyLeagueService(TestBase):
         with self.assertRaises(ForbiddenException):
             self.fantasy_league_service.get_fantasy_league_draft_order(
                 UserID(str(uuid.uuid4())), league.id
+            )
+
+    # --- send_fantasy_league_invite ---
+
+    def _setup_invite(self, membership_status=None):
+        """Helper: sets up league, owner, and target user for invite tests."""
+        league = fantasy_fixtures.fantasy_league_fixture
+        owner = fantasy_fixtures.user_fixture
+        target = fantasy_fixtures.user_2_fixture
+        self.mock_db_service.get_fantasy_league_by_id.return_value = league
+        self.mock_db_service.get_pending_and_accepted_members_for_league.return_value = []
+        self.mock_db_service.get_user_by_username.return_value = target
+        if membership_status is None:
+            self.mock_db_service.get_user_membership_for_fantasy_league.return_value = None
+        else:
+            self.mock_db_service.get_user_membership_for_fantasy_league.return_value = (
+                FantasyLeagueMembership(
+                    league_id=league.id, user_id=target.id, status=membership_status
+                )
+            )
+        return league, owner, target
+
+    def test_send_invite_no_existing_membership_creates_pending(self):
+        league, owner, target = self._setup_invite(membership_status=None)
+
+        self.fantasy_league_service.send_fantasy_league_invite(
+            owner.id, league.id, target.username
+        )
+
+        self.mock_db_service.create_fantasy_league_membership.assert_called_once()
+
+    def test_send_invite_declined_member_updates_to_pending(self):
+        league, owner, target = self._setup_invite(FantasyLeagueMembershipStatus.DECLINED)
+
+        self.fantasy_league_service.send_fantasy_league_invite(
+            owner.id, league.id, target.username
+        )
+
+        self.mock_db_service.update_fantasy_league_membership_status.assert_called_once()
+        self.mock_db_service.create_fantasy_league_membership.assert_not_called()
+
+    def test_send_invite_revoked_member_updates_to_pending(self):
+        league, owner, target = self._setup_invite(FantasyLeagueMembershipStatus.REVOKED)
+
+        self.fantasy_league_service.send_fantasy_league_invite(
+            owner.id, league.id, target.username
+        )
+
+        self.mock_db_service.update_fantasy_league_membership_status.assert_called_once()
+        self.mock_db_service.create_fantasy_league_membership.assert_not_called()
+
+    def test_send_invite_pending_member_raises_invite_exception(self):
+        league, owner, target = self._setup_invite(FantasyLeagueMembershipStatus.PENDING)
+
+        with self.assertRaises(FantasyLeagueInviteException):
+            self.fantasy_league_service.send_fantasy_league_invite(
+                owner.id, league.id, target.username
+            )
+
+    def test_send_invite_accepted_member_raises_invite_exception(self):
+        league, owner, target = self._setup_invite(FantasyLeagueMembershipStatus.ACCEPTED)
+
+        with self.assertRaises(FantasyLeagueInviteException):
+            self.fantasy_league_service.send_fantasy_league_invite(
+                owner.id, league.id, target.username
             )

--- a/tests/fantasy/unit/service/test_fantasy_league_service.py
+++ b/tests/fantasy/unit/service/test_fantasy_league_service.py
@@ -15,7 +15,11 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueStatus,
     UserID,
 )
-from src.fantasy.exceptions import FantasyLeagueNotFoundException, ForbiddenException, FantasyLeagueInviteException
+from src.fantasy.exceptions import (
+    FantasyLeagueNotFoundException,
+    ForbiddenException,
+    FantasyLeagueInviteException,
+)
 from src.fantasy.service import FantasyLeagueService
 
 FANTASY_LEAGUE_SERV_PATH = "src.fantasy.service.fantasy_league_service.FantasyLeagueService"
@@ -82,7 +86,9 @@ class TestFantasyLeagueService(TestBase):
             status=FantasyLeagueMembershipStatus.ACCEPTED,
         )
         self.mock_db_service.get_fantasy_league_by_id.return_value = fantasy_league
-        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = accepted_membership
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = (
+            accepted_membership
+        )
 
         # Act
         fantasy_league_settings = self.fantasy_league_service.get_fantasy_league_settings(
@@ -213,9 +219,7 @@ class TestFantasyLeagueService(TestBase):
         self.mock_db_service.get_user_membership_for_fantasy_league.return_value = None
 
         with self.assertRaises(ForbiddenException):
-            self.fantasy_league_service.get_scoring_settings(
-                UserID(str(uuid.uuid4())), league.id
-            )
+            self.fantasy_league_service.get_scoring_settings(UserID(str(uuid.uuid4())), league.id)
 
     # --- get_fantasy_league_by_id ---
 
@@ -304,9 +308,7 @@ class TestFantasyLeagueService(TestBase):
         self.mock_db_service.get_user_membership_for_fantasy_league.return_value = None
 
         with self.assertRaises(ForbiddenException):
-            self.fantasy_league_service.get_league_members(
-                UserID(str(uuid.uuid4())), league.id
-            )
+            self.fantasy_league_service.get_league_members(UserID(str(uuid.uuid4())), league.id)
 
     # --- get_fantasy_league_draft_order ---
 
@@ -361,18 +363,14 @@ class TestFantasyLeagueService(TestBase):
     def test_send_invite_no_existing_membership_creates_pending(self):
         league, owner, target = self._setup_invite(membership_status=None)
 
-        self.fantasy_league_service.send_fantasy_league_invite(
-            owner.id, league.id, target.username
-        )
+        self.fantasy_league_service.send_fantasy_league_invite(owner.id, league.id, target.username)
 
         self.mock_db_service.create_fantasy_league_membership.assert_called_once()
 
     def test_send_invite_declined_member_updates_to_pending(self):
         league, owner, target = self._setup_invite(FantasyLeagueMembershipStatus.DECLINED)
 
-        self.fantasy_league_service.send_fantasy_league_invite(
-            owner.id, league.id, target.username
-        )
+        self.fantasy_league_service.send_fantasy_league_invite(owner.id, league.id, target.username)
 
         self.mock_db_service.update_fantasy_league_membership_status.assert_called_once()
         self.mock_db_service.create_fantasy_league_membership.assert_not_called()
@@ -380,9 +378,7 @@ class TestFantasyLeagueService(TestBase):
     def test_send_invite_revoked_member_updates_to_pending(self):
         league, owner, target = self._setup_invite(FantasyLeagueMembershipStatus.REVOKED)
 
-        self.fantasy_league_service.send_fantasy_league_invite(
-            owner.id, league.id, target.username
-        )
+        self.fantasy_league_service.send_fantasy_league_invite(owner.id, league.id, target.username)
 
         self.mock_db_service.update_fantasy_league_membership_status.assert_called_once()
         self.mock_db_service.create_fantasy_league_membership.assert_not_called()

--- a/tests/fantasy/unit/util/test_fantasy_league_util.py
+++ b/tests/fantasy/unit/util/test_fantasy_league_util.py
@@ -9,6 +9,8 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeague,
     FantasyLeagueDraftOrder,
     FantasyLeagueDraftOrderResponse,
+    FantasyLeagueMembership,
+    FantasyLeagueMembershipStatus,
     FantasyLeagueStatus,
     FantasyLeagueID,
     UserID,
@@ -21,6 +23,7 @@ from src.fantasy.exceptions import (
     FantasyLeagueNotFoundException,
     FantasyLeagueInvalidRequiredStateException,
     FantasyUnavailableException,
+    ForbiddenException,
 )
 from src.fantasy.util import FantasyLeagueUtil
 
@@ -32,6 +35,63 @@ class TestFantasyLeagueUtil(TestBase):
 
     def tearDown(self):
         self.mock_db_service.reset_mock()
+
+    def test_validate_membership_accepted_member_passes(self):
+        # Arrange
+        user = fantasy_fixtures.user_fixture
+        league = fantasy_fixtures.fantasy_league_fixture
+        membership = FantasyLeagueMembership(
+            league_id=league.id,
+            user_id=user.id,
+            status=FantasyLeagueMembershipStatus.ACCEPTED,
+        )
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = membership
+
+        # Act / Assert — should not raise
+        try:
+            self.fantasy_league_util.validate_membership(user.id, league.id)
+        except ForbiddenException:
+            self.fail("validate_membership raised ForbiddenException for an accepted member")
+
+    def test_validate_membership_pending_raises_forbidden(self):
+        user = fantasy_fixtures.user_fixture
+        league = fantasy_fixtures.fantasy_league_fixture
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = (
+            FantasyLeagueMembership(
+                league_id=league.id, user_id=user.id, status=FantasyLeagueMembershipStatus.PENDING
+            )
+        )
+        with self.assertRaises(ForbiddenException):
+            self.fantasy_league_util.validate_membership(user.id, league.id)
+
+    def test_validate_membership_declined_raises_forbidden(self):
+        user = fantasy_fixtures.user_fixture
+        league = fantasy_fixtures.fantasy_league_fixture
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = (
+            FantasyLeagueMembership(
+                league_id=league.id, user_id=user.id, status=FantasyLeagueMembershipStatus.DECLINED
+            )
+        )
+        with self.assertRaises(ForbiddenException):
+            self.fantasy_league_util.validate_membership(user.id, league.id)
+
+    def test_validate_membership_revoked_raises_forbidden(self):
+        user = fantasy_fixtures.user_fixture
+        league = fantasy_fixtures.fantasy_league_fixture
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = (
+            FantasyLeagueMembership(
+                league_id=league.id, user_id=user.id, status=FantasyLeagueMembershipStatus.REVOKED
+            )
+        )
+        with self.assertRaises(ForbiddenException):
+            self.fantasy_league_util.validate_membership(user.id, league.id)
+
+    def test_validate_membership_no_membership_raises_forbidden(self):
+        user = fantasy_fixtures.user_fixture
+        league = fantasy_fixtures.fantasy_league_fixture
+        self.mock_db_service.get_user_membership_for_fantasy_league.return_value = None
+        with self.assertRaises(ForbiddenException):
+            self.fantasy_league_util.validate_membership(user.id, league.id)
 
     def test_validate_league_successful(self):
         # Arrange

--- a/ui/src/views/LeagueDetailView.vue
+++ b/ui/src/views/LeagueDetailView.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import {
+  getLeagueById,
   getLeagueMembers,
   getLeagueSettings,
   getLeagueScoringSettings,
@@ -26,8 +27,7 @@ const auth = useAuthStore()
 
 const leagueId = route.params.id as string
 
-// We get the league object from the router state (passed from LeaguesView) or fetch it
-const league = ref<FantasyLeague | null>((history.state?.league as FantasyLeague) ?? null)
+const league = ref<FantasyLeague | null>(null)
 
 const isOwner = computed(() => !!auth.userId && league.value?.owner_id === auth.userId)
 const acceptedCount = computed(() => members.value.filter(m => m.status === 'accepted').length)
@@ -70,6 +70,7 @@ async function fetchAll() {
   draftOrderLoading.value = true
 
   await Promise.allSettled([
+    getLeagueById(leagueId).then(d => { league.value = d }).catch(() => {}),
     getLeagueMembers(leagueId).then(d => { members.value = d }).catch(() => { membersError.value = 'Unable to load members.' }).finally(() => { membersLoading.value = false }),
     getLeagueSettings(leagueId).then(d => { settings.value = d }).catch(() => { settingsError.value = 'Unable to load settings.' }).finally(() => { settingsLoading.value = false }),
     getLeagueScoringSettings(leagueId).then(d => { scoring.value = d }).catch(() => { scoringError.value = 'Unable to load scoring.' }).finally(() => { scoringLoading.value = false }),


### PR DESCRIPTION
## Summary

Three bugs fixed in this PR.

**Backend: 500 on re-inviting a declined/revoked member**
`send_fantasy_league_invite` always called INSERT, which hit a unique constraint violation when a membership row already existed (declined/revoked). Fixed to UPDATE the existing row back to `pending` for declined/revoked members. Added a guard to raise `FantasyLeagueInviteException` if the user is already pending or accepted.

**UI: isOwner always false / '?' member count / invite form hidden**
`LeagueDetailView` relied on `history.state.league` to populate the league object, which is only set when navigating from the leagues list — not on direct URL access or page refresh. Fixed to always fetch the league via `GET /fantasy/leagues/{id}` on mount.

## What was tested

- 5 new unit tests covering all invite membership status scenarios (no membership, declined, revoked, pending, accepted)
- Manual verification: owner sees Start Draft button, member count shows correctly, invite form visible on page refresh