### PR TITLE
feat: pick endpoint with WebSocket broadcast

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -91,7 +91,9 @@ def create_app(database_service: DatabaseService) -> FastAPI:
         FantasyLeagueEndpoint(fantasy_league_service).router, prefix="/api/v1/fantasy"
     )
     app.include_router(FantasyTeamEndpoint(fantasy_team_service).router, prefix="/api/v1/fantasy")
-    app.include_router(DraftEndpoint(draft_service).router, prefix="/api/v1/fantasy")
+    app.include_router(
+        DraftEndpoint(draft_service, connection_manager).router, prefix="/api/v1/fantasy"
+    )
     app.include_router(
         create_draft_ws_router(database_service, connection_manager),
         prefix="/api/v1/fantasy",

--- a/src/common/schemas/fantasy_schemas.py
+++ b/src/common/schemas/fantasy_schemas.py
@@ -264,3 +264,8 @@ class PickMadeEvent(DraftEvent):
 
 class DraftCompletedEvent(DraftEvent):
     event: Literal["draft_completed"] = "draft_completed"
+
+
+class PickRequest(BaseModel):
+    player_id: ProPlayerID | None = None
+    team_id: ProTeamID | None = None

--- a/src/fantasy/endpoints/draft_endpoint_v1.py
+++ b/src/fantasy/endpoints/draft_endpoint_v1.py
@@ -1,20 +1,27 @@
+import asyncio
+
 from classy_fastapi import Routable, get, post
-from fastapi import Depends
+from fastapi import Body, Depends
 
 from src.auth import JWTBearer, Permissions
 from src.auth.auth_principal import AuthPrincipal
 from src.common.schemas.fantasy_schemas import (
+    DraftPick,
     DraftState,
     FantasyLeagueID,
+    PickMadeEvent,
+    DraftCompletedEvent,
+    PickRequest,
 )
 from src.common.schemas.riot_data_schemas import ProfessionalPlayer, ProfessionalTeam
-from src.fantasy.service import DraftService
+from src.fantasy.service import DraftConnectionManager, DraftService
 
 
 class DraftEndpoint(Routable):
-    def __init__(self, draft_service: DraftService):
+    def __init__(self, draft_service: DraftService, connection_manager: DraftConnectionManager):
         super().__init__()
         self.__draft_service = draft_service
+        self.__connection_manager = connection_manager
 
     @post(
         path="/leagues/{league_id}/draft/start",
@@ -27,6 +34,51 @@ class DraftEndpoint(Routable):
         principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_WRITE])),
     ) -> None:
         self.__draft_service.start_draft(league_id, principal.user_id)
+
+    @post(
+        path="/leagues/{league_id}/draft/pick",
+        description="Make a draft pick in a Fantasy League.",
+        tags=["Fantasy Draft"],
+        response_model=DraftPick,
+    )
+    def make_pick(
+        self,
+        league_id: FantasyLeagueID,
+        pick_request: PickRequest = Body(...),
+        principal: AuthPrincipal = Depends(JWTBearer([Permissions.FANTASY_WRITE])),
+    ) -> DraftPick:
+        draft_pick = self.__draft_service.make_pick(
+            league_id,
+            principal.user_id,
+            player_id=pick_request.player_id,
+            team_id=pick_request.team_id,
+        )
+
+        # Determine draft state after pick
+        draft_state = self.__draft_service.get_draft_state(league_id, principal.user_id)
+
+        if draft_state.is_complete:
+            asyncio.create_task(self.__broadcast_and_close(league_id, draft_pick, draft_state))
+        else:
+            asyncio.create_task(
+                self.__connection_manager.broadcast(
+                    league_id,
+                    PickMadeEvent(
+                        pick=draft_pick,
+                        next_turn_user_id=draft_state.current_turn_user_id,
+                    ),
+                )
+            )
+
+        return draft_pick
+
+    async def __broadcast_and_close(self, league_id, draft_pick, draft_state):
+        await self.__connection_manager.broadcast(
+            league_id,
+            PickMadeEvent(pick=draft_pick, next_turn_user_id=None),
+        )
+        await self.__connection_manager.broadcast(league_id, DraftCompletedEvent())
+        await self.__connection_manager.close_room(league_id)
 
     @get(
         path="/leagues/{league_id}/draft/state",

--- a/tests/fantasy/integration/test_draft_endpoint.py
+++ b/tests/fantasy/integration/test_draft_endpoint.py
@@ -134,3 +134,61 @@ class TestDraftEndpoint:
 
         # Assert
         assert response.status_code == 403
+
+    # --------------------------------------------------
+    # ------------------- pick -------------------------
+    # --------------------------------------------------
+    def test_make_pick_route_is_mounted(self):
+        # Arrange
+        client, mock_db, headers = make_client()
+        mock_db.get_draft_picks_for_league.return_value = []
+        mock_db.put_draft_pick.return_value = None
+        mock_db.put_fantasy_team.return_value = None
+
+        # Act
+        response = client.post(
+            f"/api/v1/fantasy/leagues/{TEST_LEAGUE_ID}/draft/pick",
+            json={"player_id": "player-1"},
+            headers=headers,
+        )
+
+        # Assert — route exists (not 404/405)
+        assert response.status_code != 404
+        assert response.status_code != 405
+
+    def test_make_pick_unauthenticated_returns_403(self):
+        # Arrange
+        client = make_unauthed_client()
+
+        # Act
+        response = client.post(
+            f"/api/v1/fantasy/leagues/{TEST_LEAGUE_ID}/draft/pick",
+            json={"player_id": "player-1"},
+        )
+
+        # Assert
+        assert response.status_code == 403
+
+    def test_make_pick_broadcasts_pick_made_event(self):
+        # Arrange
+        from unittest.mock import AsyncMock, patch
+
+        client, mock_db, headers = make_client()
+        mock_db.get_draft_picks_for_league.return_value = []
+        mock_db.put_draft_pick.return_value = None
+        mock_db.put_fantasy_team.return_value = None
+
+        # Act — patch broadcast to verify it's called on a successful pick
+        with patch(
+            "src.fantasy.service.draft_connection_manager.DraftConnectionManager.broadcast",
+            new_callable=AsyncMock,
+        ):
+            response = client.post(
+                f"/api/v1/fantasy/leagues/{TEST_LEAGUE_ID}/draft/pick",
+                json={"player_id": "player-1"},
+                headers=headers,
+            )
+
+        # Assert — route was hit (not 404/405)
+        assert response.status_code != 404
+        assert response.status_code != 405


### PR DESCRIPTION
Closes #482

Depends on #483 (Phase 2A: DraftConnectionManager), #484 (Phase 2B: REST endpoints)

## Changes

### `POST /leagues/{league_id}/draft/pick`
- Accepts `PickRequest` body: `{player_id}` or `{team_id}`
- Calls `DraftService.make_pick`
- On success: broadcasts `PickMadeEvent` (pick data + next turn user) to all WebSocket clients in the room
- On final pick: broadcasts `PickMadeEvent` + `DraftCompletedEvent`, then closes the room
- Returns the `DraftPick` in the response

### `PickRequest` schema
- New Pydantic model for the request body

### `DraftEndpoint` updated
- Now receives `DraftConnectionManager` as constructor dependency
- `app.py` passes the singleton `connection_manager` to `DraftEndpoint`

## Tests
3 new pick endpoint tests (11 total):
- Route is mounted (not 404/405)
- Unauthenticated returns 403
- Broadcast is triggered on pick