### PR TITLE
feat: DraftConnectionManager and WebSocket event schemas

### DIFF
--- a/src/common/schemas/fantasy_schemas.py
+++ b/src/common/schemas/fantasy_schemas.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from pydantic import BaseModel, ConfigDict, Field, field_validator, EmailStr
-from typing import NewType
+from typing import NewType, Literal
 
 from .riot_data_schemas import RiotLeagueID, ProPlayerID, ProTeamID, PlayerRole  # type: ignore
 
@@ -252,11 +252,15 @@ class DraftState(BaseModel):
     is_complete: bool
 
 
-class PickMadeEvent(BaseModel):
-    event: str = "pick_made"
+class DraftEvent(BaseModel):
+    event: str
+
+
+class PickMadeEvent(DraftEvent):
+    event: Literal["pick_made"] = "pick_made"
     pick: DraftPick
     next_turn_user_id: UserID | None = None
 
 
-class DraftCompletedEvent(BaseModel):
-    event: str = "draft_completed"
+class DraftCompletedEvent(DraftEvent):
+    event: Literal["draft_completed"] = "draft_completed"

--- a/src/common/schemas/fantasy_schemas.py
+++ b/src/common/schemas/fantasy_schemas.py
@@ -250,3 +250,13 @@ class DraftState(BaseModel):
     picks: list[DraftPick]
     user_slots: dict[str, UserSlots]
     is_complete: bool
+
+
+class PickMadeEvent(BaseModel):
+    event: str = "pick_made"
+    pick: DraftPick
+    next_turn_user_id: UserID | None = None
+
+
+class DraftCompletedEvent(BaseModel):
+    event: str = "draft_completed"

--- a/src/fantasy/service/__init__.py
+++ b/src/fantasy/service/__init__.py
@@ -1,3 +1,4 @@
+from .draft_connection_manager import DraftConnectionManager  # noqa: F401
 from .draft_service import DraftService  # noqa: F401
 from .fantasy_league_service import FantasyLeagueService  # noqa: F401
 from .fantasy_team_service import FantasyTeamService  # noqa: F401

--- a/src/fantasy/service/draft_connection_manager.py
+++ b/src/fantasy/service/draft_connection_manager.py
@@ -1,6 +1,6 @@
 from fastapi import WebSocket
 
-from src.common.schemas.fantasy_schemas import FantasyLeagueID
+from src.common.schemas.fantasy_schemas import DraftEvent, FantasyLeagueID
 
 
 class DraftConnectionManager:
@@ -19,7 +19,8 @@ class DraftConnectionManager:
     def get_connections(self, league_id: FantasyLeagueID) -> list[WebSocket]:
         return list(self._rooms.get(league_id, set()))
 
-    async def broadcast(self, league_id: FantasyLeagueID, message: str) -> None:
+    async def broadcast(self, league_id: FantasyLeagueID, event: DraftEvent) -> None:
+        message = event.model_dump_json()
         for ws in list(self._rooms.get(league_id, set())):
             await ws.send_text(message)
 

--- a/src/fantasy/service/draft_connection_manager.py
+++ b/src/fantasy/service/draft_connection_manager.py
@@ -1,0 +1,29 @@
+from fastapi import WebSocket
+
+from src.common.schemas.fantasy_schemas import FantasyLeagueID
+
+
+class DraftConnectionManager:
+    def __init__(self):
+        self._rooms: dict[str, set[WebSocket]] = {}
+
+    def connect(self, league_id: FantasyLeagueID, websocket: WebSocket) -> None:
+        if league_id not in self._rooms:
+            self._rooms[league_id] = set()
+        self._rooms[league_id].add(websocket)
+
+    def disconnect(self, league_id: FantasyLeagueID, websocket: WebSocket) -> None:
+        if league_id in self._rooms:
+            self._rooms[league_id].discard(websocket)
+
+    def get_connections(self, league_id: FantasyLeagueID) -> list[WebSocket]:
+        return list(self._rooms.get(league_id, set()))
+
+    async def broadcast(self, league_id: FantasyLeagueID, message: str) -> None:
+        for ws in list(self._rooms.get(league_id, set())):
+            await ws.send_text(message)
+
+    async def close_room(self, league_id: FantasyLeagueID) -> None:
+        for ws in list(self._rooms.get(league_id, set())):
+            await ws.close()
+        self._rooms.pop(league_id, None)

--- a/tests/fantasy/unit/test_draft_connection_manager.py
+++ b/tests/fantasy/unit/test_draft_connection_manager.py
@@ -1,0 +1,95 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+from tests.test_base import TestBase
+from src.common.schemas.fantasy_schemas import FantasyLeagueID
+
+
+class TestDraftConnectionManager(TestBase):
+    def setUp(self):
+        super().setUp()
+        from src.fantasy.service.draft_connection_manager import DraftConnectionManager
+
+        self.manager = DraftConnectionManager()
+        self.league_id = FantasyLeagueID("test-league")
+
+    def make_ws(self):
+        ws = AsyncMock()
+        return ws
+
+    # --------------------------------------------------
+    # ------------------- connect ----------------------
+    # --------------------------------------------------
+    def test_connect_adds_websocket_to_room(self):
+        # Arrange
+        ws = self.make_ws()
+
+        # Act
+        self.manager.connect(self.league_id, ws)
+
+        # Assert
+        self.assertIn(ws, self.manager.get_connections(self.league_id))
+
+    # --------------------------------------------------
+    # ------------------ disconnect --------------------
+    # --------------------------------------------------
+    def test_disconnect_removes_websocket_from_room(self):
+        # Arrange
+        ws = self.make_ws()
+        self.manager.connect(self.league_id, ws)
+
+        # Act
+        self.manager.disconnect(self.league_id, ws)
+
+        # Assert
+        self.assertNotIn(ws, self.manager.get_connections(self.league_id))
+
+    def test_disconnect_nonexistent_connection_does_nothing(self):
+        # Arrange
+        ws = self.make_ws()
+
+        # Act & Assert — no error
+        self.manager.disconnect(self.league_id, ws)
+
+    # --------------------------------------------------
+    # ------------------- broadcast --------------------
+    # --------------------------------------------------
+    def test_broadcast_sends_message_to_all_connections(self):
+        # Arrange
+        ws1 = self.make_ws()
+        ws2 = self.make_ws()
+        self.manager.connect(self.league_id, ws1)
+        self.manager.connect(self.league_id, ws2)
+
+        # Act
+        asyncio.run(self.manager.broadcast(self.league_id, '{"event": "test"}'))
+
+        # Assert
+        ws1.send_text.assert_called_once_with('{"event": "test"}')
+        ws2.send_text.assert_called_once_with('{"event": "test"}')
+
+    def test_broadcast_to_empty_room_does_nothing(self):
+        # Act & Assert — no error
+        asyncio.run(self.manager.broadcast(self.league_id, '{"event": "test"}'))
+
+    # --------------------------------------------------
+    # ------------------ close_room --------------------
+    # --------------------------------------------------
+    def test_close_room_closes_all_connections_and_removes_room(self):
+        # Arrange
+        ws1 = self.make_ws()
+        ws2 = self.make_ws()
+        self.manager.connect(self.league_id, ws1)
+        self.manager.connect(self.league_id, ws2)
+
+        # Act
+        asyncio.run(self.manager.close_room(self.league_id))
+
+        # Assert
+        ws1.close.assert_called_once()
+        ws2.close.assert_called_once()
+        self.assertEqual([], self.manager.get_connections(self.league_id))
+
+    def test_close_room_nonexistent_room_does_nothing(self):
+        # Act & Assert — no error
+        asyncio.run(self.manager.close_room(self.league_id))

--- a/tests/fantasy/unit/test_draft_connection_manager.py
+++ b/tests/fantasy/unit/test_draft_connection_manager.py
@@ -2,7 +2,10 @@ import asyncio
 from unittest.mock import AsyncMock
 
 from tests.test_base import TestBase
-from src.common.schemas.fantasy_schemas import FantasyLeagueID
+from src.common.schemas.fantasy_schemas import (
+    DraftCompletedEvent,
+    FantasyLeagueID,
+)
 
 
 class TestDraftConnectionManager(TestBase):
@@ -60,17 +63,19 @@ class TestDraftConnectionManager(TestBase):
         ws2 = self.make_ws()
         self.manager.connect(self.league_id, ws1)
         self.manager.connect(self.league_id, ws2)
+        event = DraftCompletedEvent()
 
         # Act
-        asyncio.run(self.manager.broadcast(self.league_id, '{"event": "test"}'))
+        asyncio.run(self.manager.broadcast(self.league_id, event))
 
         # Assert
-        ws1.send_text.assert_called_once_with('{"event": "test"}')
-        ws2.send_text.assert_called_once_with('{"event": "test"}')
+        expected = event.model_dump_json()
+        ws1.send_text.assert_called_once_with(expected)
+        ws2.send_text.assert_called_once_with(expected)
 
     def test_broadcast_to_empty_room_does_nothing(self):
         # Act & Assert — no error
-        asyncio.run(self.manager.broadcast(self.league_id, '{"event": "test"}'))
+        asyncio.run(self.manager.broadcast(self.league_id, DraftCompletedEvent()))
 
     # --------------------------------------------------
     # ------------------ close_room --------------------


### PR DESCRIPTION
Closes #479

## Changes
- **`DraftConnectionManager`**: in-memory room management with `connect`, `disconnect`, `broadcast` (async), `close_room` (async)
- **`PickMadeEvent`** and **`DraftCompletedEvent`** Pydantic schemas for WebSocket messages
- Exported from `src/fantasy/service/__init__.py`

## Tests
7 unit tests using `AsyncMock` for WebSocket objects:
- connect adds to room
- disconnect removes from room
- disconnect nonexistent does nothing
- broadcast sends to all connections
- broadcast to empty room does nothing
- close_room closes all and removes room
- close_room nonexistent room does nothing