### PR TITLE
feat: REST draft endpoints (start, state, available players/teams)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -10,8 +10,13 @@ from src.common.logger import configure_logger
 from src.common.middleware import RequestLoggingMiddleware
 from src.db.database_connection_provider import DatabaseConnectionProvider
 from src.db.database_service import DatabaseService
-from src.fantasy.endpoints import FantasyLeagueEndpoint, FantasyTeamEndpoint, UserEndpointV1
-from src.fantasy.service import FantasyLeagueService, FantasyTeamService, UserService
+from src.fantasy.endpoints import (
+    DraftEndpoint,
+    FantasyLeagueEndpoint,
+    FantasyTeamEndpoint,
+    UserEndpointV1,
+)
+from src.fantasy.service import DraftService, FantasyLeagueService, FantasyTeamService, UserService
 from src.riot.endpoints import (
     AdminEndpoint,
     GameEndpoint,
@@ -71,12 +76,14 @@ def create_app(database_service: DatabaseService) -> FastAPI:
     user_service = UserService(database_service)
     fantasy_league_service = FantasyLeagueService(database_service)
     fantasy_team_service = FantasyTeamService(database_service)
+    draft_service = DraftService(database_service)
 
     app.include_router(UserEndpointV1(user_service).router, prefix="/api/v1")
     app.include_router(
         FantasyLeagueEndpoint(fantasy_league_service).router, prefix="/api/v1/fantasy"
     )
     app.include_router(FantasyTeamEndpoint(fantasy_team_service).router, prefix="/api/v1/fantasy")
+    app.include_router(DraftEndpoint(draft_service).router, prefix="/api/v1/fantasy")
 
     add_pagination(app)
 

--- a/src/fantasy/endpoints/__init__.py
+++ b/src/fantasy/endpoints/__init__.py
@@ -1,3 +1,4 @@
+from .draft_endpoint_v1 import DraftEndpoint  # noqa: F401
 from .fantasy_league_endpoint_v1 import FantasyLeagueEndpoint  # noqa: F401
 from .fantasy_team_endpoint_v1 import FantasyTeamEndpoint  # noqa: F401
 from .user_endpoint_v1 import UserEndpointV1  # noqa: F401

--- a/src/fantasy/endpoints/draft_endpoint_v1.py
+++ b/src/fantasy/endpoints/draft_endpoint_v1.py
@@ -1,0 +1,68 @@
+from classy_fastapi import Routable, get, post
+from fastapi import Depends
+
+from src.auth import JWTBearer, Permissions
+from src.auth.auth_principal import AuthPrincipal
+from src.common.schemas.fantasy_schemas import (
+    DraftState,
+    FantasyLeagueID,
+)
+from src.common.schemas.riot_data_schemas import ProfessionalPlayer, ProfessionalTeam
+from src.fantasy.service import DraftService
+
+
+class DraftEndpoint(Routable):
+    def __init__(self, draft_service: DraftService):
+        super().__init__()
+        self.__draft_service = draft_service
+
+    @post(
+        path="/leagues/{league_id}/draft/start",
+        description="Start the draft for a Fantasy League.",
+        tags=["Fantasy Draft"],
+    )
+    def start_draft(
+        self,
+        league_id: FantasyLeagueID,
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_WRITE])),
+    ) -> None:
+        self.__draft_service.start_draft(league_id, principal.user_id)
+
+    @get(
+        path="/leagues/{league_id}/draft/state",
+        description="Get the current draft state for a Fantasy League.",
+        tags=["Fantasy Draft"],
+        response_model=DraftState,
+    )
+    def get_draft_state(
+        self,
+        league_id: FantasyLeagueID,
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_READ])),
+    ) -> DraftState:
+        return self.__draft_service.get_draft_state(league_id, principal.user_id)
+
+    @get(
+        path="/leagues/{league_id}/draft/available-players",
+        description="Get available players to draft in a Fantasy League.",
+        tags=["Fantasy Draft"],
+        response_model=list[ProfessionalPlayer],
+    )
+    def get_available_players(
+        self,
+        league_id: FantasyLeagueID,
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_READ])),
+    ) -> list[ProfessionalPlayer]:
+        return self.__draft_service.get_available_players(league_id, principal.user_id)
+
+    @get(
+        path="/leagues/{league_id}/draft/available-teams",
+        description="Get available teams to draft in a Fantasy League.",
+        tags=["Fantasy Draft"],
+        response_model=list[ProfessionalTeam],
+    )
+    def get_available_teams(
+        self,
+        league_id: FantasyLeagueID,
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_READ])),
+    ) -> list[ProfessionalTeam]:
+        return self.__draft_service.get_available_teams(league_id, principal.user_id)

--- a/tests/fantasy/integration/test_draft_endpoint.py
+++ b/tests/fantasy/integration/test_draft_endpoint.py
@@ -1,0 +1,136 @@
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from src.app import create_app
+from src.auth import sign_jwt, Permissions
+from src.db.database_service import DatabaseService
+
+TEST_USER_ID = "test-user-id"
+TEST_LEAGUE_ID = "test-league-id"
+ALL_PERMISSIONS = [p.value for p in Permissions]
+
+
+def make_client():
+    mock_db = MagicMock(spec=DatabaseService)
+    app = create_app(mock_db)
+    token_data = sign_jwt(TEST_USER_ID, ALL_PERMISSIONS, "test-user")
+    headers = {"Authorization": f"Bearer {token_data['access_token']}"}
+    client = TestClient(app, raise_server_exceptions=False)
+    return client, mock_db, headers
+
+
+def make_unauthed_client():
+    mock_db = MagicMock(spec=DatabaseService)
+    app = create_app(mock_db)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestDraftEndpoint:
+    # --------------------------------------------------
+    # ------------------- start ------------------------
+    # --------------------------------------------------
+    def test_start_draft_route_is_mounted(self):
+        # Arrange
+        client, mock_db, headers = make_client()
+
+        # Act — route exists (not 404/405), service may return error due to mock
+        response = client.post(
+            f"/api/v1/fantasy/leagues/{TEST_LEAGUE_ID}/draft/start",
+            headers=headers,
+        )
+
+        # Assert
+        assert response.status_code != 404
+        assert response.status_code != 405
+
+    def test_start_draft_unauthenticated_returns_403(self):
+        # Arrange
+        client = make_unauthed_client()
+
+        # Act
+        response = client.post(f"/api/v1/fantasy/leagues/{TEST_LEAGUE_ID}/draft/start")
+
+        # Assert
+        assert response.status_code == 403
+
+    # --------------------------------------------------
+    # ------------------- state ------------------------
+    # --------------------------------------------------
+    def test_get_draft_state_route_is_mounted(self):
+        # Arrange
+        client, mock_db, headers = make_client()
+
+        # Act
+        response = client.get(
+            f"/api/v1/fantasy/leagues/{TEST_LEAGUE_ID}/draft/state",
+            headers=headers,
+        )
+
+        # Assert
+        assert response.status_code != 404
+        assert response.status_code != 405
+
+    def test_get_draft_state_unauthenticated_returns_403(self):
+        # Arrange
+        client = make_unauthed_client()
+
+        # Act
+        response = client.get(f"/api/v1/fantasy/leagues/{TEST_LEAGUE_ID}/draft/state")
+
+        # Assert
+        assert response.status_code == 403
+
+    # --------------------------------------------------
+    # ------------- available-players ------------------
+    # --------------------------------------------------
+    def test_get_available_players_route_is_mounted(self):
+        # Arrange
+        client, mock_db, headers = make_client()
+
+        # Act
+        response = client.get(
+            f"/api/v1/fantasy/leagues/{TEST_LEAGUE_ID}/draft/available-players",
+            headers=headers,
+        )
+
+        # Assert
+        assert response.status_code != 404
+        assert response.status_code != 405
+
+    def test_get_available_players_unauthenticated_returns_403(self):
+        # Arrange
+        client = make_unauthed_client()
+
+        # Act
+        response = client.get(f"/api/v1/fantasy/leagues/{TEST_LEAGUE_ID}/draft/available-players")
+
+        # Assert
+        assert response.status_code == 403
+
+    # --------------------------------------------------
+    # -------------- available-teams -------------------
+    # --------------------------------------------------
+    def test_get_available_teams_route_is_mounted(self):
+        # Arrange
+        client, mock_db, headers = make_client()
+
+        # Act
+        response = client.get(
+            f"/api/v1/fantasy/leagues/{TEST_LEAGUE_ID}/draft/available-teams",
+            headers=headers,
+        )
+
+        # Assert
+        assert response.status_code != 404
+        assert response.status_code != 405
+
+    def test_get_available_teams_unauthenticated_returns_403(self):
+        # Arrange
+        client = make_unauthed_client()
+
+        # Act
+        response = client.get(f"/api/v1/fantasy/leagues/{TEST_LEAGUE_ID}/draft/available-teams")
+
+        # Assert
+        assert response.status_code == 403


### PR DESCRIPTION
Closes #480

## Changes
- **`DraftEndpoint`** — new `classy_fastapi.Routable` with 4 routes:
  - `POST /leagues/{league_id}/draft/start` (FANTASY_WRITE)
  - `GET /leagues/{league_id}/draft/state` (FANTASY_READ)
  - `GET /leagues/{league_id}/draft/available-players` (FANTASY_READ)
  - `GET /leagues/{league_id}/draft/available-teams` (FANTASY_READ)
- **`app.py`** — `DraftService` instantiated and `DraftEndpoint` router wired under `/api/v1/fantasy`

## Tests
8 endpoint tests verifying:
- All 4 routes are mounted (not 404/405)
- All 4 routes reject unauthenticated requests (403)

Note: pick endpoint is in #482 (requires DraftConnectionManager for broadcasting)