### PR TITLE
feat: add draft_picks table, model, schema, and DAO

### DIFF
--- a/alembic/versions/007_add_draft_picks_table.py
+++ b/alembic/versions/007_add_draft_picks_table.py
@@ -1,0 +1,32 @@
+"""add_draft_picks_table
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-05-28
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "007"
+down_revision = "006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "draft_picks",
+        sa.Column("fantasy_league_id", sa.String(), nullable=False),
+        sa.Column("pick_number", sa.Integer(), nullable=False),
+        sa.Column("round_number", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("player_id", sa.String(), nullable=True),
+        sa.Column("team_id", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint("fantasy_league_id", "pick_number"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("draft_picks")

--- a/src/common/schemas/fantasy_schemas.py
+++ b/src/common/schemas/fantasy_schemas.py
@@ -219,3 +219,14 @@ class FantasyTeam(BaseModel):
             self.adc_player_id = player_id
         if role == PlayerRole.SUPPORT:
             self.support_player_id = player_id
+
+
+class DraftPick(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    fantasy_league_id: FantasyLeagueID
+    pick_number: int
+    round_number: int
+    user_id: UserID
+    player_id: ProPlayerID | None = None
+    team_id: ProTeamID | None = None

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -1,4 +1,5 @@
 from src.common.schemas.fantasy_schemas import (
+    DraftPick,
     FantasyLeague,
     FantasyLeagueID,
     FantasyLeagueDraftOrder,
@@ -39,6 +40,7 @@ from src.common.schemas.riot_data_schemas import (
 from src.db.database_connection_provider import DatabaseConnectionProvider
 from src.db.fantasy_dao import (
     draft_order_dao,
+    draft_pick_dao,
     fantasy_league_dao,
     fantasy_team_dao,
     membership_dao,
@@ -361,6 +363,14 @@ class DatabaseService:
             draft_order_dao.update_fantasy_league_draft_order_position(
                 db, draft_order, new_position
             )
+
+    def put_draft_pick(self, draft_pick: DraftPick) -> None:
+        with self.connection_provider.get_db() as db:
+            draft_pick_dao.put_draft_pick(db, draft_pick)
+
+    def get_draft_picks_for_league(self, fantasy_league_id: FantasyLeagueID) -> list[DraftPick]:
+        with self.connection_provider.get_db() as db:
+            return draft_pick_dao.get_draft_picks_for_league(db, fantasy_league_id)
 
     def create_fantasy_league(self, fantasy_league: FantasyLeague) -> None:
         with self.connection_provider.get_db() as db:

--- a/src/db/fantasy_dao/draft_pick_dao.py
+++ b/src/db/fantasy_dao/draft_pick_dao.py
@@ -1,0 +1,18 @@
+from src.common.schemas.fantasy_schemas import FantasyLeagueID, DraftPick
+from src.db.models import DraftPickModel
+
+
+def put_draft_pick(session, draft_pick: DraftPick) -> None:
+    db_draft_pick = DraftPickModel(**draft_pick.model_dump())
+    session.merge(db_draft_pick)
+    session.commit()
+
+
+def get_draft_picks_for_league(session, fantasy_league_id: FantasyLeagueID) -> list[DraftPick]:
+    db_draft_picks: list[DraftPickModel] = (
+        session.query(DraftPickModel)
+        .filter(DraftPickModel.fantasy_league_id == fantasy_league_id)
+        .order_by(DraftPickModel.pick_number)
+        .all()
+    )
+    return [DraftPick.model_validate(dp) for dp in db_draft_picks]

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -347,3 +347,16 @@ class FantasyTeamModel(Base):  # type: ignore
     team_id = Column(String, ForeignKey("professional_teams.id", ondelete="CASCADE"), nullable=True)
 
     __table_args__ = (PrimaryKeyConstraint("fantasy_league_id", "user_id", "week"),)
+
+
+class DraftPickModel(Base):  # type: ignore
+    __tablename__ = "draft_picks"
+
+    fantasy_league_id = Column(String, primary_key=True, nullable=False)
+    pick_number = Column(Integer, primary_key=True, nullable=False)
+    round_number = Column(Integer, nullable=False)
+    user_id = Column(String, nullable=False)
+    player_id = Column(String, nullable=True)
+    team_id = Column(String, nullable=True)
+
+    __table_args__ = (PrimaryKeyConstraint("fantasy_league_id", "pick_number"),)

--- a/tests/db/fantasy/test_draft_pick.py
+++ b/tests/db/fantasy/test_draft_pick.py
@@ -58,3 +58,34 @@ class TestCrudDraftPick(TestBase):
 
         # Assert
         self.assertEqual([], picks)
+
+    def test_get_draft_picks_isolated_by_league(self):
+        # Arrange
+        league_a = fantasy_fixtures.fantasy_league_draft_fixture.id
+        league_b = fantasy_fixtures.fantasy_league_active_fixture.id
+        pick_a = DraftPick(
+            fantasy_league_id=league_a,
+            pick_number=1,
+            round_number=1,
+            user_id=fantasy_fixtures.user_fixture.id,
+            player_id=ProPlayerID("player-a"),
+        )
+        pick_b = DraftPick(
+            fantasy_league_id=league_b,
+            pick_number=1,
+            round_number=1,
+            user_id=fantasy_fixtures.user_fixture.id,
+            player_id=ProPlayerID("player-b"),
+        )
+        self.db.put_draft_pick(pick_a)
+        self.db.put_draft_pick(pick_b)
+
+        # Act
+        picks_a = self.db.get_draft_picks_for_league(league_a)
+        picks_b = self.db.get_draft_picks_for_league(league_b)
+
+        # Assert
+        self.assertEqual(1, len(picks_a))
+        self.assertEqual(pick_a, picks_a[0])
+        self.assertEqual(1, len(picks_b))
+        self.assertEqual(pick_b, picks_b[0])

--- a/tests/db/fantasy/test_draft_pick.py
+++ b/tests/db/fantasy/test_draft_pick.py
@@ -1,0 +1,60 @@
+from tests.test_base import TestBase
+from tests.test_util import fantasy_fixtures
+
+from src.common.schemas.fantasy_schemas import DraftPick, FantasyLeagueID
+from src.common.schemas.riot_data_schemas import ProPlayerID, ProTeamID
+
+
+class TestCrudDraftPick(TestBase):
+    def test_put_and_get_draft_pick(self):
+        # Arrange
+        draft_pick = DraftPick(
+            fantasy_league_id=fantasy_fixtures.fantasy_league_draft_fixture.id,
+            pick_number=1,
+            round_number=1,
+            user_id=fantasy_fixtures.user_fixture.id,
+            player_id=ProPlayerID("player-1"),
+        )
+
+        # Act
+        self.db.put_draft_pick(draft_pick)
+
+        # Assert
+        picks = self.db.get_draft_picks_for_league(draft_pick.fantasy_league_id)
+        self.assertEqual(1, len(picks))
+        self.assertEqual(draft_pick, picks[0])
+
+    def test_get_draft_picks_returns_ordered(self):
+        # Arrange
+        league_id = fantasy_fixtures.fantasy_league_draft_fixture.id
+        pick_1 = DraftPick(
+            fantasy_league_id=league_id,
+            pick_number=1,
+            round_number=1,
+            user_id=fantasy_fixtures.user_fixture.id,
+            player_id=ProPlayerID("player-1"),
+        )
+        pick_2 = DraftPick(
+            fantasy_league_id=league_id,
+            pick_number=2,
+            round_number=1,
+            user_id=fantasy_fixtures.user_2_fixture.id,
+            team_id=ProTeamID("team-1"),
+        )
+        self.db.put_draft_pick(pick_2)
+        self.db.put_draft_pick(pick_1)
+
+        # Act
+        picks = self.db.get_draft_picks_for_league(league_id)
+
+        # Assert
+        self.assertEqual(2, len(picks))
+        self.assertEqual(pick_1, picks[0])
+        self.assertEqual(pick_2, picks[1])
+
+    def test_get_draft_picks_empty_league(self):
+        # Act
+        picks = self.db.get_draft_picks_for_league(FantasyLeagueID("nonexistent"))
+
+        # Assert
+        self.assertEqual([], picks)


### PR DESCRIPTION
Closes #465

## Changes
- **Migration 007**: creates `draft_picks` table with PK `(fantasy_league_id, pick_number)`
- **SQLAlchemy model**: `DraftPickModel` with columns: fantasy_league_id, pick_number, round_number, user_id, player_id (nullable), team_id (nullable)
- **Pydantic schema**: `DraftPick` in `fantasy_schemas.py`
- **DAO**: `draft_pick_dao.py` with `put_draft_pick` and `get_draft_picks_for_league`
- **DatabaseService**: wired up both DAO methods

## Tests
3 tests in `tests/db/fantasy/test_draft_pick.py`:
- `test_put_and_get_draft_pick` — basic round-trip
- `test_get_draft_picks_returns_ordered` — picks returned by pick_number order
- `test_get_draft_picks_empty_league` — empty list for nonexistent league