### PR TITLE
feat: auto_pick and available players/teams queries

### DIFF
--- a/src/fantasy/service/draft_service.py
+++ b/src/fantasy/service/draft_service.py
@@ -1,7 +1,9 @@
 import logging
 import math
+import random
 
 from src.db.database_service import DatabaseService
+from src.db.models import ProfessionalPlayerModel, LeagueModel
 from src.common.schemas.fantasy_schemas import (
     DraftPick,
     DraftState,
@@ -13,7 +15,13 @@ from src.common.schemas.fantasy_schemas import (
     UserID,
     UserSlots,
 )
-from src.common.schemas.riot_data_schemas import ProPlayerID, ProTeamID, PlayerRole
+from src.common.schemas.riot_data_schemas import (
+    ProfessionalPlayer,
+    ProfessionalTeam,
+    ProPlayerID,
+    ProTeamID,
+    PlayerRole,
+)
 from src.fantasy.exceptions import (
     FantasyDraftException,
     FantasyLeagueStartDraftException,
@@ -211,6 +219,78 @@ class DraftService:
             user_slots=user_slots,
             is_complete=is_complete,
         )
+
+    def get_available_players(
+        self, league_id: FantasyLeagueID, user_id: UserID
+    ) -> list[ProfessionalPlayer]:
+        fantasy_league = self.fantasy_league_util.validate_league(
+            league_id, [FantasyLeagueStatus.DRAFT]
+        )
+        self.fantasy_league_util.validate_membership(user_id, league_id)
+
+        # Get players from available leagues, excluding role=none
+        filters = [
+            LeagueModel.id.in_(fantasy_league.available_leagues),
+            ProfessionalPlayerModel.role != PlayerRole.NONE.value,
+        ]
+        all_players = self.db.get_players(filters)
+
+        # Exclude already-drafted players
+        existing_picks = self.db.get_draft_picks_for_league(league_id)
+        drafted_player_ids = {pick.player_id for pick in existing_picks if pick.player_id}
+        return [p for p in all_players if p.id not in drafted_player_ids]
+
+    def get_available_teams(
+        self, league_id: FantasyLeagueID, user_id: UserID
+    ) -> list[ProfessionalTeam]:
+        fantasy_league = self.fantasy_league_util.validate_league(
+            league_id, [FantasyLeagueStatus.DRAFT]
+        )
+        self.fantasy_league_util.validate_membership(user_id, league_id)
+
+        # Get teams from available leagues
+        filters = [LeagueModel.id.in_(fantasy_league.available_leagues)]
+        all_teams = self.db.get_teams(filters, join_league=True)
+
+        # Exclude already-drafted teams
+        existing_picks = self.db.get_draft_picks_for_league(league_id)
+        drafted_team_ids = {pick.team_id for pick in existing_picks if pick.team_id}
+        return [t for t in all_teams if t.id not in drafted_team_ids]
+
+    def auto_pick(self, league_id: FantasyLeagueID, user_id: UserID) -> DraftPick:
+        # Determine user's current slots
+        user_teams = self.db.get_all_fantasy_teams_for_user(league_id, user_id)
+        if user_teams:
+            fantasy_team = user_teams[-1]
+        else:
+            fantasy_team = FantasyTeam(fantasy_league_id=league_id, user_id=user_id, week=0)
+
+        # Slot priority order
+        slot_roles = [
+            PlayerRole.TOP,
+            PlayerRole.JUNGLE,
+            PlayerRole.MID,
+            PlayerRole.BOTTOM,
+            PlayerRole.SUPPORT,
+        ]
+
+        # Try player slots first
+        available_players = self.get_available_players(league_id, user_id)
+        for role in slot_roles:
+            if fantasy_team.get_player_id_for_role(role) is None:
+                candidates = [p for p in available_players if p.role == role]
+                if candidates:
+                    chosen = random.choice(candidates)
+                    return self.make_pick(league_id, user_id, player_id=chosen.id)
+
+        # All player slots filled — pick a team
+        if fantasy_team.team_id is None:
+            available_teams = self.get_available_teams(league_id, user_id)
+            if available_teams:
+                chosen_team = random.choice(available_teams)
+                return self.make_pick(league_id, user_id, team_id=chosen_team.id)
+
+        raise FantasyDraftException("No valid picks available for auto_pick")
 
     def _validate_and_apply_player_pick(
         self, player_id, fantasy_league, fantasy_team, existing_picks

--- a/src/fantasy/service/draft_service.py
+++ b/src/fantasy/service/draft_service.py
@@ -227,8 +227,18 @@ class DraftService:
             league_id, [FantasyLeagueStatus.DRAFT]
         )
         self.fantasy_league_util.validate_membership(user_id, league_id)
+
+        # Get players from available leagues, excluding role=none
+        filters = [
+            LeagueModel.id.in_(fantasy_league.available_leagues),
+            ProfessionalPlayerModel.role != PlayerRole.NONE.value,
+        ]
+        all_players = self.db.get_players(filters)
+
+        # Exclude already-drafted players
         existing_picks = self.db.get_draft_picks_for_league(league_id)
-        return self._available_players(fantasy_league, existing_picks)
+        drafted_player_ids = {pick.player_id for pick in existing_picks if pick.player_id}
+        return [p for p in all_players if p.id not in drafted_player_ids]
 
     def get_available_teams(
         self, league_id: FantasyLeagueID, user_id: UserID
@@ -237,16 +247,17 @@ class DraftService:
             league_id, [FantasyLeagueStatus.DRAFT]
         )
         self.fantasy_league_util.validate_membership(user_id, league_id)
+
+        # Get teams from available leagues
+        filters = [LeagueModel.id.in_(fantasy_league.available_leagues)]
+        all_teams = self.db.get_teams(filters, join_league=True)
+
+        # Exclude already-drafted teams
         existing_picks = self.db.get_draft_picks_for_league(league_id)
-        return self._available_teams(fantasy_league, existing_picks)
+        drafted_team_ids = {pick.team_id for pick in existing_picks if pick.team_id}
+        return [t for t in all_teams if t.id not in drafted_team_ids]
 
     def auto_pick(self, league_id: FantasyLeagueID, user_id: UserID) -> DraftPick:
-        fantasy_league = self.fantasy_league_util.validate_league(
-            league_id, [FantasyLeagueStatus.DRAFT]
-        )
-        self.fantasy_league_util.validate_membership(user_id, league_id)
-        existing_picks = self.db.get_draft_picks_for_league(league_id)
-
         # Determine user's current slots
         user_teams = self.db.get_all_fantasy_teams_for_user(league_id, user_id)
         if user_teams:
@@ -256,12 +267,15 @@ class DraftService:
 
         # Slot priority order
         slot_roles = [
-            PlayerRole.TOP, PlayerRole.JUNGLE, PlayerRole.MID,
-            PlayerRole.BOTTOM, PlayerRole.SUPPORT,
+            PlayerRole.TOP,
+            PlayerRole.JUNGLE,
+            PlayerRole.MID,
+            PlayerRole.BOTTOM,
+            PlayerRole.SUPPORT,
         ]
 
         # Try player slots first
-        available_players = self._available_players(fantasy_league, existing_picks)
+        available_players = self.get_available_players(league_id, user_id)
         for role in slot_roles:
             if fantasy_team.get_player_id_for_role(role) is None:
                 candidates = [p for p in available_players if p.role == role]
@@ -271,27 +285,12 @@ class DraftService:
 
         # All player slots filled — pick a team
         if fantasy_team.team_id is None:
-            available_teams = self._available_teams(fantasy_league, existing_picks)
+            available_teams = self.get_available_teams(league_id, user_id)
             if available_teams:
                 chosen_team = random.choice(available_teams)
                 return self.make_pick(league_id, user_id, team_id=chosen_team.id)
 
         raise FantasyDraftException("No valid picks available for auto_pick")
-
-    def _available_players(self, fantasy_league, existing_picks) -> list[ProfessionalPlayer]:
-        filters = [
-            LeagueModel.id.in_(fantasy_league.available_leagues),
-            ProfessionalPlayerModel.role != PlayerRole.NONE.value,
-        ]
-        all_players = self.db.get_players(filters)
-        drafted_player_ids = {pick.player_id for pick in existing_picks if pick.player_id}
-        return [p for p in all_players if p.id not in drafted_player_ids]
-
-    def _available_teams(self, fantasy_league, existing_picks) -> list[ProfessionalTeam]:
-        filters = [LeagueModel.id.in_(fantasy_league.available_leagues)]
-        all_teams = self.db.get_teams(filters, join_league=True)
-        drafted_team_ids = {pick.team_id for pick in existing_picks if pick.team_id}
-        return [t for t in all_teams if t.id not in drafted_team_ids]
 
     def _validate_and_apply_player_pick(
         self, player_id, fantasy_league, fantasy_team, existing_picks

--- a/src/fantasy/service/draft_service.py
+++ b/src/fantasy/service/draft_service.py
@@ -227,18 +227,8 @@ class DraftService:
             league_id, [FantasyLeagueStatus.DRAFT]
         )
         self.fantasy_league_util.validate_membership(user_id, league_id)
-
-        # Get players from available leagues, excluding role=none
-        filters = [
-            LeagueModel.id.in_(fantasy_league.available_leagues),
-            ProfessionalPlayerModel.role != PlayerRole.NONE.value,
-        ]
-        all_players = self.db.get_players(filters)
-
-        # Exclude already-drafted players
         existing_picks = self.db.get_draft_picks_for_league(league_id)
-        drafted_player_ids = {pick.player_id for pick in existing_picks if pick.player_id}
-        return [p for p in all_players if p.id not in drafted_player_ids]
+        return self._available_players(fantasy_league, existing_picks)
 
     def get_available_teams(
         self, league_id: FantasyLeagueID, user_id: UserID
@@ -247,17 +237,16 @@ class DraftService:
             league_id, [FantasyLeagueStatus.DRAFT]
         )
         self.fantasy_league_util.validate_membership(user_id, league_id)
-
-        # Get teams from available leagues
-        filters = [LeagueModel.id.in_(fantasy_league.available_leagues)]
-        all_teams = self.db.get_teams(filters, join_league=True)
-
-        # Exclude already-drafted teams
         existing_picks = self.db.get_draft_picks_for_league(league_id)
-        drafted_team_ids = {pick.team_id for pick in existing_picks if pick.team_id}
-        return [t for t in all_teams if t.id not in drafted_team_ids]
+        return self._available_teams(fantasy_league, existing_picks)
 
     def auto_pick(self, league_id: FantasyLeagueID, user_id: UserID) -> DraftPick:
+        fantasy_league = self.fantasy_league_util.validate_league(
+            league_id, [FantasyLeagueStatus.DRAFT]
+        )
+        self.fantasy_league_util.validate_membership(user_id, league_id)
+        existing_picks = self.db.get_draft_picks_for_league(league_id)
+
         # Determine user's current slots
         user_teams = self.db.get_all_fantasy_teams_for_user(league_id, user_id)
         if user_teams:
@@ -267,15 +256,12 @@ class DraftService:
 
         # Slot priority order
         slot_roles = [
-            PlayerRole.TOP,
-            PlayerRole.JUNGLE,
-            PlayerRole.MID,
-            PlayerRole.BOTTOM,
-            PlayerRole.SUPPORT,
+            PlayerRole.TOP, PlayerRole.JUNGLE, PlayerRole.MID,
+            PlayerRole.BOTTOM, PlayerRole.SUPPORT,
         ]
 
         # Try player slots first
-        available_players = self.get_available_players(league_id, user_id)
+        available_players = self._available_players(fantasy_league, existing_picks)
         for role in slot_roles:
             if fantasy_team.get_player_id_for_role(role) is None:
                 candidates = [p for p in available_players if p.role == role]
@@ -285,12 +271,27 @@ class DraftService:
 
         # All player slots filled — pick a team
         if fantasy_team.team_id is None:
-            available_teams = self.get_available_teams(league_id, user_id)
+            available_teams = self._available_teams(fantasy_league, existing_picks)
             if available_teams:
                 chosen_team = random.choice(available_teams)
                 return self.make_pick(league_id, user_id, team_id=chosen_team.id)
 
         raise FantasyDraftException("No valid picks available for auto_pick")
+
+    def _available_players(self, fantasy_league, existing_picks) -> list[ProfessionalPlayer]:
+        filters = [
+            LeagueModel.id.in_(fantasy_league.available_leagues),
+            ProfessionalPlayerModel.role != PlayerRole.NONE.value,
+        ]
+        all_players = self.db.get_players(filters)
+        drafted_player_ids = {pick.player_id for pick in existing_picks if pick.player_id}
+        return [p for p in all_players if p.id not in drafted_player_ids]
+
+    def _available_teams(self, fantasy_league, existing_picks) -> list[ProfessionalTeam]:
+        filters = [LeagueModel.id.in_(fantasy_league.available_leagues)]
+        all_teams = self.db.get_teams(filters, join_league=True)
+        drafted_team_ids = {pick.team_id for pick in existing_picks if pick.team_id}
+        return [t for t in all_teams if t.id not in drafted_team_ids]
 
     def _validate_and_apply_player_pick(
         self, player_id, fantasy_league, fantasy_team, existing_picks

--- a/tests/fantasy/integration/service/test_draft_service.py
+++ b/tests/fantasy/integration/service/test_draft_service.py
@@ -515,6 +515,56 @@ class DraftServiceIntegrationTest(TestBase):
         self.assertNotIn(riot_fixtures.team_1_fixture.id, available_ids)
         self.assertIn(riot_fixtures.team_2_fixture.id, available_ids)
 
+    def test_get_available_teams_only_from_available_leagues(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league()
+        other_league = riot_fixtures.league_2_fixture
+        self.db.put_league(other_league)
+        other_team = ProfessionalTeam(
+            id=ProTeamID("other-league-team-2"),
+            slug="other",
+            name="Other",
+            code="OT",
+            image="http://img.png",
+            status="active",
+            home_league_name=other_league.name,
+        )
+        self.db.put_team(other_team)
+
+        # Act
+        available = self.draft_service.get_available_teams(league.id, user_ids[0])
+
+        # Assert
+        available_ids = [t.id for t in available]
+        self.assertIn(riot_fixtures.team_1_fixture.id, available_ids)
+        self.assertNotIn(other_team.id, available_ids)
+
+    def test_get_available_players_returns_empty_when_all_drafted(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league()
+        player = self.make_player(PlayerRole.TOP)
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=player.id)
+
+        # Act — the only available player was just drafted
+        available = self.draft_service.get_available_players(league.id, user_ids[1])
+
+        # Assert
+        self.assertEqual([], available)
+
+    def test_get_available_teams_returns_empty_when_all_drafted(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league()
+        # team_1 is the only team in the available league
+        self.draft_service.make_pick(
+            league.id, user_ids[0], team_id=riot_fixtures.team_1_fixture.id
+        )
+
+        # Act
+        available = self.draft_service.get_available_teams(league.id, user_ids[1])
+
+        # Assert
+        self.assertEqual([], available)
+
     # --------------------------------------------------
     # ------------------ auto_pick ---------------------
     # --------------------------------------------------

--- a/tests/fantasy/integration/service/test_draft_service.py
+++ b/tests/fantasy/integration/service/test_draft_service.py
@@ -447,3 +447,148 @@ class DraftServiceIntegrationTest(TestBase):
         self.assertIsNone(state.current_turn_user_id)
         self.assertEqual(24, len(state.picks))
         self.assertEqual(24, state.total_picks)
+
+    # --------------------------------------------------
+    # ------------- get_available_players --------------
+    # --------------------------------------------------
+    def test_get_available_players_excludes_drafted_and_role_none(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league()
+        valid_player = self.make_player(PlayerRole.TOP)
+        drafted_player = self.make_player(PlayerRole.JUNGLE)
+        none_player = self.make_player(PlayerRole.NONE)
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=drafted_player.id)
+
+        # Act
+        available = self.draft_service.get_available_players(league.id, user_ids[0])
+
+        # Assert
+        available_ids = [p.id for p in available]
+        self.assertIn(valid_player.id, available_ids)
+        self.assertNotIn(drafted_player.id, available_ids)
+        self.assertNotIn(none_player.id, available_ids)
+
+    def test_get_available_players_only_from_available_leagues(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league()
+        valid_player = self.make_player(PlayerRole.TOP)
+
+        # Player from a different league
+        other_league = riot_fixtures.league_2_fixture
+        self.db.put_league(other_league)
+        other_team = ProfessionalTeam(
+            id=ProTeamID("other-league-team"),
+            slug="other",
+            name="Other",
+            code="OT",
+            image="http://img.png",
+            status="active",
+            home_league_name=other_league.name,
+        )
+        self.db.put_team(other_team)
+        other_player = self.make_player(PlayerRole.MID, team_id=other_team.id)
+
+        # Act
+        available = self.draft_service.get_available_players(league.id, user_ids[0])
+
+        # Assert
+        available_ids = [p.id for p in available]
+        self.assertIn(valid_player.id, available_ids)
+        self.assertNotIn(other_player.id, available_ids)
+
+    # --------------------------------------------------
+    # ------------- get_available_teams ----------------
+    # --------------------------------------------------
+    def test_get_available_teams_excludes_drafted(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league()
+        self.db.put_team(riot_fixtures.team_2_fixture)
+        self.draft_service.make_pick(
+            league.id, user_ids[0], team_id=riot_fixtures.team_1_fixture.id
+        )
+
+        # Act
+        available = self.draft_service.get_available_teams(league.id, user_ids[1])
+
+        # Assert
+        available_ids = [t.id for t in available]
+        self.assertNotIn(riot_fixtures.team_1_fixture.id, available_ids)
+        self.assertIn(riot_fixtures.team_2_fixture.id, available_ids)
+
+    # --------------------------------------------------
+    # ------------------ auto_pick ---------------------
+    # --------------------------------------------------
+    def test_auto_pick_fills_first_empty_slot(self):
+        # Arrange
+        league, user_ids = self.setup_draft_league()
+        self.make_player(PlayerRole.TOP)  # available for auto_pick
+
+        # Act
+        result = self.draft_service.auto_pick(league.id, user_ids[0])
+
+        # Assert — should pick a TOP player (first empty slot)
+        self.assertEqual(user_ids[0], result.user_id)
+        self.assertIsNotNone(result.player_id)
+        teams = self.db.get_all_fantasy_teams_for_user(league.id, user_ids[0])
+        self.assertIsNotNone(teams[0].top_player_id)
+
+    def test_auto_pick_skips_filled_slots(self):
+        # Arrange — fill TOP for user 0, then advance back to user 0
+        league, user_ids = self.setup_draft_league()
+        self.make_player(PlayerRole.JUNGLE)  # available for auto_pick
+        top_player = self.make_player(PlayerRole.TOP)
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=top_player.id)
+        self.advance_draft(league, user_ids, 6)
+
+        # Act — user 0's turn again, TOP is filled so should pick JUNGLE
+        self.draft_service.auto_pick(league.id, user_ids[0])
+
+        # Assert
+        teams = self.db.get_all_fantasy_teams_for_user(league.id, user_ids[0])
+        self.assertIsNotNone(teams[0].jungle_player_id)
+
+    def test_auto_pick_picks_team_when_all_player_slots_filled(self):
+        # Arrange — fill all 5 player slots for user 0
+        league, user_ids = self.setup_draft_league()
+        self.db.put_team(riot_fixtures.team_2_fixture)
+
+        # User 0's turns in a 4-user snake: picks 1, 8, 9, 16, 17, 24
+        # Fill 5 player slots across user 0's first 5 turns
+        roles_to_fill = [
+            PlayerRole.TOP,
+            PlayerRole.JUNGLE,
+            PlayerRole.MID,
+            PlayerRole.BOTTOM,
+            PlayerRole.SUPPORT,
+        ]
+
+        # Pick 1: user 0
+        p = self.make_player(roles_to_fill[0])
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=p.id)
+        # Advance picks 2-7 (6 picks)
+        self.advance_draft(league, user_ids, 6)
+        # Pick 8: user 0 (round 2 snake: pos 4,3,2,1 → pick 8 = pos 1 = user 0)
+        p = self.make_player(roles_to_fill[1])
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=p.id)
+        # Pick 9: user 0 (round 3: pos 1 = user 0)
+        p = self.make_player(roles_to_fill[2])
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=p.id)
+        # Advance picks 10-15 (6 picks)
+        self.advance_draft(league, user_ids, 6)
+        # Pick 16: user 0 (round 4 snake: pos 4,3,2,1 → pick 16 = pos 1 = user 0)
+        p = self.make_player(roles_to_fill[3])
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=p.id)
+        # Pick 17: user 0 (round 5: pos 1 = user 0)
+        p = self.make_player(roles_to_fill[4])
+        self.draft_service.make_pick(league.id, user_ids[0], player_id=p.id)
+        # Advance picks 18-23 (6 picks)
+        self.advance_draft(league, user_ids, 6)
+
+        # Now pick 24: user 0's turn, all player slots filled
+        # Act
+        result = self.draft_service.auto_pick(league.id, user_ids[0])
+
+        # Assert
+        self.assertIsNotNone(result.team_id)
+        teams = self.db.get_all_fantasy_teams_for_user(league.id, user_ids[0])
+        self.assertIsNotNone(teams[0].team_id)


### PR DESCRIPTION
Closes #469

Depends on #474 (Phase 1D: draft completion + get_draft_state)

## Changes

### `get_available_players(league_id, user_id) -> list[ProfessionalPlayer]`
- Filters players from the league's `available_leagues`
- Excludes players with `role = none`
- Excludes player IDs already in `draft_picks` for this league

### `get_available_teams(league_id, user_id) -> list[ProfessionalTeam]`
- Filters teams from the league's `available_leagues`
- Excludes team IDs already in `draft_picks` for this league

### `auto_pick(league_id, user_id) -> DraftPick`
- Deterministic slot priority: top → jungle → mid → adc → support → team
- Finds first unfilled slot for the user
- Selects a random valid player/team from the available pool
- Delegates to `make_pick` internally