### PR TITLE
feat: DraftService.make_pick with validation and snake order

### DIFF
--- a/src/fantasy/service/draft_service.py
+++ b/src/fantasy/service/draft_service.py
@@ -1,13 +1,18 @@
 import logging
+import math
 
 from src.db.database_service import DatabaseService
 from src.common.schemas.fantasy_schemas import (
+    DraftPick,
     FantasyLeagueID,
     FantasyLeagueStatus,
     FantasyLeagueMembershipStatus,
+    FantasyTeam,
     UserID,
 )
+from src.common.schemas.riot_data_schemas import ProPlayerID, ProTeamID, PlayerRole
 from src.fantasy.exceptions import (
+    FantasyDraftException,
     FantasyLeagueStartDraftException,
     ForbiddenException,
 )
@@ -53,3 +58,123 @@ class DraftService:
         self.db.update_fantasy_league_status(league_id, FantasyLeagueStatus.DRAFT)
         self.db.update_fantasy_league_current_draft_position(league_id, 1)
         self.db.update_fantasy_league_current_week(league_id, 0)
+
+    def make_pick(
+        self,
+        league_id: FantasyLeagueID,
+        user_id: UserID,
+        player_id: ProPlayerID | None = None,
+        team_id: ProTeamID | None = None,
+    ) -> DraftPick:
+        # Validate league is in DRAFT status
+        fantasy_league = self.fantasy_league_util.validate_league(
+            league_id, [FantasyLeagueStatus.DRAFT]
+        )
+
+        # Validate exactly one of player_id or team_id
+        if player_id is None and team_id is None:
+            raise FantasyDraftException("Must provide either player_id or team_id")
+        if player_id is not None and team_id is not None:
+            raise FantasyDraftException("Cannot provide both player_id and team_id")
+
+        # Determine whose turn it is via snake order
+        existing_picks = self.db.get_draft_picks_for_league(league_id)
+        pick_number = len(existing_picks) + 1
+        num_users = fantasy_league.number_of_teams
+        round_number = math.ceil(pick_number / num_users)
+        position_in_round = pick_number - (round_number - 1) * num_users
+
+        # Snake: odd rounds go 1→N, even rounds go N→1
+        if round_number % 2 == 0:
+            draft_position = num_users - position_in_round + 1
+        else:
+            draft_position = position_in_round
+
+        # Map draft_position to user via draft order
+        draft_order = self.db.get_fantasy_league_draft_order(league_id)
+        expected_user_id = None
+        for entry in draft_order:
+            if entry.position == draft_position:
+                expected_user_id = entry.user_id
+                break
+
+        if user_id != expected_user_id:
+            raise FantasyDraftException(
+                f"Not your turn: Expected user at position {draft_position}, got {user_id}"
+            )
+
+        # Get or create user's fantasy team for week 0 (draft week)
+        user_teams = self.db.get_all_fantasy_teams_for_user(league_id, user_id)
+        if user_teams:
+            fantasy_team = user_teams[-1]
+        else:
+            fantasy_team = FantasyTeam(fantasy_league_id=league_id, user_id=user_id, week=0)
+
+        if player_id is not None:
+            # Validate player
+            player = self.db.get_player_by_id(player_id)
+            if player is None:
+                raise FantasyDraftException(f"Player not found: {player_id}")
+            if player.role == PlayerRole.NONE:
+                raise FantasyDraftException(
+                    f"Player has role=none and cannot be drafted: {player_id}"
+                )
+
+            # Validate player from available leagues
+            player_league_ids = self.db.get_league_ids_for_player(player_id)
+            if not any(lid in fantasy_league.available_leagues for lid in player_league_ids):
+                raise FantasyDraftException(f"Player not from available leagues: {player_id}")
+
+            # Validate player not already drafted
+            for pick in existing_picks:
+                if pick.player_id == player_id:
+                    raise FantasyDraftException(f"Player already drafted: {player_id}")
+
+            # Validate role slot empty
+            if fantasy_team.get_player_id_for_role(player.role) is not None:
+                raise FantasyDraftException(f"Role slot already filled: {player.role.value}")
+
+            # Update fantasy team
+            fantasy_team.set_player_id_for_role(player_id, player.role)
+
+        else:
+            # team_id pick
+            team = self.db.get_team_by_id(team_id)
+            if team is None:
+                raise FantasyDraftException(f"Team not found: {team_id}")
+
+            # Validate team not already drafted
+            for pick in existing_picks:
+                if pick.team_id == team_id:
+                    raise FantasyDraftException(f"Team already drafted: {team_id}")
+
+            # Validate team slot empty
+            if fantasy_team.team_id is not None:
+                raise FantasyDraftException("Team slot already filled")
+
+            # Update fantasy team
+            fantasy_team.team_id = team_id
+
+        # Persist
+        draft_pick = DraftPick(
+            fantasy_league_id=league_id,
+            pick_number=pick_number,
+            round_number=round_number,
+            user_id=user_id,
+            player_id=player_id,
+            team_id=team_id,
+        )
+        self.db.put_draft_pick(draft_pick)
+        self.db.put_fantasy_team(fantasy_team)
+
+        # Advance draft position
+        next_pick = pick_number + 1
+        next_round = math.ceil(next_pick / num_users)
+        next_pos_in_round = next_pick - (next_round - 1) * num_users
+        if next_round % 2 == 0:
+            next_draft_position = num_users - next_pos_in_round + 1
+        else:
+            next_draft_position = next_pos_in_round
+        self.db.update_fantasy_league_current_draft_position(league_id, next_draft_position)
+
+        return draft_pick

--- a/tests/fantasy/integration/service/test_draft_service.py
+++ b/tests/fantasy/integration/service/test_draft_service.py
@@ -33,6 +33,7 @@ class DraftServiceIntegrationTest(TestBase):
     def setUp(self):
         super().setUp()
         self.draft_service = DraftService(self.db)
+        self._player_counter = 0
 
     def create_membership(self, league_id, user_id, status):
         self.db.create_fantasy_league_membership(
@@ -44,14 +45,23 @@ class DraftServiceIntegrationTest(TestBase):
             FantasyLeagueDraftOrder(fantasy_league_id=league_id, user_id=user_id, position=position)
         )
 
+    def make_player(self, role, team_id=None):
+        """Create and persist a player with the given role. Returns the player."""
+        self._player_counter += 1
+        player = ProfessionalPlayer(
+            id=ProPlayerID(f"test-player-{self._player_counter}"),
+            summoner_name=f"Player{self._player_counter}",
+            image="http://img.png",
+            role=role,
+            team_id=team_id or riot_fixtures.team_1_fixture.id,
+        )
+        self.db.put_player(player)
+        return player
+
     def setup_draft_league(self):
         """Set up a 4-user league in DRAFT status.
         Returns (league, [user_ids]) where user_ids[0] is the owner at position 1.
-        Snake order for 4 users:
-          Round 1 (picks 1-4): users 0,1,2,3
-          Round 2 (picks 5-8): users 3,2,1,0
-          Round 3 (picks 9-12): users 0,1,2,3
-          ...
+        Snake order: R1 picks 1-4 → users 0,1,2,3 | R2 picks 5-8 → users 3,2,1,0
         """
         league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
         league.available_leagues = [riot_fixtures.league_1_fixture.id]
@@ -76,6 +86,38 @@ class DraftServiceIntegrationTest(TestBase):
 
         self.draft_service.start_draft(league.id, owner.id)
         return league, user_ids
+
+    def advance_draft(self, league, user_ids, num_picks):
+        """Make num_picks filler picks following snake order from current state.
+        Each user gets a different role each time to avoid slot conflicts.
+        """
+        snake = [0, 1, 2, 3, 3, 2, 1, 0]  # repeats every 8 picks for 4 users
+        all_roles = [
+            PlayerRole.TOP,
+            PlayerRole.JUNGLE,
+            PlayerRole.MID,
+            PlayerRole.BOTTOM,
+            PlayerRole.SUPPORT,
+        ]
+        user_pick_count: dict[int, int] = {0: 0, 1: 0, 2: 0, 3: 0}
+
+        existing = self.db.get_draft_picks_for_league(league.id)
+        start = len(existing)
+
+        # Count existing picks per user to know which role index to start at
+        for pick in existing:
+            for i, uid in enumerate(user_ids):
+                if pick.user_id == uid:
+                    user_pick_count[i] += 1
+                    break
+
+        for i in range(num_picks):
+            idx = (start + i) % len(snake)
+            user_idx = snake[idx]
+            role = all_roles[user_pick_count[user_idx] % len(all_roles)]
+            user_pick_count[user_idx] += 1
+            player = self.make_player(role)
+            self.draft_service.make_pick(league.id, user_ids[user_idx], player_id=player.id)
 
     # --------------------------------------------------
     # ------------------- start_draft ------------------
@@ -161,8 +203,7 @@ class DraftServiceIntegrationTest(TestBase):
     # --------------------------------------------------
     def test_make_pick_valid_player(self):
         league, user_ids = self.setup_draft_league()
-        player = riot_fixtures.player_1_fixture  # role=TOP
-        self.db.put_player(player)
+        player = self.make_player(PlayerRole.TOP)
 
         result = self.draft_service.make_pick(league.id, user_ids[0], player_id=player.id)
 
@@ -182,34 +223,11 @@ class DraftServiceIntegrationTest(TestBase):
 
     def test_make_pick_snake_order_reverses_in_round_2(self):
         league, user_ids = self.setup_draft_league()
-        # Create 5 unique players for picks
-        players = []
-        roles = [
-            PlayerRole.TOP,
-            PlayerRole.JUNGLE,
-            PlayerRole.MID,
-            PlayerRole.BOTTOM,
-            PlayerRole.SUPPORT,
-        ]
-        for i, role in enumerate(roles):
-            p = ProfessionalPlayer(
-                id=ProPlayerID(f"snake-player-{i}"),
-                summoner_name=f"P{i}",
-                image="http://img.png",
-                role=role,
-                team_id=riot_fixtures.team_1_fixture.id,
-            )
-            self.db.put_player(p)
-            players.append(p)
+        # Fill round 1 (4 picks), then verify round 2 starts with user 3
+        self.advance_draft(league, user_ids, 4)
 
-        # Round 1: users 0,1,2,3 (picks 1-4)
-        self.draft_service.make_pick(league.id, user_ids[0], player_id=players[0].id)
-        self.draft_service.make_pick(league.id, user_ids[1], player_id=players[1].id)
-        self.draft_service.make_pick(league.id, user_ids[2], player_id=players[2].id)
-        self.draft_service.make_pick(league.id, user_ids[3], player_id=players[3].id)
-
-        # Round 2 (snake): user 3 picks first
-        result = self.draft_service.make_pick(league.id, user_ids[3], player_id=players[4].id)
+        player = self.make_player(PlayerRole.SUPPORT)
+        result = self.draft_service.make_pick(league.id, user_ids[3], player_id=player.id)
 
         self.assertEqual(5, result.pick_number)
         self.assertEqual(2, result.round_number)
@@ -217,100 +235,44 @@ class DraftServiceIntegrationTest(TestBase):
 
     def test_make_pick_rejects_not_users_turn(self):
         league, user_ids = self.setup_draft_league()
-        player = riot_fixtures.player_1_fixture
-        self.db.put_player(player)
+        player = self.make_player(PlayerRole.TOP)
 
-        # user_ids[1] tries to pick but it's user_ids[0]'s turn
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[1], player_id=player.id)
 
     def test_make_pick_rejects_player_already_drafted(self):
         league, user_ids = self.setup_draft_league()
-        player = riot_fixtures.player_1_fixture  # TOP
-        self.db.put_player(player)
+        player = self.make_player(PlayerRole.TOP)
 
         self.draft_service.make_pick(league.id, user_ids[0], player_id=player.id)
 
-        # user 1 tries same player
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[1], player_id=player.id)
 
     def test_make_pick_rejects_role_slot_filled(self):
         league, user_ids = self.setup_draft_league()
-        # Create 8 players to fill round 1 + most of round 2
-        players = []
-        roles = [
-            PlayerRole.TOP,
-            PlayerRole.TOP,
-            PlayerRole.TOP,
-            PlayerRole.TOP,
-            PlayerRole.JUNGLE,
-            PlayerRole.JUNGLE,
-            PlayerRole.JUNGLE,
-            PlayerRole.TOP,
-        ]
-        for i, role in enumerate(roles):
-            p = ProfessionalPlayer(
-                id=ProPlayerID(f"role-test-{i}"),
-                summoner_name=f"P{i}",
-                image="http://img.png",
-                role=role,
-                team_id=riot_fixtures.team_1_fixture.id,
-            )
-            self.db.put_player(p)
-            players.append(p)
+        # User 0 picks TOP in pick 1
+        top_player = self.make_player(PlayerRole.TOP)
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=top_player.id)
+        # Advance picks 2-7 so it's user 0's turn again (pick 8)
+        self.advance_draft(league, user_ids, 6)
 
-        # Round 1 (picks 1-4): users 0,1,2,3 all pick TOP
-        self.draft_service.make_pick(league.id, user_ids[0], player_id=players[0].id)
-        self.draft_service.make_pick(league.id, user_ids[1], player_id=players[1].id)
-        self.draft_service.make_pick(league.id, user_ids[2], player_id=players[2].id)
-        self.draft_service.make_pick(league.id, user_ids[3], player_id=players[3].id)
-        # Round 2 (snake, picks 5-8): users 3,2,1,0
-        self.draft_service.make_pick(league.id, user_ids[3], player_id=players[4].id)
-        self.draft_service.make_pick(league.id, user_ids[2], player_id=players[5].id)
-        self.draft_service.make_pick(league.id, user_ids[1], player_id=players[6].id)
-
-        # Pick 8: user 0's turn — already has TOP filled, tries another TOP
+        # User 0 tries another TOP
+        another_top = self.make_player(PlayerRole.TOP)
         with self.assertRaises(FantasyDraftException):
-            self.draft_service.make_pick(league.id, user_ids[0], player_id=players[7].id)
+            self.draft_service.make_pick(league.id, user_ids[0], player_id=another_top.id)
 
     def test_make_pick_rejects_team_slot_filled(self):
         league, user_ids = self.setup_draft_league()
-        self.db.put_team(riot_fixtures.team_2_fixture)
-        # Create players for intermediate picks
-        players = []
-        roles = [
-            PlayerRole.TOP,
-            PlayerRole.TOP,
-            PlayerRole.TOP,
-            PlayerRole.JUNGLE,
-            PlayerRole.JUNGLE,
-            PlayerRole.JUNGLE,
-        ]
-        for i, role in enumerate(roles):
-            p = ProfessionalPlayer(
-                id=ProPlayerID(f"team-test-{i}"),
-                summoner_name=f"P{i}",
-                image="http://img.png",
-                role=role,
-                team_id=riot_fixtures.team_1_fixture.id,
-            )
-            self.db.put_player(p)
-            players.append(p)
-
-        # User 0 picks team
+        # User 0 picks a team in pick 1
         self.draft_service.make_pick(
             league.id, user_ids[0], team_id=riot_fixtures.team_1_fixture.id
         )
-        # Fill picks 2-7 to get back to user 0
-        self.draft_service.make_pick(league.id, user_ids[1], player_id=players[0].id)
-        self.draft_service.make_pick(league.id, user_ids[2], player_id=players[1].id)
-        self.draft_service.make_pick(league.id, user_ids[3], player_id=players[2].id)
-        self.draft_service.make_pick(league.id, user_ids[3], player_id=players[3].id)
-        self.draft_service.make_pick(league.id, user_ids[2], player_id=players[4].id)
-        self.draft_service.make_pick(league.id, user_ids[1], player_id=players[5].id)
+        # Advance picks 2-7 so it's user 0's turn again
+        self.advance_draft(league, user_ids, 6)
 
-        # Pick 8: user 0 tries another team
+        # User 0 tries another team
+        self.db.put_team(riot_fixtures.team_2_fixture)
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(
                 league.id, user_ids[0], team_id=riot_fixtures.team_2_fixture.id
@@ -318,40 +280,27 @@ class DraftServiceIntegrationTest(TestBase):
 
     def test_make_pick_rejects_player_with_role_none(self):
         league, user_ids = self.setup_draft_league()
-        none_player = ProfessionalPlayer(
-            id=ProPlayerID("none-role-player"),
-            summoner_name="NoneRole",
-            image="http://img.png",
-            role=PlayerRole.NONE,
-            team_id=riot_fixtures.team_1_fixture.id,
-        )
-        self.db.put_player(none_player)
+        none_player = self.make_player(PlayerRole.NONE)
 
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[0], player_id=none_player.id)
 
     def test_make_pick_rejects_player_not_from_available_leagues(self):
         league, user_ids = self.setup_draft_league()
+        # Player on a team in a different league
         other_league = riot_fixtures.league_2_fixture
         self.db.put_league(other_league)
         other_team = ProfessionalTeam(
             id=ProTeamID("other-team"),
             slug="other",
-            name="Other Team",
+            name="Other",
             code="OT",
             image="http://img.png",
             status="active",
             home_league_name=other_league.name,
         )
         self.db.put_team(other_team)
-        other_player = ProfessionalPlayer(
-            id=ProPlayerID("other-player"),
-            summoner_name="OtherPlayer",
-            image="http://img.png",
-            role=PlayerRole.TOP,
-            team_id=other_team.id,
-        )
-        self.db.put_player(other_player)
+        other_player = self.make_player(PlayerRole.TOP, team_id=other_team.id)
 
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[0], player_id=other_player.id)
@@ -364,8 +313,7 @@ class DraftServiceIntegrationTest(TestBase):
 
     def test_make_pick_rejects_both_player_and_team(self):
         league, user_ids = self.setup_draft_league()
-        player = riot_fixtures.player_1_fixture
-        self.db.put_player(player)
+        player = self.make_player(PlayerRole.TOP)
 
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(

--- a/tests/fantasy/integration/service/test_draft_service.py
+++ b/tests/fantasy/integration/service/test_draft_service.py
@@ -2,16 +2,19 @@ import uuid
 from copy import deepcopy
 
 from tests.test_base import TestBase
-from tests.test_util import fantasy_fixtures
+from tests.test_util import fantasy_fixtures, riot_fixtures
 
 from src.common.schemas.fantasy_schemas import (
     FantasyLeagueID,
     FantasyLeagueStatus,
     FantasyLeagueMembershipStatus,
     FantasyLeagueMembership,
+    FantasyLeagueDraftOrder,
     UserID,
 )
+from src.common.schemas.riot_data_schemas import ProPlayerID, ProTeamID  # noqa: F401
 from src.fantasy.exceptions import (
+    FantasyDraftException,  # noqa: F401
     FantasyLeagueNotFoundException,
     FantasyLeagueStartDraftException,
     FantasyLeagueInvalidRequiredStateException,
@@ -30,11 +33,44 @@ class DraftServiceIntegrationTest(TestBase):
             FantasyLeagueMembership(league_id=league_id, user_id=user_id, status=status)
         )
 
+    def create_draft_order(self, league_id, user_id, position):
+        self.db.create_fantasy_league_draft_order(
+            FantasyLeagueDraftOrder(fantasy_league_id=league_id, user_id=user_id, position=position)
+        )
+
+    def setup_draft_league(self, num_users=2):
+        """Set up a league in DRAFT status with the given number of users.
+        Returns (league, [user_ids]) where user_ids[0] is the owner and picks first.
+        """
+        league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
+        league.available_leagues = [riot_fixtures.league_1_fixture.id]
+        league.number_of_teams = num_users
+        self.db.create_fantasy_league(league)
+
+        # Set up riot data
+        self.db.put_league(riot_fixtures.league_1_fixture)
+        self.db.put_team(riot_fixtures.team_1_fixture)
+
+        user_ids = []
+        owner = fantasy_fixtures.user_fixture
+        self.db.create_user(owner)
+        user_ids.append(owner.id)
+        self.create_membership(league.id, owner.id, FantasyLeagueMembershipStatus.ACCEPTED)
+        self.create_draft_order(league.id, owner.id, 1)
+
+        for i in range(num_users - 1):
+            uid = UserID(str(uuid.uuid4()))
+            user_ids.append(uid)
+            self.create_membership(league.id, uid, FantasyLeagueMembershipStatus.ACCEPTED)
+            self.create_draft_order(league.id, uid, i + 2)
+
+        self.draft_service.start_draft(league.id, owner.id)
+        return league, user_ids
+
     # --------------------------------------------------
     # ------------------- start_draft ------------------
     # --------------------------------------------------
     def test_start_draft_successful(self):
-        # Arrange
         user = fantasy_fixtures.user_fixture
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
         fantasy_league.available_leagues = ["someRiotLeagueId"]
@@ -49,36 +85,28 @@ class DraftServiceIntegrationTest(TestBase):
                 FantasyLeagueMembershipStatus.ACCEPTED,
             )
 
-        # Act
         self.draft_service.start_draft(fantasy_league.id, user.id)
 
-        # Assert
         db_league = self.db.get_fantasy_league_by_id(fantasy_league.id)
         self.assertEqual(FantasyLeagueStatus.DRAFT, db_league.status)
         self.assertEqual(1, db_league.current_draft_position)
         self.assertEqual(0, db_league.current_week)
 
     def test_start_draft_rejects_non_owner(self):
-        # Arrange
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
         fantasy_league.available_leagues = ["someRiotLeagueId"]
         self.db.create_fantasy_league(fantasy_league)
 
-        non_owner_id = UserID(str(uuid.uuid4()))
-
-        # Act & Assert
         with self.assertRaises(ForbiddenException):
-            self.draft_service.start_draft(fantasy_league.id, non_owner_id)
+            self.draft_service.start_draft(fantasy_league.id, UserID(str(uuid.uuid4())))
 
     def test_start_draft_rejects_wrong_member_count(self):
-        # Arrange
         user = fantasy_fixtures.user_fixture
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
         fantasy_league.available_leagues = ["someRiotLeagueId"]
         self.db.create_fantasy_league(fantasy_league)
         self.db.create_user(user)
 
-        # Only add half the required members
         for _ in range(fantasy_league.number_of_teams - 1):
             self.create_membership(
                 fantasy_league.id,
@@ -86,13 +114,10 @@ class DraftServiceIntegrationTest(TestBase):
                 FantasyLeagueMembershipStatus.ACCEPTED,
             )
 
-        # Act & Assert
-        with self.assertRaises(FantasyLeagueStartDraftException) as ctx:
+        with self.assertRaises(FantasyLeagueStartDraftException):
             self.draft_service.start_draft(fantasy_league.id, user.id)
-        self.assertIn("Invalid member count", str(ctx.exception))
 
     def test_start_draft_rejects_empty_available_leagues(self):
-        # Arrange
         user = fantasy_fixtures.user_fixture
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
         fantasy_league.available_leagues = []
@@ -106,23 +131,245 @@ class DraftServiceIntegrationTest(TestBase):
                 FantasyLeagueMembershipStatus.ACCEPTED,
             )
 
-        # Act & Assert
-        with self.assertRaises(FantasyLeagueStartDraftException) as ctx:
+        with self.assertRaises(FantasyLeagueStartDraftException):
             self.draft_service.start_draft(fantasy_league.id, user.id)
-        self.assertIn("Available leagues not set", str(ctx.exception))
 
     def test_start_draft_rejects_non_pre_draft_status(self):
-        # Arrange
-        user = fantasy_fixtures.user_fixture
         active_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
         active_league.available_leagues = ["someRiotLeagueId"]
         self.db.create_fantasy_league(active_league)
 
-        # Act & Assert
         with self.assertRaises(FantasyLeagueInvalidRequiredStateException):
-            self.draft_service.start_draft(active_league.id, user.id)
+            self.draft_service.start_draft(active_league.id, fantasy_fixtures.user_fixture.id)
 
     def test_start_draft_rejects_nonexistent_league(self):
-        # Act & Assert
         with self.assertRaises(FantasyLeagueNotFoundException):
-            self.draft_service.start_draft(FantasyLeagueID("nonexistent"), UserID("some-user"))
+            self.draft_service.start_draft(FantasyLeagueID("nonexistent"), UserID("x"))
+
+    # --------------------------------------------------
+    # ------------------- make_pick --------------------
+    # --------------------------------------------------
+    def test_make_pick_valid_player(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league(num_users=2)
+        player = riot_fixtures.player_1_fixture  # role=TOP, team=team_1
+        self.db.put_player(player)
+
+        # Act
+        result = self.draft_service.make_pick(league.id, user_ids[0], player_id=player.id)
+
+        # Assert — returns correct DraftPick
+        self.assertEqual(1, result.pick_number)
+        self.assertEqual(1, result.round_number)
+        self.assertEqual(user_ids[0], result.user_id)
+        self.assertEqual(player.id, result.player_id)
+
+        # Assert — draft_picks persisted
+        picks = self.db.get_draft_picks_for_league(league.id)
+        self.assertEqual(1, len(picks))
+
+        # Assert — FantasyTeam updated
+        teams = self.db.get_all_fantasy_teams_for_user(league.id, user_ids[0])
+        self.assertEqual(player.id, teams[0].top_player_id)
+
+        # Assert — draft position advanced to user 2
+        db_league = self.db.get_fantasy_league_by_id(league.id)
+        self.assertEqual(2, db_league.current_draft_position)
+
+    def test_make_pick_snake_order_reverses_in_round_2(self):
+        # Arrange — 2-user league, make picks for round 1, then verify round 2 reverses
+        league, user_ids = self.setup_draft_league(num_users=2)
+        player_1 = riot_fixtures.player_1_fixture  # TOP
+        player_2 = riot_fixtures.player_2_fixture  # JUNGLE
+        player_3 = riot_fixtures.player_3_fixture  # MID
+        self.db.put_player(player_1)
+        self.db.put_player(player_2)
+        self.db.put_player(player_3)
+
+        # Round 1: user_ids[0] (pos 1) then user_ids[1] (pos 2)
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=player_1.id)
+        self.draft_service.make_pick(league.id, user_ids[1], player_id=player_2.id)
+
+        # Round 2 (snake): user_ids[1] (pos 2) picks first
+        result = self.draft_service.make_pick(league.id, user_ids[1], player_id=player_3.id)
+
+        # Assert
+        self.assertEqual(3, result.pick_number)
+        self.assertEqual(2, result.round_number)
+        self.assertEqual(user_ids[1], result.user_id)
+
+    def test_make_pick_rejects_not_users_turn(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league(num_users=2)
+        player = riot_fixtures.player_1_fixture
+        self.db.put_player(player)
+
+        # Act & Assert — user_ids[1] tries to pick but it's user_ids[0]'s turn
+        with self.assertRaises(FantasyDraftException):
+            self.draft_service.make_pick(league.id, user_ids[1], player_id=player.id)
+
+    def test_make_pick_rejects_player_already_drafted(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league(num_users=2)
+        player = riot_fixtures.player_1_fixture  # TOP
+        self.db.put_player(player)
+
+        # User 0 drafts the player
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=player.id)
+
+        # Act & Assert — user 1 tries to draft the same player
+        with self.assertRaises(FantasyDraftException):
+            self.draft_service.make_pick(league.id, user_ids[1], player_id=player.id)
+
+    def test_make_pick_rejects_role_slot_filled(self):
+        # Arrange — 2-user league, user picks two TOP players
+        league, user_ids = self.setup_draft_league(num_users=2)
+        player_top_1 = riot_fixtures.player_1_fixture  # TOP
+        self.db.put_player(player_top_1)
+
+        # Need a second TOP player from team_2
+        from src.common.schemas.riot_data_schemas import ProfessionalPlayer, PlayerRole
+
+        self.db.put_team(riot_fixtures.team_2_fixture)
+        player_top_2 = ProfessionalPlayer(
+            id=ProPlayerID("second-top"),
+            summoner_name="SecondTop",
+            image="http://img.png",
+            role=PlayerRole.TOP,
+            team_id=riot_fixtures.team_2_fixture.id,
+        )
+        self.db.put_player(player_top_2)
+
+        # User 0 picks first TOP
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=player_top_1.id)
+        # User 1 picks (to advance turn back to user 0 in round 2 via snake)
+        player_jg = riot_fixtures.player_2_fixture  # JUNGLE
+        self.db.put_player(player_jg)
+        self.draft_service.make_pick(league.id, user_ids[1], player_id=player_jg.id)
+        # Round 2 snake: user 1 picks again
+        player_mid = riot_fixtures.player_3_fixture  # MID
+        self.db.put_player(player_mid)
+        self.draft_service.make_pick(league.id, user_ids[1], player_id=player_mid.id)
+
+        # Now it's user 0's turn again (round 2, position 1)
+        # Act & Assert — user 0 tries to pick another TOP
+        with self.assertRaises(FantasyDraftException):
+            self.draft_service.make_pick(league.id, user_ids[0], player_id=player_top_2.id)
+
+    def test_make_pick_rejects_team_slot_filled(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league(num_users=2)
+        self.db.put_team(riot_fixtures.team_2_fixture)
+
+        # User 0 picks team_1
+        self.draft_service.make_pick(
+            league.id, user_ids[0], team_id=riot_fixtures.team_1_fixture.id
+        )
+        # User 1 picks to advance
+        player = riot_fixtures.player_1_fixture
+        self.db.put_player(player)
+        self.draft_service.make_pick(league.id, user_ids[1], player_id=player.id)
+        # Round 2 snake: user 1 picks again
+        player_2 = riot_fixtures.player_2_fixture
+        self.db.put_player(player_2)
+        self.draft_service.make_pick(league.id, user_ids[1], player_id=player_2.id)
+
+        # Now user 0's turn — tries to pick another team
+        with self.assertRaises(FantasyDraftException):
+            self.draft_service.make_pick(
+                league.id, user_ids[0], team_id=riot_fixtures.team_2_fixture.id
+            )
+
+    def test_make_pick_rejects_player_with_role_none(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league(num_users=2)
+        from src.common.schemas.riot_data_schemas import ProfessionalPlayer, PlayerRole
+
+        none_player = ProfessionalPlayer(
+            id=ProPlayerID("none-role-player"),
+            summoner_name="NoneRole",
+            image="http://img.png",
+            role=PlayerRole.NONE,
+            team_id=riot_fixtures.team_1_fixture.id,
+        )
+        self.db.put_player(none_player)
+
+        # Act & Assert
+        with self.assertRaises(FantasyDraftException):
+            self.draft_service.make_pick(league.id, user_ids[0], player_id=none_player.id)
+
+    def test_make_pick_rejects_player_not_from_available_leagues(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league(num_users=2)
+        # Create a player on a team in a different league
+        from src.common.schemas.riot_data_schemas import (
+            ProfessionalPlayer,
+            ProfessionalTeam,
+            PlayerRole,
+        )
+
+        other_league = riot_fixtures.league_2_fixture
+        self.db.put_league(other_league)
+        other_team = ProfessionalTeam(
+            id=ProTeamID("other-team"),
+            slug="other",
+            name="Other Team",
+            code="OT",
+            image="http://img.png",
+            status="active",
+            home_league_name=other_league.name,
+        )
+        self.db.put_team(other_team)
+        other_player = ProfessionalPlayer(
+            id=ProPlayerID("other-player"),
+            summoner_name="OtherPlayer",
+            image="http://img.png",
+            role=PlayerRole.TOP,
+            team_id=other_team.id,
+        )
+        self.db.put_player(other_player)
+
+        # Act & Assert
+        with self.assertRaises(FantasyDraftException):
+            self.draft_service.make_pick(league.id, user_ids[0], player_id=other_player.id)
+
+    def test_make_pick_rejects_neither_player_nor_team(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league(num_users=2)
+
+        # Act & Assert
+        with self.assertRaises(FantasyDraftException):
+            self.draft_service.make_pick(league.id, user_ids[0])
+
+    def test_make_pick_rejects_both_player_and_team(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league(num_users=2)
+        player = riot_fixtures.player_1_fixture
+        self.db.put_player(player)
+
+        # Act & Assert
+        with self.assertRaises(FantasyDraftException):
+            self.draft_service.make_pick(
+                league.id,
+                user_ids[0],
+                player_id=player.id,
+                team_id=riot_fixtures.team_1_fixture.id,
+            )
+
+    def test_make_pick_valid_team(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league(num_users=2)
+
+        # Act
+        result = self.draft_service.make_pick(
+            league.id, user_ids[0], team_id=riot_fixtures.team_1_fixture.id
+        )
+
+        # Assert
+        self.assertEqual(1, result.pick_number)
+        self.assertEqual(riot_fixtures.team_1_fixture.id, result.team_id)
+        self.assertIsNone(result.player_id)
+
+        # Verify FantasyTeam updated
+        teams = self.db.get_all_fantasy_teams_for_user(league.id, user_ids[0])
+        self.assertEqual(riot_fixtures.team_1_fixture.id, teams[0].team_id)

--- a/tests/fantasy/integration/service/test_draft_service.py
+++ b/tests/fantasy/integration/service/test_draft_service.py
@@ -123,6 +123,7 @@ class DraftServiceIntegrationTest(TestBase):
     # ------------------- start_draft ------------------
     # --------------------------------------------------
     def test_start_draft_successful(self):
+        # Arrange
         user = fantasy_fixtures.user_fixture
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
         fantasy_league.available_leagues = ["someRiotLeagueId"]
@@ -137,22 +138,27 @@ class DraftServiceIntegrationTest(TestBase):
                 FantasyLeagueMembershipStatus.ACCEPTED,
             )
 
+        # Act
         self.draft_service.start_draft(fantasy_league.id, user.id)
 
+        # Assert
         db_league = self.db.get_fantasy_league_by_id(fantasy_league.id)
         self.assertEqual(FantasyLeagueStatus.DRAFT, db_league.status)
         self.assertEqual(1, db_league.current_draft_position)
         self.assertEqual(0, db_league.current_week)
 
     def test_start_draft_rejects_non_owner(self):
+        # Arrange
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
         fantasy_league.available_leagues = ["someRiotLeagueId"]
         self.db.create_fantasy_league(fantasy_league)
 
+        # Act & Assert
         with self.assertRaises(ForbiddenException):
             self.draft_service.start_draft(fantasy_league.id, UserID(str(uuid.uuid4())))
 
     def test_start_draft_rejects_wrong_member_count(self):
+        # Arrange
         user = fantasy_fixtures.user_fixture
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
         fantasy_league.available_leagues = ["someRiotLeagueId"]
@@ -166,10 +172,12 @@ class DraftServiceIntegrationTest(TestBase):
                 FantasyLeagueMembershipStatus.ACCEPTED,
             )
 
+        # Act & Assert
         with self.assertRaises(FantasyLeagueStartDraftException):
             self.draft_service.start_draft(fantasy_league.id, user.id)
 
     def test_start_draft_rejects_empty_available_leagues(self):
+        # Arrange
         user = fantasy_fixtures.user_fixture
         fantasy_league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
         fantasy_league.available_leagues = []
@@ -183,18 +191,22 @@ class DraftServiceIntegrationTest(TestBase):
                 FantasyLeagueMembershipStatus.ACCEPTED,
             )
 
+        # Act & Assert
         with self.assertRaises(FantasyLeagueStartDraftException):
             self.draft_service.start_draft(fantasy_league.id, user.id)
 
     def test_start_draft_rejects_non_pre_draft_status(self):
+        # Arrange
         active_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
         active_league.available_leagues = ["someRiotLeagueId"]
         self.db.create_fantasy_league(active_league)
 
+        # Act & Assert
         with self.assertRaises(FantasyLeagueInvalidRequiredStateException):
             self.draft_service.start_draft(active_league.id, fantasy_fixtures.user_fixture.id)
 
     def test_start_draft_rejects_nonexistent_league(self):
+        # Act & Assert
         with self.assertRaises(FantasyLeagueNotFoundException):
             self.draft_service.start_draft(FantasyLeagueID("nonexistent"), UserID("x"))
 
@@ -202,11 +214,14 @@ class DraftServiceIntegrationTest(TestBase):
     # ------------------- make_pick --------------------
     # --------------------------------------------------
     def test_make_pick_valid_player(self):
+        # Arrange
         league, user_ids = self.setup_draft_league()
         player = self.make_player(PlayerRole.TOP)
 
+        # Act
         result = self.draft_service.make_pick(league.id, user_ids[0], player_id=player.id)
 
+        # Assert
         self.assertEqual(1, result.pick_number)
         self.assertEqual(1, result.round_number)
         self.assertEqual(user_ids[0], result.user_id)
@@ -222,72 +237,77 @@ class DraftServiceIntegrationTest(TestBase):
         self.assertEqual(2, db_league.current_draft_position)
 
     def test_make_pick_snake_order_reverses_in_round_2(self):
+        # Arrange
         league, user_ids = self.setup_draft_league()
-        # Fill round 1 (4 picks), then verify round 2 starts with user 3
         self.advance_draft(league, user_ids, 4)
-
         player = self.make_player(PlayerRole.SUPPORT)
+
+        # Act — round 2 starts with user 3 (snake reversal)
         result = self.draft_service.make_pick(league.id, user_ids[3], player_id=player.id)
 
+        # Assert
         self.assertEqual(5, result.pick_number)
         self.assertEqual(2, result.round_number)
         self.assertEqual(user_ids[3], result.user_id)
 
     def test_make_pick_rejects_not_users_turn(self):
+        # Arrange
         league, user_ids = self.setup_draft_league()
         player = self.make_player(PlayerRole.TOP)
 
+        # Act & Assert — user 1 tries to pick but it's user 0's turn
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[1], player_id=player.id)
 
     def test_make_pick_rejects_player_already_drafted(self):
+        # Arrange
         league, user_ids = self.setup_draft_league()
         player = self.make_player(PlayerRole.TOP)
-
         self.draft_service.make_pick(league.id, user_ids[0], player_id=player.id)
 
+        # Act & Assert — user 1 tries to draft the same player
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[1], player_id=player.id)
 
     def test_make_pick_rejects_role_slot_filled(self):
+        # Arrange — user 0 picks TOP, then we advance to user 0's next turn
         league, user_ids = self.setup_draft_league()
-        # User 0 picks TOP in pick 1
         top_player = self.make_player(PlayerRole.TOP)
         self.draft_service.make_pick(league.id, user_ids[0], player_id=top_player.id)
-        # Advance picks 2-7 so it's user 0's turn again (pick 8)
         self.advance_draft(league, user_ids, 6)
-
-        # User 0 tries another TOP
         another_top = self.make_player(PlayerRole.TOP)
+
+        # Act & Assert — user 0 tries another TOP (slot already filled)
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[0], player_id=another_top.id)
 
     def test_make_pick_rejects_team_slot_filled(self):
+        # Arrange — user 0 picks a team, then we advance to user 0's next turn
         league, user_ids = self.setup_draft_league()
-        # User 0 picks a team in pick 1
         self.draft_service.make_pick(
             league.id, user_ids[0], team_id=riot_fixtures.team_1_fixture.id
         )
-        # Advance picks 2-7 so it's user 0's turn again
         self.advance_draft(league, user_ids, 6)
-
-        # User 0 tries another team
         self.db.put_team(riot_fixtures.team_2_fixture)
+
+        # Act & Assert — user 0 tries another team (slot already filled)
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(
                 league.id, user_ids[0], team_id=riot_fixtures.team_2_fixture.id
             )
 
     def test_make_pick_rejects_player_with_role_none(self):
+        # Arrange
         league, user_ids = self.setup_draft_league()
         none_player = self.make_player(PlayerRole.NONE)
 
+        # Act & Assert
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[0], player_id=none_player.id)
 
     def test_make_pick_rejects_player_not_from_available_leagues(self):
+        # Arrange
         league, user_ids = self.setup_draft_league()
-        # Player on a team in a different league
         other_league = riot_fixtures.league_2_fixture
         self.db.put_league(other_league)
         other_team = ProfessionalTeam(
@@ -302,19 +322,24 @@ class DraftServiceIntegrationTest(TestBase):
         self.db.put_team(other_team)
         other_player = self.make_player(PlayerRole.TOP, team_id=other_team.id)
 
+        # Act & Assert
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[0], player_id=other_player.id)
 
     def test_make_pick_rejects_neither_player_nor_team(self):
+        # Arrange
         league, user_ids = self.setup_draft_league()
 
+        # Act & Assert
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[0])
 
     def test_make_pick_rejects_both_player_and_team(self):
+        # Arrange
         league, user_ids = self.setup_draft_league()
         player = self.make_player(PlayerRole.TOP)
 
+        # Act & Assert
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(
                 league.id,
@@ -324,12 +349,15 @@ class DraftServiceIntegrationTest(TestBase):
             )
 
     def test_make_pick_valid_team(self):
+        # Arrange
         league, user_ids = self.setup_draft_league()
 
+        # Act
         result = self.draft_service.make_pick(
             league.id, user_ids[0], team_id=riot_fixtures.team_1_fixture.id
         )
 
+        # Assert
         self.assertEqual(1, result.pick_number)
         self.assertEqual(riot_fixtures.team_1_fixture.id, result.team_id)
         self.assertIsNone(result.player_id)

--- a/tests/fantasy/integration/service/test_draft_service.py
+++ b/tests/fantasy/integration/service/test_draft_service.py
@@ -12,9 +12,15 @@ from src.common.schemas.fantasy_schemas import (
     FantasyLeagueDraftOrder,
     UserID,
 )
-from src.common.schemas.riot_data_schemas import ProPlayerID, ProTeamID  # noqa: F401
+from src.common.schemas.riot_data_schemas import (
+    ProfessionalPlayer,
+    ProfessionalTeam,
+    PlayerRole,
+    ProPlayerID,
+    ProTeamID,
+)
 from src.fantasy.exceptions import (
-    FantasyDraftException,  # noqa: F401
+    FantasyDraftException,
     FantasyLeagueNotFoundException,
     FantasyLeagueStartDraftException,
     FantasyLeagueInvalidRequiredStateException,
@@ -38,16 +44,20 @@ class DraftServiceIntegrationTest(TestBase):
             FantasyLeagueDraftOrder(fantasy_league_id=league_id, user_id=user_id, position=position)
         )
 
-    def setup_draft_league(self, num_users=2):
-        """Set up a league in DRAFT status with the given number of users.
-        Returns (league, [user_ids]) where user_ids[0] is the owner and picks first.
+    def setup_draft_league(self):
+        """Set up a 4-user league in DRAFT status.
+        Returns (league, [user_ids]) where user_ids[0] is the owner at position 1.
+        Snake order for 4 users:
+          Round 1 (picks 1-4): users 0,1,2,3
+          Round 2 (picks 5-8): users 3,2,1,0
+          Round 3 (picks 9-12): users 0,1,2,3
+          ...
         """
         league = deepcopy(fantasy_fixtures.fantasy_league_fixture)
         league.available_leagues = [riot_fixtures.league_1_fixture.id]
-        league.number_of_teams = num_users
+        league.number_of_teams = 4
         self.db.create_fantasy_league(league)
 
-        # Set up riot data
         self.db.put_league(riot_fixtures.league_1_fixture)
         self.db.put_team(riot_fixtures.team_1_fixture)
 
@@ -58,7 +68,7 @@ class DraftServiceIntegrationTest(TestBase):
         self.create_membership(league.id, owner.id, FantasyLeagueMembershipStatus.ACCEPTED)
         self.create_draft_order(league.id, owner.id, 1)
 
-        for i in range(num_users - 1):
+        for i in range(3):
             uid = UserID(str(uuid.uuid4()))
             user_ids.append(uid)
             self.create_membership(league.id, uid, FantasyLeagueMembershipStatus.ACCEPTED)
@@ -150,141 +160,164 @@ class DraftServiceIntegrationTest(TestBase):
     # ------------------- make_pick --------------------
     # --------------------------------------------------
     def test_make_pick_valid_player(self):
-        # Arrange
-        league, user_ids = self.setup_draft_league(num_users=2)
-        player = riot_fixtures.player_1_fixture  # role=TOP, team=team_1
+        league, user_ids = self.setup_draft_league()
+        player = riot_fixtures.player_1_fixture  # role=TOP
         self.db.put_player(player)
 
-        # Act
         result = self.draft_service.make_pick(league.id, user_ids[0], player_id=player.id)
 
-        # Assert — returns correct DraftPick
         self.assertEqual(1, result.pick_number)
         self.assertEqual(1, result.round_number)
         self.assertEqual(user_ids[0], result.user_id)
         self.assertEqual(player.id, result.player_id)
 
-        # Assert — draft_picks persisted
         picks = self.db.get_draft_picks_for_league(league.id)
         self.assertEqual(1, len(picks))
 
-        # Assert — FantasyTeam updated
         teams = self.db.get_all_fantasy_teams_for_user(league.id, user_ids[0])
         self.assertEqual(player.id, teams[0].top_player_id)
 
-        # Assert — draft position advanced to user 2
         db_league = self.db.get_fantasy_league_by_id(league.id)
         self.assertEqual(2, db_league.current_draft_position)
 
     def test_make_pick_snake_order_reverses_in_round_2(self):
-        # Arrange — 2-user league, make picks for round 1, then verify round 2 reverses
-        league, user_ids = self.setup_draft_league(num_users=2)
-        player_1 = riot_fixtures.player_1_fixture  # TOP
-        player_2 = riot_fixtures.player_2_fixture  # JUNGLE
-        player_3 = riot_fixtures.player_3_fixture  # MID
-        self.db.put_player(player_1)
-        self.db.put_player(player_2)
-        self.db.put_player(player_3)
+        league, user_ids = self.setup_draft_league()
+        # Create 5 unique players for picks
+        players = []
+        roles = [
+            PlayerRole.TOP,
+            PlayerRole.JUNGLE,
+            PlayerRole.MID,
+            PlayerRole.BOTTOM,
+            PlayerRole.SUPPORT,
+        ]
+        for i, role in enumerate(roles):
+            p = ProfessionalPlayer(
+                id=ProPlayerID(f"snake-player-{i}"),
+                summoner_name=f"P{i}",
+                image="http://img.png",
+                role=role,
+                team_id=riot_fixtures.team_1_fixture.id,
+            )
+            self.db.put_player(p)
+            players.append(p)
 
-        # Round 1: user_ids[0] (pos 1) then user_ids[1] (pos 2)
-        self.draft_service.make_pick(league.id, user_ids[0], player_id=player_1.id)
-        self.draft_service.make_pick(league.id, user_ids[1], player_id=player_2.id)
+        # Round 1: users 0,1,2,3 (picks 1-4)
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=players[0].id)
+        self.draft_service.make_pick(league.id, user_ids[1], player_id=players[1].id)
+        self.draft_service.make_pick(league.id, user_ids[2], player_id=players[2].id)
+        self.draft_service.make_pick(league.id, user_ids[3], player_id=players[3].id)
 
-        # Round 2 (snake): user_ids[1] (pos 2) picks first
-        result = self.draft_service.make_pick(league.id, user_ids[1], player_id=player_3.id)
+        # Round 2 (snake): user 3 picks first
+        result = self.draft_service.make_pick(league.id, user_ids[3], player_id=players[4].id)
 
-        # Assert
-        self.assertEqual(3, result.pick_number)
+        self.assertEqual(5, result.pick_number)
         self.assertEqual(2, result.round_number)
-        self.assertEqual(user_ids[1], result.user_id)
+        self.assertEqual(user_ids[3], result.user_id)
 
     def test_make_pick_rejects_not_users_turn(self):
-        # Arrange
-        league, user_ids = self.setup_draft_league(num_users=2)
+        league, user_ids = self.setup_draft_league()
         player = riot_fixtures.player_1_fixture
         self.db.put_player(player)
 
-        # Act & Assert — user_ids[1] tries to pick but it's user_ids[0]'s turn
+        # user_ids[1] tries to pick but it's user_ids[0]'s turn
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[1], player_id=player.id)
 
     def test_make_pick_rejects_player_already_drafted(self):
-        # Arrange
-        league, user_ids = self.setup_draft_league(num_users=2)
+        league, user_ids = self.setup_draft_league()
         player = riot_fixtures.player_1_fixture  # TOP
         self.db.put_player(player)
 
-        # User 0 drafts the player
         self.draft_service.make_pick(league.id, user_ids[0], player_id=player.id)
 
-        # Act & Assert — user 1 tries to draft the same player
+        # user 1 tries same player
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[1], player_id=player.id)
 
     def test_make_pick_rejects_role_slot_filled(self):
-        # Arrange — 2-user league, user picks two TOP players
-        league, user_ids = self.setup_draft_league(num_users=2)
-        player_top_1 = riot_fixtures.player_1_fixture  # TOP
-        self.db.put_player(player_top_1)
+        league, user_ids = self.setup_draft_league()
+        # Create 8 players to fill round 1 + most of round 2
+        players = []
+        roles = [
+            PlayerRole.TOP,
+            PlayerRole.TOP,
+            PlayerRole.TOP,
+            PlayerRole.TOP,
+            PlayerRole.JUNGLE,
+            PlayerRole.JUNGLE,
+            PlayerRole.JUNGLE,
+            PlayerRole.TOP,
+        ]
+        for i, role in enumerate(roles):
+            p = ProfessionalPlayer(
+                id=ProPlayerID(f"role-test-{i}"),
+                summoner_name=f"P{i}",
+                image="http://img.png",
+                role=role,
+                team_id=riot_fixtures.team_1_fixture.id,
+            )
+            self.db.put_player(p)
+            players.append(p)
 
-        # Need a second TOP player from team_2
-        from src.common.schemas.riot_data_schemas import ProfessionalPlayer, PlayerRole
+        # Round 1 (picks 1-4): users 0,1,2,3 all pick TOP
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=players[0].id)
+        self.draft_service.make_pick(league.id, user_ids[1], player_id=players[1].id)
+        self.draft_service.make_pick(league.id, user_ids[2], player_id=players[2].id)
+        self.draft_service.make_pick(league.id, user_ids[3], player_id=players[3].id)
+        # Round 2 (snake, picks 5-8): users 3,2,1,0
+        self.draft_service.make_pick(league.id, user_ids[3], player_id=players[4].id)
+        self.draft_service.make_pick(league.id, user_ids[2], player_id=players[5].id)
+        self.draft_service.make_pick(league.id, user_ids[1], player_id=players[6].id)
 
-        self.db.put_team(riot_fixtures.team_2_fixture)
-        player_top_2 = ProfessionalPlayer(
-            id=ProPlayerID("second-top"),
-            summoner_name="SecondTop",
-            image="http://img.png",
-            role=PlayerRole.TOP,
-            team_id=riot_fixtures.team_2_fixture.id,
-        )
-        self.db.put_player(player_top_2)
-
-        # User 0 picks first TOP
-        self.draft_service.make_pick(league.id, user_ids[0], player_id=player_top_1.id)
-        # User 1 picks (to advance turn back to user 0 in round 2 via snake)
-        player_jg = riot_fixtures.player_2_fixture  # JUNGLE
-        self.db.put_player(player_jg)
-        self.draft_service.make_pick(league.id, user_ids[1], player_id=player_jg.id)
-        # Round 2 snake: user 1 picks again
-        player_mid = riot_fixtures.player_3_fixture  # MID
-        self.db.put_player(player_mid)
-        self.draft_service.make_pick(league.id, user_ids[1], player_id=player_mid.id)
-
-        # Now it's user 0's turn again (round 2, position 1)
-        # Act & Assert — user 0 tries to pick another TOP
+        # Pick 8: user 0's turn — already has TOP filled, tries another TOP
         with self.assertRaises(FantasyDraftException):
-            self.draft_service.make_pick(league.id, user_ids[0], player_id=player_top_2.id)
+            self.draft_service.make_pick(league.id, user_ids[0], player_id=players[7].id)
 
     def test_make_pick_rejects_team_slot_filled(self):
-        # Arrange
-        league, user_ids = self.setup_draft_league(num_users=2)
+        league, user_ids = self.setup_draft_league()
         self.db.put_team(riot_fixtures.team_2_fixture)
+        # Create players for intermediate picks
+        players = []
+        roles = [
+            PlayerRole.TOP,
+            PlayerRole.TOP,
+            PlayerRole.TOP,
+            PlayerRole.JUNGLE,
+            PlayerRole.JUNGLE,
+            PlayerRole.JUNGLE,
+        ]
+        for i, role in enumerate(roles):
+            p = ProfessionalPlayer(
+                id=ProPlayerID(f"team-test-{i}"),
+                summoner_name=f"P{i}",
+                image="http://img.png",
+                role=role,
+                team_id=riot_fixtures.team_1_fixture.id,
+            )
+            self.db.put_player(p)
+            players.append(p)
 
-        # User 0 picks team_1
+        # User 0 picks team
         self.draft_service.make_pick(
             league.id, user_ids[0], team_id=riot_fixtures.team_1_fixture.id
         )
-        # User 1 picks to advance
-        player = riot_fixtures.player_1_fixture
-        self.db.put_player(player)
-        self.draft_service.make_pick(league.id, user_ids[1], player_id=player.id)
-        # Round 2 snake: user 1 picks again
-        player_2 = riot_fixtures.player_2_fixture
-        self.db.put_player(player_2)
-        self.draft_service.make_pick(league.id, user_ids[1], player_id=player_2.id)
+        # Fill picks 2-7 to get back to user 0
+        self.draft_service.make_pick(league.id, user_ids[1], player_id=players[0].id)
+        self.draft_service.make_pick(league.id, user_ids[2], player_id=players[1].id)
+        self.draft_service.make_pick(league.id, user_ids[3], player_id=players[2].id)
+        self.draft_service.make_pick(league.id, user_ids[3], player_id=players[3].id)
+        self.draft_service.make_pick(league.id, user_ids[2], player_id=players[4].id)
+        self.draft_service.make_pick(league.id, user_ids[1], player_id=players[5].id)
 
-        # Now user 0's turn — tries to pick another team
+        # Pick 8: user 0 tries another team
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(
                 league.id, user_ids[0], team_id=riot_fixtures.team_2_fixture.id
             )
 
     def test_make_pick_rejects_player_with_role_none(self):
-        # Arrange
-        league, user_ids = self.setup_draft_league(num_users=2)
-        from src.common.schemas.riot_data_schemas import ProfessionalPlayer, PlayerRole
-
+        league, user_ids = self.setup_draft_league()
         none_player = ProfessionalPlayer(
             id=ProPlayerID("none-role-player"),
             summoner_name="NoneRole",
@@ -294,20 +327,11 @@ class DraftServiceIntegrationTest(TestBase):
         )
         self.db.put_player(none_player)
 
-        # Act & Assert
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[0], player_id=none_player.id)
 
     def test_make_pick_rejects_player_not_from_available_leagues(self):
-        # Arrange
-        league, user_ids = self.setup_draft_league(num_users=2)
-        # Create a player on a team in a different league
-        from src.common.schemas.riot_data_schemas import (
-            ProfessionalPlayer,
-            ProfessionalTeam,
-            PlayerRole,
-        )
-
+        league, user_ids = self.setup_draft_league()
         other_league = riot_fixtures.league_2_fixture
         self.db.put_league(other_league)
         other_team = ProfessionalTeam(
@@ -329,25 +353,20 @@ class DraftServiceIntegrationTest(TestBase):
         )
         self.db.put_player(other_player)
 
-        # Act & Assert
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[0], player_id=other_player.id)
 
     def test_make_pick_rejects_neither_player_nor_team(self):
-        # Arrange
-        league, user_ids = self.setup_draft_league(num_users=2)
+        league, user_ids = self.setup_draft_league()
 
-        # Act & Assert
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(league.id, user_ids[0])
 
     def test_make_pick_rejects_both_player_and_team(self):
-        # Arrange
-        league, user_ids = self.setup_draft_league(num_users=2)
+        league, user_ids = self.setup_draft_league()
         player = riot_fixtures.player_1_fixture
         self.db.put_player(player)
 
-        # Act & Assert
         with self.assertRaises(FantasyDraftException):
             self.draft_service.make_pick(
                 league.id,
@@ -357,19 +376,15 @@ class DraftServiceIntegrationTest(TestBase):
             )
 
     def test_make_pick_valid_team(self):
-        # Arrange
-        league, user_ids = self.setup_draft_league(num_users=2)
+        league, user_ids = self.setup_draft_league()
 
-        # Act
         result = self.draft_service.make_pick(
             league.id, user_ids[0], team_id=riot_fixtures.team_1_fixture.id
         )
 
-        # Assert
         self.assertEqual(1, result.pick_number)
         self.assertEqual(riot_fixtures.team_1_fixture.id, result.team_id)
         self.assertIsNone(result.player_id)
 
-        # Verify FantasyTeam updated
         teams = self.db.get_all_fantasy_teams_for_user(league.id, user_ids[0])
         self.assertEqual(riot_fixtures.team_1_fixture.id, teams[0].team_id)


### PR DESCRIPTION
Closes #467

Depends on #472 (Phase 1B: DraftService.start_draft)

## Changes
`DraftService.make_pick(league_id, user_id, player_id=None, team_id=None) -> DraftPick`

### Snake order
- Derives whose turn from pick count + draft order table
- Odd rounds (1,3,5): positions 1→N
- Even rounds (2,4,6): positions N→1

### Validation (in order):
1. League must be in DRAFT status
2. Exactly one of player_id or team_id must be provided
3. It must be the user's turn
4. Player picks: player exists, role!=none, from available leagues, not already drafted, role slot empty
5. Team picks: team exists, not already drafted, team slot empty

### On success:
- Persists DraftPick row
- Updates user's FantasyTeam (role slot or team_id)
- Advances current_draft_position (snake order)

## Tests
11 new tests in `test_draft_service.py`:
- `test_make_pick_valid_player` — full round-trip
- `test_make_pick_snake_order_reverses_in_round_2`
- `test_make_pick_rejects_not_users_turn`
- `test_make_pick_rejects_player_already_drafted`
- `test_make_pick_rejects_role_slot_filled`
- `test_make_pick_rejects_team_slot_filled`
- `test_make_pick_rejects_player_with_role_none`
- `test_make_pick_rejects_player_not_from_available_leagues`
- `test_make_pick_rejects_neither_player_nor_team`
- `test_make_pick_rejects_both_player_and_team`
- `test_make_pick_valid_team`