### PR TITLE
feat: draft completion and get_draft_state

### DIFF
--- a/src/common/schemas/fantasy_schemas.py
+++ b/src/common/schemas/fantasy_schemas.py
@@ -230,3 +230,23 @@ class DraftPick(BaseModel):
     user_id: UserID
     player_id: ProPlayerID | None = None
     team_id: ProTeamID | None = None
+
+
+class UserSlots(BaseModel):
+    top_player_id: ProPlayerID | None = None
+    jungle_player_id: ProPlayerID | None = None
+    mid_player_id: ProPlayerID | None = None
+    adc_player_id: ProPlayerID | None = None
+    support_player_id: ProPlayerID | None = None
+    team_id: ProTeamID | None = None
+
+
+class DraftState(BaseModel):
+    fantasy_league_id: FantasyLeagueID
+    current_round: int
+    current_pick_number: int
+    total_picks: int
+    current_turn_user_id: UserID | None
+    picks: list[DraftPick]
+    user_slots: dict[str, UserSlots]
+    is_complete: bool

--- a/src/fantasy/service/draft_service.py
+++ b/src/fantasy/service/draft_service.py
@@ -4,11 +4,13 @@ import math
 from src.db.database_service import DatabaseService
 from src.common.schemas.fantasy_schemas import (
     DraftPick,
+    DraftState,
     FantasyLeagueID,
     FantasyLeagueStatus,
     FantasyLeagueMembershipStatus,
     FantasyTeam,
     UserID,
+    UserSlots,
 )
 from src.common.schemas.riot_data_schemas import ProPlayerID, ProTeamID, PlayerRole
 from src.fantasy.exceptions import (
@@ -167,14 +169,81 @@ class DraftService:
         self.db.put_draft_pick(draft_pick)
         self.db.put_fantasy_team(fantasy_team)
 
-        # Advance draft position
-        next_pick = pick_number + 1
-        next_round = math.ceil(next_pick / num_users)
-        next_pos_in_round = next_pick - (next_round - 1) * num_users
-        if next_round % 2 == 0:
-            next_draft_position = num_users - next_pos_in_round + 1
+        # Advance draft position or complete draft
+        total_picks = 6 * num_users
+        if pick_number >= total_picks:
+            # Draft complete
+            self.db.update_fantasy_league_status(league_id, FantasyLeagueStatus.ACTIVE)
+            self.db.update_fantasy_league_current_week(league_id, 1)
         else:
-            next_draft_position = next_pos_in_round
-        self.db.update_fantasy_league_current_draft_position(league_id, next_draft_position)
+            next_pick = pick_number + 1
+            next_round = math.ceil(next_pick / num_users)
+            next_pos_in_round = next_pick - (next_round - 1) * num_users
+            if next_round % 2 == 0:
+                next_draft_position = num_users - next_pos_in_round + 1
+            else:
+                next_draft_position = next_pos_in_round
+            self.db.update_fantasy_league_current_draft_position(league_id, next_draft_position)
 
         return draft_pick
+
+    def get_draft_state(self, league_id: FantasyLeagueID, user_id: UserID) -> DraftState:
+        fantasy_league = self.fantasy_league_util.validate_league(
+            league_id,
+            [FantasyLeagueStatus.DRAFT, FantasyLeagueStatus.ACTIVE, FantasyLeagueStatus.COMPLETED],
+        )
+        self.fantasy_league_util.validate_membership(user_id, league_id)
+
+        num_users = fantasy_league.number_of_teams
+        total_picks = 6 * num_users
+        existing_picks = self.db.get_draft_picks_for_league(league_id)
+        current_pick_number = len(existing_picks) + 1
+        is_complete = len(existing_picks) >= total_picks
+
+        # Determine current round and whose turn
+        if is_complete:
+            current_round = 6
+            current_turn_user_id = None
+        else:
+            current_round = math.ceil(current_pick_number / num_users)
+            pos_in_round = current_pick_number - (current_round - 1) * num_users
+            if current_round % 2 == 0:
+                draft_position = num_users - pos_in_round + 1
+            else:
+                draft_position = pos_in_round
+
+            draft_order = self.db.get_fantasy_league_draft_order(league_id)
+            current_turn_user_id = None
+            for entry in draft_order:
+                if entry.position == draft_position:
+                    current_turn_user_id = entry.user_id
+                    break
+
+        # Build user slots from fantasy teams
+        user_slots: dict[str, UserSlots] = {}
+        draft_order = self.db.get_fantasy_league_draft_order(league_id)
+        for entry in draft_order:
+            teams = self.db.get_all_fantasy_teams_for_user(league_id, entry.user_id)
+            if teams:
+                t = teams[-1]
+                user_slots[entry.user_id] = UserSlots(
+                    top_player_id=t.top_player_id,
+                    jungle_player_id=t.jungle_player_id,
+                    mid_player_id=t.mid_player_id,
+                    adc_player_id=t.adc_player_id,
+                    support_player_id=t.support_player_id,
+                    team_id=t.team_id,
+                )
+            else:
+                user_slots[entry.user_id] = UserSlots()
+
+        return DraftState(
+            fantasy_league_id=league_id,
+            current_round=current_round,
+            current_pick_number=current_pick_number,
+            total_picks=total_picks,
+            current_turn_user_id=current_turn_user_id,
+            picks=existing_picks,
+            user_slots=user_slots,
+            is_complete=is_complete,
+        )

--- a/src/fantasy/service/draft_service.py
+++ b/src/fantasy/service/draft_service.py
@@ -6,6 +6,7 @@ from src.common.schemas.fantasy_schemas import (
     DraftPick,
     DraftState,
     FantasyLeagueID,
+    FantasyLeagueDraftOrder,
     FantasyLeagueStatus,
     FantasyLeagueMembershipStatus,
     FantasyTeam,
@@ -21,6 +22,34 @@ from src.fantasy.exceptions import (
 from src.fantasy.util import FantasyLeagueUtil
 
 logger = logging.getLogger("api.fantasy")
+
+PICKS_PER_USER = 6
+
+
+def _snake_position(pick_number: int, num_users: int) -> int:
+    """Return the draft_position (1-based) for a given pick_number using snake order.
+    Odd rounds go 1→N, even rounds go N→1.
+    """
+    round_number = math.ceil(pick_number / num_users)
+    position_in_round = pick_number - (round_number - 1) * num_users
+    if round_number % 2 == 0:
+        return num_users - position_in_round + 1
+    return position_in_round
+
+
+def _get_round(pick_number: int, num_users: int) -> int:
+    """Return the round number (1-based) for a given pick_number."""
+    return math.ceil(pick_number / num_users)
+
+
+def _get_user_for_position(
+    draft_order: list[FantasyLeagueDraftOrder], position: int
+) -> UserID | None:
+    """Find the user_id at the given draft position."""
+    for entry in draft_order:
+        if entry.position == position:
+            return entry.user_id
+    return None
 
 
 class DraftService:
@@ -80,26 +109,15 @@ class DraftService:
             raise FantasyDraftException("Cannot provide both player_id and team_id")
 
         # Determine whose turn it is via snake order
+        num_users = fantasy_league.number_of_teams
         existing_picks = self.db.get_draft_picks_for_league(league_id)
         pick_number = len(existing_picks) + 1
-        num_users = fantasy_league.number_of_teams
-        round_number = math.ceil(pick_number / num_users)
-        position_in_round = pick_number - (round_number - 1) * num_users
+        round_number = _get_round(pick_number, num_users)
+        draft_position = _snake_position(pick_number, num_users)
 
-        # Snake: odd rounds go 1→N, even rounds go N→1
-        if round_number % 2 == 0:
-            draft_position = num_users - position_in_round + 1
-        else:
-            draft_position = position_in_round
-
-        # Map draft_position to user via draft order
+        # Validate it's the user's turn
         draft_order = self.db.get_fantasy_league_draft_order(league_id)
-        expected_user_id = None
-        for entry in draft_order:
-            if entry.position == draft_position:
-                expected_user_id = entry.user_id
-                break
-
+        expected_user_id = _get_user_for_position(draft_order, draft_position)
         if user_id != expected_user_id:
             raise FantasyDraftException(
                 f"Not your turn: Expected user at position {draft_position}, got {user_id}"
@@ -113,49 +131,11 @@ class DraftService:
             fantasy_team = FantasyTeam(fantasy_league_id=league_id, user_id=user_id, week=0)
 
         if player_id is not None:
-            # Validate player
-            player = self.db.get_player_by_id(player_id)
-            if player is None:
-                raise FantasyDraftException(f"Player not found: {player_id}")
-            if player.role == PlayerRole.NONE:
-                raise FantasyDraftException(
-                    f"Player has role=none and cannot be drafted: {player_id}"
-                )
-
-            # Validate player from available leagues
-            player_league_ids = self.db.get_league_ids_for_player(player_id)
-            if not any(lid in fantasy_league.available_leagues for lid in player_league_ids):
-                raise FantasyDraftException(f"Player not from available leagues: {player_id}")
-
-            # Validate player not already drafted
-            for pick in existing_picks:
-                if pick.player_id == player_id:
-                    raise FantasyDraftException(f"Player already drafted: {player_id}")
-
-            # Validate role slot empty
-            if fantasy_team.get_player_id_for_role(player.role) is not None:
-                raise FantasyDraftException(f"Role slot already filled: {player.role.value}")
-
-            # Update fantasy team
-            fantasy_team.set_player_id_for_role(player_id, player.role)
-
+            self._validate_and_apply_player_pick(
+                player_id, fantasy_league, fantasy_team, existing_picks
+            )
         else:
-            # team_id pick
-            team = self.db.get_team_by_id(team_id)
-            if team is None:
-                raise FantasyDraftException(f"Team not found: {team_id}")
-
-            # Validate team not already drafted
-            for pick in existing_picks:
-                if pick.team_id == team_id:
-                    raise FantasyDraftException(f"Team already drafted: {team_id}")
-
-            # Validate team slot empty
-            if fantasy_team.team_id is not None:
-                raise FantasyDraftException("Team slot already filled")
-
-            # Update fantasy team
-            fantasy_team.team_id = team_id
+            self._validate_and_apply_team_pick(team_id, fantasy_team, existing_picks)
 
         # Persist
         draft_pick = DraftPick(
@@ -170,20 +150,13 @@ class DraftService:
         self.db.put_fantasy_team(fantasy_team)
 
         # Advance draft position or complete draft
-        total_picks = 6 * num_users
+        total_picks = PICKS_PER_USER * num_users
         if pick_number >= total_picks:
-            # Draft complete
             self.db.update_fantasy_league_status(league_id, FantasyLeagueStatus.ACTIVE)
             self.db.update_fantasy_league_current_week(league_id, 1)
         else:
-            next_pick = pick_number + 1
-            next_round = math.ceil(next_pick / num_users)
-            next_pos_in_round = next_pick - (next_round - 1) * num_users
-            if next_round % 2 == 0:
-                next_draft_position = num_users - next_pos_in_round + 1
-            else:
-                next_draft_position = next_pos_in_round
-            self.db.update_fantasy_league_current_draft_position(league_id, next_draft_position)
+            next_position = _snake_position(pick_number + 1, num_users)
+            self.db.update_fantasy_league_current_draft_position(league_id, next_position)
 
         return draft_pick
 
@@ -195,29 +168,20 @@ class DraftService:
         self.fantasy_league_util.validate_membership(user_id, league_id)
 
         num_users = fantasy_league.number_of_teams
-        total_picks = 6 * num_users
+        total_picks = PICKS_PER_USER * num_users
         existing_picks = self.db.get_draft_picks_for_league(league_id)
         current_pick_number = len(existing_picks) + 1
         is_complete = len(existing_picks) >= total_picks
 
         # Determine current round and whose turn
         if is_complete:
-            current_round = 6
+            current_round = PICKS_PER_USER
             current_turn_user_id = None
         else:
-            current_round = math.ceil(current_pick_number / num_users)
-            pos_in_round = current_pick_number - (current_round - 1) * num_users
-            if current_round % 2 == 0:
-                draft_position = num_users - pos_in_round + 1
-            else:
-                draft_position = pos_in_round
-
+            current_round = _get_round(current_pick_number, num_users)
+            draft_position = _snake_position(current_pick_number, num_users)
             draft_order = self.db.get_fantasy_league_draft_order(league_id)
-            current_turn_user_id = None
-            for entry in draft_order:
-                if entry.position == draft_position:
-                    current_turn_user_id = entry.user_id
-                    break
+            current_turn_user_id = _get_user_for_position(draft_order, draft_position)
 
         # Build user slots from fantasy teams
         user_slots: dict[str, UserSlots] = {}
@@ -247,3 +211,39 @@ class DraftService:
             user_slots=user_slots,
             is_complete=is_complete,
         )
+
+    def _validate_and_apply_player_pick(
+        self, player_id, fantasy_league, fantasy_team, existing_picks
+    ) -> None:
+        player = self.db.get_player_by_id(player_id)
+        if player is None:
+            raise FantasyDraftException(f"Player not found: {player_id}")
+        if player.role == PlayerRole.NONE:
+            raise FantasyDraftException(f"Player has role=none and cannot be drafted: {player_id}")
+
+        player_league_ids = self.db.get_league_ids_for_player(player_id)
+        if not any(lid in fantasy_league.available_leagues for lid in player_league_ids):
+            raise FantasyDraftException(f"Player not from available leagues: {player_id}")
+
+        for pick in existing_picks:
+            if pick.player_id == player_id:
+                raise FantasyDraftException(f"Player already drafted: {player_id}")
+
+        if fantasy_team.get_player_id_for_role(player.role) is not None:
+            raise FantasyDraftException(f"Role slot already filled: {player.role.value}")
+
+        fantasy_team.set_player_id_for_role(player_id, player.role)
+
+    def _validate_and_apply_team_pick(self, team_id, fantasy_team, existing_picks) -> None:
+        team = self.db.get_team_by_id(team_id)
+        if team is None:
+            raise FantasyDraftException(f"Team not found: {team_id}")
+
+        for pick in existing_picks:
+            if pick.team_id == team_id:
+                raise FantasyDraftException(f"Team already drafted: {team_id}")
+
+        if fantasy_team.team_id is not None:
+            raise FantasyDraftException("Team slot already filled")
+
+        fantasy_team.team_id = team_id

--- a/tests/fantasy/integration/service/test_draft_service.py
+++ b/tests/fantasy/integration/service/test_draft_service.py
@@ -5,6 +5,7 @@ from tests.test_base import TestBase
 from tests.test_util import fantasy_fixtures, riot_fixtures
 
 from src.common.schemas.fantasy_schemas import (
+    DraftState,  # noqa: F401
     FantasyLeagueID,
     FantasyLeagueStatus,
     FantasyLeagueMembershipStatus,
@@ -114,10 +115,27 @@ class DraftServiceIntegrationTest(TestBase):
         for i in range(num_picks):
             idx = (start + i) % len(snake)
             user_idx = snake[idx]
-            role = all_roles[user_pick_count[user_idx] % len(all_roles)]
+            pick_num_for_user = user_pick_count[user_idx]
             user_pick_count[user_idx] += 1
-            player = self.make_player(role)
-            self.draft_service.make_pick(league.id, user_ids[user_idx], player_id=player.id)
+
+            if pick_num_for_user < 5:
+                # Player pick
+                role = all_roles[pick_num_for_user]
+                player = self.make_player(role)
+                self.draft_service.make_pick(league.id, user_ids[user_idx], player_id=player.id)
+            else:
+                # Team pick (6th pick for this user)
+                team = ProfessionalTeam(
+                    id=ProTeamID(f"filler-team-{user_idx}-{self._player_counter}"),
+                    slug=f"filler-{user_idx}",
+                    name="Filler Team",
+                    code=f"F{user_idx}",
+                    image="http://img.png",
+                    status="active",
+                    home_league_name=riot_fixtures.league_1_fixture.name,
+                )
+                self.db.put_team(team)
+                self.draft_service.make_pick(league.id, user_ids[user_idx], team_id=team.id)
 
     # --------------------------------------------------
     # ------------------- start_draft ------------------
@@ -364,3 +382,68 @@ class DraftServiceIntegrationTest(TestBase):
 
         teams = self.db.get_all_fantasy_teams_for_user(league.id, user_ids[0])
         self.assertEqual(riot_fixtures.team_1_fixture.id, teams[0].team_id)
+
+    # --------------------------------------------------
+    # -------------- draft completion ------------------
+    # --------------------------------------------------
+    def test_draft_completes_after_final_pick(self):
+        # Arrange — 4 users × 6 picks = 24 total picks
+        league, user_ids = self.setup_draft_league()
+        self.advance_draft(league, user_ids, 23)
+
+        # Act — make the 24th (final) pick (user 0's 6th pick = team pick)
+        final_team = ProfessionalTeam(
+            id=ProTeamID("final-team"),
+            slug="final",
+            name="Final Team",
+            code="FT",
+            image="http://img.png",
+            status="active",
+            home_league_name=riot_fixtures.league_1_fixture.name,
+        )
+        self.db.put_team(final_team)
+        self.draft_service.make_pick(league.id, user_ids[0], team_id=final_team.id)
+
+        # Assert
+        db_league = self.db.get_fantasy_league_by_id(league.id)
+        self.assertEqual(FantasyLeagueStatus.ACTIVE, db_league.status)
+        self.assertEqual(1, db_league.current_week)
+
+    # --------------------------------------------------
+    # --------------- get_draft_state ------------------
+    # --------------------------------------------------
+    def test_get_draft_state_mid_draft(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league()
+        player = self.make_player(PlayerRole.TOP)
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=player.id)
+
+        # Act
+        state = self.draft_service.get_draft_state(league.id, user_ids[0])
+
+        # Assert
+        self.assertEqual(league.id, state.fantasy_league_id)
+        self.assertEqual(1, state.current_round)
+        self.assertEqual(2, state.current_pick_number)
+        self.assertEqual(24, state.total_picks)
+        self.assertEqual(user_ids[1], state.current_turn_user_id)
+        self.assertEqual(1, len(state.picks))
+        self.assertFalse(state.is_complete)
+        # User 0 should have TOP filled
+        self.assertEqual(player.id, state.user_slots[user_ids[0]].top_player_id)
+        # User 1 should have nothing
+        self.assertIsNone(state.user_slots[user_ids[1]].top_player_id)
+
+    def test_get_draft_state_after_completion(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league()
+        self.advance_draft(league, user_ids, 24)
+
+        # Act
+        state = self.draft_service.get_draft_state(league.id, user_ids[0])
+
+        # Assert
+        self.assertTrue(state.is_complete)
+        self.assertIsNone(state.current_turn_user_id)
+        self.assertEqual(24, len(state.picks))
+        self.assertEqual(24, state.total_picks)


### PR DESCRIPTION
Closes #468

Depends on #473 (Phase 1C: make_pick)

## Changes

### Draft completion
- After the final pick (`pick_number == 6 × num_users`), league transitions to ACTIVE with `current_week = 1`
- Integrated into `make_pick` — no separate method needed

### `get_draft_state(league_id, user_id) -> DraftState`
Returns:
- `current_round`, `current_pick_number`, `total_picks`
- `current_turn_user_id` (None if complete)
- `picks` — all picks made so far
- `user_slots` — each user's filled slots (top, jg, mid, adc, sup, team)
- `is_complete` — boolean

### New schemas
- `DraftState` — response model for draft state queries
- `UserSlots` — per-user slot fill status

## Tests
3 new tests (20 total):
- `test_draft_completes_after_final_pick`
- `test_get_draft_state_mid_draft`
- `test_get_draft_state_after_completion`