### PR TITLE
feat: add DraftService.start_draft

### DIFF
--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -418,6 +418,14 @@ class DatabaseService:
                 db, fantasy_league_id, new_current_draft_position
             )
 
+    def update_fantasy_league_current_week(
+        self, fantasy_league_id: FantasyLeagueID, current_week: int
+    ) -> FantasyLeague:
+        with self.connection_provider.get_db() as db:
+            return fantasy_league_dao.update_fantasy_league_current_week(
+                db, fantasy_league_id, current_week
+            )
+
     def put_fantasy_team(self, fantasy_team: FantasyTeam) -> None:
         with self.connection_provider.get_db() as db:
             fantasy_team_dao.put_fantasy_team(db, fantasy_team)

--- a/src/db/fantasy_dao/fantasy_league_dao.py
+++ b/src/db/fantasy_dao/fantasy_league_dao.py
@@ -89,3 +89,17 @@ def update_fantasy_league_current_draft_position(
     session.commit()
     session.refresh(db_fantasy_league)
     return FantasyLeague.model_validate(db_fantasy_league)
+
+
+def update_fantasy_league_current_week(
+    session, fantasy_league_id: FantasyLeagueID, current_week: int
+) -> FantasyLeague:
+    db_fantasy_league: FantasyLeague | None = (
+        session.query(FantasyLeagueModel).filter_by(id=fantasy_league_id).first()
+    )
+    assert db_fantasy_league is not None
+
+    db_fantasy_league.current_week = current_week
+    session.commit()
+    session.refresh(db_fantasy_league)
+    return FantasyLeague.model_validate(db_fantasy_league)

--- a/src/fantasy/service/__init__.py
+++ b/src/fantasy/service/__init__.py
@@ -1,3 +1,4 @@
+from .draft_service import DraftService  # noqa: F401
 from .fantasy_league_service import FantasyLeagueService  # noqa: F401
 from .fantasy_team_service import FantasyTeamService  # noqa: F401
 from .fantasy_user_service import UserService  # noqa: F401

--- a/src/fantasy/service/draft_service.py
+++ b/src/fantasy/service/draft_service.py
@@ -1,0 +1,55 @@
+import logging
+
+from src.db.database_service import DatabaseService
+from src.common.schemas.fantasy_schemas import (
+    FantasyLeagueID,
+    FantasyLeagueStatus,
+    FantasyLeagueMembershipStatus,
+    UserID,
+)
+from src.fantasy.exceptions import (
+    FantasyLeagueStartDraftException,
+    ForbiddenException,
+)
+from src.fantasy.util import FantasyLeagueUtil
+
+logger = logging.getLogger("api.fantasy")
+
+
+class DraftService:
+    def __init__(self, database_service: DatabaseService):
+        self.db = database_service
+        self.fantasy_league_util = FantasyLeagueUtil(database_service)
+
+    def start_draft(self, league_id: FantasyLeagueID, owner_id: UserID) -> None:
+        logger.info("Starting draft for league=%s by user=%s", league_id, owner_id)
+        fantasy_league = self.fantasy_league_util.validate_league(
+            league_id, [FantasyLeagueStatus.PRE_DRAFT]
+        )
+        if fantasy_league.owner_id != owner_id:
+            raise ForbiddenException()
+
+        pending_and_accepted_memberships = self.db.get_pending_and_accepted_members_for_league(
+            league_id
+        )
+        accepted_count = sum(
+            1
+            for m in pending_and_accepted_memberships
+            if m.status == FantasyLeagueMembershipStatus.ACCEPTED
+        )
+        if accepted_count != fantasy_league.number_of_teams:
+            raise FantasyLeagueStartDraftException(
+                f"Invalid member count: The fantasy league with ID {league_id} does not "
+                f"have correct number of members to start the draft. "
+                f"Expected {fantasy_league.number_of_teams} but has {accepted_count}."
+            )
+
+        if len(fantasy_league.available_leagues) == 0:
+            raise FantasyLeagueStartDraftException(
+                f"Available leagues not set: The fantasy league with ID {league_id} must "
+                f"have one Riot league set for players to draft from before starting the draft."
+            )
+
+        self.db.update_fantasy_league_status(league_id, FantasyLeagueStatus.DRAFT)
+        self.db.update_fantasy_league_current_draft_position(league_id, 1)
+        self.db.update_fantasy_league_current_week(league_id, 0)

--- a/src/fantasy/service/fantasy_league_service.py
+++ b/src/fantasy/service/fantasy_league_service.py
@@ -20,7 +20,6 @@ from src.common.schemas.fantasy_schemas import (
 from src.fantasy.exceptions import (
     FantasyLeagueInviteException,
     FantasyLeagueSettingsException,
-    FantasyLeagueStartDraftException,
     ForbiddenException,
     UserNotFoundException,
 )
@@ -355,37 +354,6 @@ class FantasyLeagueService:
             self.db.update_fantasy_league_draft_order_position(
                 db_draft_position, updated_position.position
             )
-
-    def start_fantasy_draft(self, user_id: UserID, fantasy_league_id: FantasyLeagueID) -> None:
-        logger.info("Starting draft for league=%s by user=%s", fantasy_league_id, user_id)
-        fantasy_league = self.fantasy_league_util.validate_league(
-            fantasy_league_id, [FantasyLeagueStatus.PRE_DRAFT]
-        )
-        if fantasy_league.owner_id != user_id:
-            raise ForbiddenException()
-
-        pending_and_accepted_memberships = self.db.get_pending_and_accepted_members_for_league(
-            fantasy_league_id
-        )
-        accepted_count = 0
-        for membership in pending_and_accepted_memberships:
-            if membership.status == FantasyLeagueMembershipStatus.ACCEPTED:
-                accepted_count += 1
-        if accepted_count != fantasy_league.number_of_teams:
-            raise FantasyLeagueStartDraftException(
-                f"Invalid member count: The fantasy league with ID {fantasy_league_id} does not "
-                f"have correct number of members to start the draft. "
-                f"Expected {fantasy_league.number_of_teams} but has {accepted_count}."
-            )
-
-        if len(fantasy_league.available_leagues) == 0:
-            raise FantasyLeagueStartDraftException(
-                f"Available leagues not set: The fantasy league with ID {fantasy_league_id} must "
-                f"have one Riot league set for players to draft from before starting the draft."
-            )
-
-        self.db.update_fantasy_league_status(fantasy_league_id, FantasyLeagueStatus.DRAFT)
-        self.db.update_fantasy_league_current_draft_position(fantasy_league_id, 1)
 
     def create_fantasy_league_membership(
         self, league_id: FantasyLeagueID, user_id: UserID, status: FantasyLeagueMembershipStatus

--- a/tests/fantasy/integration/service/test_draft_service.py
+++ b/tests/fantasy/integration/service/test_draft_service.py
@@ -1,0 +1,128 @@
+import uuid
+from copy import deepcopy
+
+from tests.test_base import TestBase
+from tests.test_util import fantasy_fixtures
+
+from src.common.schemas.fantasy_schemas import (
+    FantasyLeagueID,
+    FantasyLeagueStatus,
+    FantasyLeagueMembershipStatus,
+    FantasyLeagueMembership,
+    UserID,
+)
+from src.fantasy.exceptions import (
+    FantasyLeagueNotFoundException,
+    FantasyLeagueStartDraftException,
+    FantasyLeagueInvalidRequiredStateException,
+    ForbiddenException,
+)
+from src.fantasy.service import DraftService
+
+
+class DraftServiceIntegrationTest(TestBase):
+    def setUp(self):
+        super().setUp()
+        self.draft_service = DraftService(self.db)
+
+    def create_membership(self, league_id, user_id, status):
+        self.db.create_fantasy_league_membership(
+            FantasyLeagueMembership(league_id=league_id, user_id=user_id, status=status)
+        )
+
+    # --------------------------------------------------
+    # ------------------- start_draft ------------------
+    # --------------------------------------------------
+    def test_start_draft_successful(self):
+        # Arrange
+        user = fantasy_fixtures.user_fixture
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
+        fantasy_league.available_leagues = ["someRiotLeagueId"]
+        self.db.create_fantasy_league(fantasy_league)
+        self.db.create_user(user)
+
+        self.create_membership(fantasy_league.id, user.id, FantasyLeagueMembershipStatus.ACCEPTED)
+        for _ in range(fantasy_league.number_of_teams - 1):
+            self.create_membership(
+                fantasy_league.id,
+                UserID(str(uuid.uuid4())),
+                FantasyLeagueMembershipStatus.ACCEPTED,
+            )
+
+        # Act
+        self.draft_service.start_draft(fantasy_league.id, user.id)
+
+        # Assert
+        db_league = self.db.get_fantasy_league_by_id(fantasy_league.id)
+        self.assertEqual(FantasyLeagueStatus.DRAFT, db_league.status)
+        self.assertEqual(1, db_league.current_draft_position)
+        self.assertEqual(0, db_league.current_week)
+
+    def test_start_draft_rejects_non_owner(self):
+        # Arrange
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
+        fantasy_league.available_leagues = ["someRiotLeagueId"]
+        self.db.create_fantasy_league(fantasy_league)
+
+        non_owner_id = UserID(str(uuid.uuid4()))
+
+        # Act & Assert
+        with self.assertRaises(ForbiddenException):
+            self.draft_service.start_draft(fantasy_league.id, non_owner_id)
+
+    def test_start_draft_rejects_wrong_member_count(self):
+        # Arrange
+        user = fantasy_fixtures.user_fixture
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
+        fantasy_league.available_leagues = ["someRiotLeagueId"]
+        self.db.create_fantasy_league(fantasy_league)
+        self.db.create_user(user)
+
+        # Only add half the required members
+        for _ in range(fantasy_league.number_of_teams - 1):
+            self.create_membership(
+                fantasy_league.id,
+                UserID(str(uuid.uuid4())),
+                FantasyLeagueMembershipStatus.ACCEPTED,
+            )
+
+        # Act & Assert
+        with self.assertRaises(FantasyLeagueStartDraftException) as ctx:
+            self.draft_service.start_draft(fantasy_league.id, user.id)
+        self.assertIn("Invalid member count", str(ctx.exception))
+
+    def test_start_draft_rejects_empty_available_leagues(self):
+        # Arrange
+        user = fantasy_fixtures.user_fixture
+        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
+        fantasy_league.available_leagues = []
+        self.db.create_fantasy_league(fantasy_league)
+        self.db.create_user(user)
+
+        for _ in range(fantasy_league.number_of_teams):
+            self.create_membership(
+                fantasy_league.id,
+                UserID(str(uuid.uuid4())),
+                FantasyLeagueMembershipStatus.ACCEPTED,
+            )
+
+        # Act & Assert
+        with self.assertRaises(FantasyLeagueStartDraftException) as ctx:
+            self.draft_service.start_draft(fantasy_league.id, user.id)
+        self.assertIn("Available leagues not set", str(ctx.exception))
+
+    def test_start_draft_rejects_non_pre_draft_status(self):
+        # Arrange
+        user = fantasy_fixtures.user_fixture
+        active_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        active_league.available_leagues = ["someRiotLeagueId"]
+        self.db.create_fantasy_league(active_league)
+
+        # Act & Assert
+        with self.assertRaises(FantasyLeagueInvalidRequiredStateException):
+            self.draft_service.start_draft(active_league.id, user.id)
+
+    def test_start_draft_rejects_nonexistent_league(self):
+        # Act & Assert
+        with self.assertRaises(FantasyLeagueNotFoundException):
+            self.draft_service.start_draft(FantasyLeagueID("nonexistent"), UserID("some-user"))

--- a/tests/fantasy/integration/service/test_fantasy_league_service.py
+++ b/tests/fantasy/integration/service/test_fantasy_league_service.py
@@ -7,7 +7,6 @@ from tests.test_util import fantasy_fixtures, riot_fixtures
 from src.common.schemas.fantasy_schemas import (
     FantasyLeague,
     FantasyLeagueID,
-    FantasyLeagueStatus,
     FantasyLeagueMembershipStatus,
     FantasyLeagueMembership,
     FantasyLeagueSettings,
@@ -24,7 +23,6 @@ from src.fantasy.exceptions import (
     FantasyLeagueInviteException,
     FantasyLeagueNotFoundException,
     FantasyLeagueSettingsException,
-    FantasyLeagueStartDraftException,
     FantasyUnavailableException,
     FantasyLeagueInvalidRequiredStateException,
     ForbiddenException,
@@ -1403,137 +1401,6 @@ class FantasyLeagueServiceIntegrationTest(TestBase):
                 fantasy_fixtures.fantasy_league_active_fixture.id,
                 updated_draft_order,
             )
-
-    # --------------------------------------------------
-    # -------------- Start Fantasy Draft ---------------
-    # --------------------------------------------------
-    def test_start_fantasy_draft_successful(self):
-        # Arrange
-        user = fantasy_fixtures.user_fixture
-        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
-        fantasy_league.available_leagues = ["someRiotLeagueId"]
-        self.db.create_fantasy_league(fantasy_league)
-        self.db.create_user(user)
-
-        self.create_fantasy_league_membership_for_league(
-            fantasy_league.id, user.id, FantasyLeagueMembershipStatus.ACCEPTED
-        )
-        for i in range(fantasy_league.number_of_teams - 1):  # -1 as we created one for user already
-            self.create_fantasy_league_membership_for_league(
-                fantasy_league.id, UserID(str(uuid.uuid4())), FantasyLeagueMembershipStatus.ACCEPTED
-            )
-
-        # Act and Assert
-        try:
-            self.fantasy_league_service.start_fantasy_draft(user.id, fantasy_league.id)
-        except FantasyLeagueStartDraftException:
-            self.fail("Start Fantasy Draft failed with an unexpected exception!")
-        db_fantasy_league = self.db.get_fantasy_league_by_id(fantasy_league.id)
-        self.assertEqual(FantasyLeagueStatus.DRAFT, db_fantasy_league.status)
-        self.assertEqual(1, db_fantasy_league.current_draft_position)
-
-    def test_start_fantasy_draft_no_fantasy_league_found_exception(self):
-        # Arrange
-        user = fantasy_fixtures.user_fixture
-        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
-        fantasy_league.available_leagues = ["someRiotLeagueId"]
-        self.db.create_fantasy_league(fantasy_league)
-
-        # Act and Assert
-        with self.assertRaises(FantasyLeagueNotFoundException):
-            self.fantasy_league_service.start_fantasy_draft(
-                user.id, FantasyLeagueID("badFantasyLeagueId")
-            )
-        db_fantasy_league = self.db.get_fantasy_league_by_id(fantasy_league.id)
-        self.assertEqual(FantasyLeagueStatus.PRE_DRAFT, db_fantasy_league.status)
-        self.assertEqual(None, db_fantasy_league.current_draft_position)
-
-    def test_start_fantasy_draft_not_in_pre_draft_exception(self):
-        # Arrange
-        user = fantasy_fixtures.user_fixture
-        active_fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
-        active_fantasy_league.available_leagues = ["someRiotLeagueId"]
-        self.db.create_fantasy_league(active_fantasy_league)
-
-        # Act and Assert
-        with self.assertRaises(FantasyLeagueInvalidRequiredStateException):
-            self.fantasy_league_service.start_fantasy_draft(user.id, active_fantasy_league.id)
-        db_fantasy_league = self.db.get_fantasy_league_by_id(active_fantasy_league.id)
-        self.assertEqual(FantasyLeagueStatus.ACTIVE, db_fantasy_league.status)
-        self.assertEqual(None, db_fantasy_league.current_draft_position)
-
-    def test_start_fantasy_draft_not_enough_members_exception(self):
-        # Arrange
-        user = fantasy_fixtures.user_fixture
-        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
-        fantasy_league.available_leagues = ["someRiotLeagueId"]
-        self.db.create_fantasy_league(fantasy_league)
-        self.db.create_user(user)
-
-        for i in range(fantasy_league.number_of_teams - 1):
-            self.create_fantasy_league_membership_for_league(
-                fantasy_league.id, UserID(str(uuid.uuid4())), FantasyLeagueMembershipStatus.ACCEPTED
-            )
-
-        # Act and Assert
-        with self.assertRaises(FantasyLeagueStartDraftException) as context:
-            self.fantasy_league_service.start_fantasy_draft(user.id, fantasy_league.id)
-        self.assertIn("Invalid member count", str(context.exception))
-        self.assertIn(
-            f"Expected {fantasy_league.number_of_teams} but has "
-            f"{fantasy_league.number_of_teams - 1}",
-            str(context.exception),
-        )
-        db_fantasy_league = self.db.get_fantasy_league_by_id(fantasy_league.id)
-        self.assertEqual(FantasyLeagueStatus.PRE_DRAFT, db_fantasy_league.status)
-        self.assertEqual(None, db_fantasy_league.current_draft_position)
-
-    def test_start_fantasy_draft_too_many__members_exception(self):
-        # Arrange
-        user = fantasy_fixtures.user_fixture
-        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
-        fantasy_league.available_leagues = ["someRiotLeagueId"]
-        self.db.create_fantasy_league(fantasy_league)
-        self.db.create_user(user)
-
-        for i in range(fantasy_league.number_of_teams + 1):
-            self.create_fantasy_league_membership_for_league(
-                fantasy_league.id, UserID(str(uuid.uuid4())), FantasyLeagueMembershipStatus.ACCEPTED
-            )
-
-        # Act and Assert
-        with self.assertRaises(FantasyLeagueStartDraftException) as context:
-            self.fantasy_league_service.start_fantasy_draft(user.id, fantasy_league.id)
-        self.assertIn("Invalid member count", str(context.exception))
-        self.assertIn(
-            f"Expected {fantasy_league.number_of_teams} but has "
-            f"{fantasy_league.number_of_teams + 1}",
-            str(context.exception),
-        )
-        db_fantasy_league = self.db.get_fantasy_league_by_id(fantasy_league.id)
-        self.assertEqual(FantasyLeagueStatus.PRE_DRAFT, db_fantasy_league.status)
-        self.assertEqual(None, db_fantasy_league.current_draft_position)
-
-    def test_start_fantasy_draft_no_available_leagues_set_exception(self):
-        # Arrange
-        user = fantasy_fixtures.user_fixture
-        fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
-        fantasy_league.available_leagues = []
-        self.db.create_fantasy_league(fantasy_league)
-        self.db.create_user(user)
-
-        for i in range(fantasy_league.number_of_teams):
-            self.create_fantasy_league_membership_for_league(
-                fantasy_league.id, UserID(str(uuid.uuid4())), FantasyLeagueMembershipStatus.ACCEPTED
-            )
-
-        # Act and Assert
-        with self.assertRaises(FantasyLeagueStartDraftException) as context:
-            self.fantasy_league_service.start_fantasy_draft(user.id, fantasy_league.id)
-        self.assertIn("Available leagues not set", str(context.exception))
-        db_fantasy_league = self.db.get_fantasy_league_by_id(fantasy_league.id)
-        self.assertEqual(FantasyLeagueStatus.PRE_DRAFT, db_fantasy_league.status)
-        self.assertEqual(None, db_fantasy_league.current_draft_position)
 
     def create_fantasy_league_membership_for_league(
         self, league_id: FantasyLeagueID, user_id: UserID, status: FantasyLeagueMembershipStatus


### PR DESCRIPTION
Closes #466

Depends on #471 (Phase 1A: draft_picks table)

## Changes
- **New `DraftService`** at `src/fantasy/service/draft_service.py` with `start_draft(league_id, owner_id)`
- **New behavior**: sets `current_week = 0` on draft start (draft happens at week 0, transitions to week 1 on completion)
- **DAO**: added `update_fantasy_league_current_week` to `fantasy_league_dao.py` and `DatabaseService`
- **Removed** `start_fantasy_draft` from `FantasyLeagueService` (moved to `DraftService`)
- **Exported** `DraftService` from `src/fantasy/service/__init__.py`

## Tests
6 tests in `tests/fantasy/integration/service/test_draft_service.py`:
- `test_start_draft_successful` — transitions to DRAFT, sets position=1, week=0
- `test_start_draft_rejects_non_owner`
- `test_start_draft_rejects_wrong_member_count`
- `test_start_draft_rejects_empty_available_leagues`
- `test_start_draft_rejects_non_pre_draft_status`
- `test_start_draft_rejects_nonexistent_league`

Old start_draft tests removed from `test_fantasy_league_service.py`.