### PR TITLE
feat: add team slot to fantasy roster model

### DIFF
--- a/alembic/versions/006_add_team_slot_to_fantasy_team.py
+++ b/alembic/versions/006_add_team_slot_to_fantasy_team.py
@@ -1,0 +1,31 @@
+"""add_team_slot_to_fantasy_team
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-05-26
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "006"
+down_revision = "005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "fantasy_teams",
+        sa.Column(
+            "team_id",
+            sa.String(),
+            sa.ForeignKey("professional_teams.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("fantasy_teams", "team_id")

--- a/src/common/schemas/fantasy_schemas.py
+++ b/src/common/schemas/fantasy_schemas.py
@@ -2,7 +2,7 @@ from enum import Enum
 from pydantic import BaseModel, ConfigDict, Field, field_validator, EmailStr
 from typing import NewType
 
-from .riot_data_schemas import RiotLeagueID, ProPlayerID, PlayerRole  # type: ignore
+from .riot_data_schemas import RiotLeagueID, ProPlayerID, ProTeamID, PlayerRole  # type: ignore
 
 UserID = NewType("UserID", str)
 FantasyLeagueID = NewType("FantasyLeagueID", str)
@@ -192,6 +192,7 @@ class FantasyTeam(BaseModel):
     mid_player_id: ProPlayerID | None = None
     adc_player_id: ProPlayerID | None = None
     support_player_id: ProPlayerID | None = None
+    team_id: ProTeamID | None = None
 
     def get_player_id_for_role(self, role: PlayerRole) -> ProPlayerID | None:
         if role == PlayerRole.TOP:

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -344,5 +344,6 @@ class FantasyTeamModel(Base):  # type: ignore
     mid_player_id = Column(String, nullable=True)
     adc_player_id = Column(String, nullable=True)
     support_player_id = Column(String, nullable=True)
+    team_id = Column(String, ForeignKey("professional_teams.id", ondelete="CASCADE"), nullable=True)
 
     __table_args__ = (PrimaryKeyConstraint("fantasy_league_id", "user_id", "week"),)

--- a/tests/db/fantasy/test_fantasy_team.py
+++ b/tests/db/fantasy/test_fantasy_team.py
@@ -1,8 +1,9 @@
 from tests.test_base import TestBase
 from tests.test_util import fantasy_fixtures
+from tests.test_util import riot_fixtures
 
 from src.common.schemas.fantasy_schemas import FantasyLeagueID, UserID
-from src.common.schemas.riot_data_schemas import ProPlayerID
+from src.common.schemas.riot_data_schemas import ProPlayerID, ProTeamID
 
 
 class TestCrudFantasyTeam(TestBase):
@@ -112,3 +113,33 @@ class TestCrudFantasyTeam(TestBase):
 
         week_3_fantasy_teams = self.db.get_all_fantasy_teams_for_week(fantasy_league.id, 3)
         self.assertEqual(0, len(week_3_fantasy_teams))
+
+    def test_fantasy_team_team_id_defaults_to_none(self):
+        # Arrange
+        fantasy_team = fantasy_fixtures.fantasy_team_week_1
+
+        # Act
+        self.db.put_fantasy_team(fantasy_team)
+
+        # Assert
+        stored = self.db.get_all_fantasy_teams_for_user(
+            fantasy_team.fantasy_league_id, fantasy_team.user_id
+        )
+        self.assertIsNone(stored[0].team_id)
+
+    def test_fantasy_team_with_team_id_round_trips(self):
+        # Arrange
+        pro_team = riot_fixtures.team_1_fixture
+        self.db.put_team(pro_team)
+        fantasy_team = fantasy_fixtures.fantasy_team_week_1.model_copy(
+            update={"team_id": ProTeamID(pro_team.id)}
+        )
+
+        # Act
+        self.db.put_fantasy_team(fantasy_team)
+
+        # Assert
+        stored = self.db.get_all_fantasy_teams_for_user(
+            fantasy_team.fantasy_league_id, fantasy_team.user_id
+        )
+        self.assertEqual(ProTeamID(pro_team.id), stored[0].team_id)

--- a/ui/src/types/fantasy.ts
+++ b/ui/src/types/fantasy.ts
@@ -49,6 +49,7 @@ export interface FantasyTeam {
   mid_player_id: string | null
   adc_player_id: string | null
   support_player_id: string | null
+  team_id: string | null
 }
 
 export interface RosterEntry {


### PR DESCRIPTION
Closes #462

## Changes
- **Migration 006**: adds nullable `team_id` column (FK → `professional_teams.id`, CASCADE delete) to `fantasy_teams`
- **SQLAlchemy model**: `FantasyTeamModel.team_id` column
- **Pydantic schema**: `FantasyTeam.team_id: ProTeamID | None = None`
- **TypeScript interface**: `FantasyTeam.team_id: string | null`

## Tests
Added two DB round-trip tests in `tests/db/fantasy/test_fantasy_team.py`:
- `test_fantasy_team_team_id_defaults_to_none`
- `test_fantasy_team_with_team_id_round_trips`

## Out of scope
Draft logic, pickup/drop endpoints, and scoring engine integration are deferred per the issue.