### PR TITLE
feat: WebSocket endpoint for draft room

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -16,7 +16,14 @@ from src.fantasy.endpoints import (
     FantasyTeamEndpoint,
     UserEndpointV1,
 )
-from src.fantasy.service import DraftService, FantasyLeagueService, FantasyTeamService, UserService
+from src.fantasy.endpoints.draft_websocket import create_draft_ws_router
+from src.fantasy.service import (
+    DraftConnectionManager,
+    DraftService,
+    FantasyLeagueService,
+    FantasyTeamService,
+    UserService,
+)
 from src.riot.endpoints import (
     AdminEndpoint,
     GameEndpoint,
@@ -77,6 +84,7 @@ def create_app(database_service: DatabaseService) -> FastAPI:
     fantasy_league_service = FantasyLeagueService(database_service)
     fantasy_team_service = FantasyTeamService(database_service)
     draft_service = DraftService(database_service)
+    connection_manager = DraftConnectionManager()
 
     app.include_router(UserEndpointV1(user_service).router, prefix="/api/v1")
     app.include_router(
@@ -84,6 +92,10 @@ def create_app(database_service: DatabaseService) -> FastAPI:
     )
     app.include_router(FantasyTeamEndpoint(fantasy_team_service).router, prefix="/api/v1/fantasy")
     app.include_router(DraftEndpoint(draft_service).router, prefix="/api/v1/fantasy")
+    app.include_router(
+        create_draft_ws_router(database_service, connection_manager),
+        prefix="/api/v1/fantasy",
+    )
 
     add_pagination(app)
 

--- a/src/fantasy/endpoints/draft_websocket.py
+++ b/src/fantasy/endpoints/draft_websocket.py
@@ -1,0 +1,61 @@
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from src.auth.auth_handler import decode_jwt
+from src.common.schemas.fantasy_schemas import (
+    FantasyLeagueID,
+    FantasyLeagueMembershipStatus,
+    FantasyLeagueStatus,
+    UserID,
+)
+from src.db.database_service import DatabaseService
+from src.fantasy.service import DraftConnectionManager
+
+
+def create_draft_ws_router(
+    database_service: DatabaseService,
+    connection_manager: DraftConnectionManager,
+) -> APIRouter:
+    router = APIRouter(tags=["Fantasy Draft"])
+
+    @router.websocket("/leagues/{league_id}/draft/ws")
+    async def draft_websocket(
+        websocket: WebSocket,
+        league_id: FantasyLeagueID,
+        token: str | None = None,
+    ):
+        # Validate token
+        if not token:
+            await websocket.close(code=4001)
+            return
+
+        payload = decode_jwt(token)
+        if not payload:
+            await websocket.close(code=4001)
+            return
+
+        user_id = UserID(payload.get("user_id", ""))
+
+        # Validate league is in DRAFT status
+        fantasy_league = database_service.get_fantasy_league_by_id(league_id)
+        if fantasy_league is None or fantasy_league.status != FantasyLeagueStatus.DRAFT:
+            await websocket.close(code=4002)
+            return
+
+        # Validate membership
+        membership = database_service.get_user_membership_for_fantasy_league(user_id, league_id)
+        if membership is None or membership.status != FantasyLeagueMembershipStatus.ACCEPTED:
+            await websocket.close(code=4003)
+            return
+
+        # Accept and register connection
+        await websocket.accept()
+        connection_manager.connect(league_id, websocket)
+
+        try:
+            while True:
+                # Keep connection alive — WebSocket is read-only push
+                await websocket.receive_text()
+        except WebSocketDisconnect:
+            connection_manager.disconnect(league_id, websocket)
+
+    return router

--- a/tests/fantasy/integration/test_draft_websocket.py
+++ b/tests/fantasy/integration/test_draft_websocket.py
@@ -1,0 +1,121 @@
+from unittest.mock import MagicMock
+from copy import deepcopy
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from src.app import create_app
+from src.auth import sign_jwt, Permissions
+from src.common.schemas.fantasy_schemas import (
+    FantasyLeague,
+    FantasyLeagueID,
+    FantasyLeagueMembership,
+    FantasyLeagueMembershipStatus,
+    UserID,
+)
+from src.db.database_service import DatabaseService
+from tests.test_util import fantasy_fixtures
+
+TEST_USER_ID = "test-user-id"
+TEST_LEAGUE_ID = "test-league-id"
+ALL_PERMISSIONS = [p.value for p in Permissions]
+WS_URL = f"/api/v1/fantasy/leagues/{TEST_LEAGUE_ID}/draft/ws"
+
+
+def make_token(user_id=TEST_USER_ID):
+    return sign_jwt(user_id, ALL_PERMISSIONS, "test-user")["access_token"]
+
+
+def make_draft_league() -> FantasyLeague:
+    league = deepcopy(fantasy_fixtures.fantasy_league_draft_fixture)
+    league.id = FantasyLeagueID(TEST_LEAGUE_ID)
+    return league
+
+
+def make_accepted_membership(user_id=TEST_USER_ID) -> FantasyLeagueMembership:
+    return FantasyLeagueMembership(
+        league_id=FantasyLeagueID(TEST_LEAGUE_ID),
+        user_id=UserID(user_id),
+        status=FantasyLeagueMembershipStatus.ACCEPTED,
+    )
+
+
+class TestDraftWebSocketEndpoint:
+    def setup_method(self):
+        self.mock_db = MagicMock(spec=DatabaseService)
+        self.app = create_app(self.mock_db)
+        self.client = TestClient(self.app, raise_server_exceptions=False)
+
+    # --------------------------------------------------
+    # ----------- successful connection ----------------
+    # --------------------------------------------------
+    def test_authenticated_member_can_connect(self):
+        # Arrange
+        self.mock_db.get_fantasy_league_by_id.return_value = make_draft_league()
+        self.mock_db.get_user_membership_for_fantasy_league.return_value = (
+            make_accepted_membership()
+        )
+        token = make_token()
+
+        # Act & Assert — connection accepted, no exception
+        with self.client.websocket_connect(f"{WS_URL}?token={token}"):
+            pass  # connected successfully
+
+    # --------------------------------------------------
+    # ----------- rejected connections -----------------
+    # --------------------------------------------------
+    def test_missing_token_rejects_connection(self):
+        # Act & Assert
+        with pytest.raises(WebSocketDisconnect):
+            with self.client.websocket_connect(WS_URL):
+                pass
+
+    def test_invalid_token_rejects_connection(self):
+        # Act & Assert
+        with pytest.raises(WebSocketDisconnect):
+            with self.client.websocket_connect(f"{WS_URL}?token=invalid-token"):
+                pass
+
+    def test_non_member_rejects_connection(self):
+        # Arrange
+        self.mock_db.get_fantasy_league_by_id.return_value = make_draft_league()
+        self.mock_db.get_user_membership_for_fantasy_league.return_value = None
+        token = make_token()
+
+        # Act & Assert
+        with pytest.raises(WebSocketDisconnect):
+            with self.client.websocket_connect(f"{WS_URL}?token={token}"):
+                pass
+
+    def test_non_draft_league_rejects_connection(self):
+        # Arrange
+        active_league = deepcopy(fantasy_fixtures.fantasy_league_active_fixture)
+        active_league.id = FantasyLeagueID(TEST_LEAGUE_ID)
+        self.mock_db.get_fantasy_league_by_id.return_value = active_league
+        self.mock_db.get_user_membership_for_fantasy_league.return_value = (
+            make_accepted_membership()
+        )
+        token = make_token()
+
+        # Act & Assert
+        with pytest.raises(WebSocketDisconnect):
+            with self.client.websocket_connect(f"{WS_URL}?token={token}"):
+                pass
+
+    # --------------------------------------------------
+    # -------------- disconnect cleanup ----------------
+    # --------------------------------------------------
+    def test_disconnect_removes_connection_from_manager(self):
+        # Arrange
+        self.mock_db.get_fantasy_league_by_id.return_value = make_draft_league()
+        self.mock_db.get_user_membership_for_fantasy_league.return_value = (
+            make_accepted_membership()
+        )
+        token = make_token()
+
+        # Act — connect then disconnect
+        with self.client.websocket_connect(f"{WS_URL}?token={token}"):
+            pass  # disconnect on exit
+
+        # Assert — no error raised means disconnect was handled cleanly


### PR DESCRIPTION
Closes #481

Depends on #483 (Phase 2A: DraftConnectionManager)

## Changes
- **`draft_websocket.py`** — `create_draft_ws_router(db, manager)` factory that returns an `APIRouter` with the WebSocket route
- **Route**: `WS /api/v1/fantasy/leagues/{league_id}/draft/ws?token=<jwt>`
- **Validation on connect**: JWT token → league in DRAFT status → accepted membership
- **Close codes**: 4001 (bad/missing token), 4002 (wrong league status), 4003 (not a member)
- **Lifecycle**: registers with `DraftConnectionManager` on accept, removes on disconnect
- **`app.py`**: `DraftConnectionManager` singleton instantiated and passed to both `DraftEndpoint` (future) and WebSocket router

## Tests
6 WebSocket integration tests:
- Authenticated member connects successfully
- Missing token rejected
- Invalid token rejected
- Non-member rejected
- Non-DRAFT league rejected
- Disconnect handled cleanly (no error)